### PR TITLE
Remove external extension support

### DIFF
--- a/selene-common/src/main/kotlin/org/dockbox/selene/core/impl/util/extension/SimpleExtensionContext.kt
+++ b/selene-common/src/main/kotlin/org/dockbox/selene/core/impl/util/extension/SimpleExtensionContext.kt
@@ -23,19 +23,9 @@ import org.dockbox.selene.core.util.extension.Extension
 import org.dockbox.selene.core.util.extension.ExtensionContext
 import org.dockbox.selene.core.util.extension.status.ExtensionStatus
 
-class SimpleExtensionContext(override var type: ExtensionContext.ComponentType, override var source: String) : ExtensionContext {
+class SimpleExtensionContext(override var type: ExtensionContext.ComponentType, override var source: String, override var extensionClass: Class<*>, override var extension: Extension) : ExtensionContext {
 
     override var entryStatus: MutableMap<Class<*>, ExtensionStatus> = ConcurrentHashMap()
-    override var classes: MutableMap<Extension, Class<*>> = ConcurrentHashMap()
-
-    override fun addComponentClass(clazz: Class<*>): Boolean {
-        if (clazz.isAnnotationPresent(Extension::class.java)) {
-            val header = clazz.getAnnotation(Extension::class.java)
-            classes[header] = clazz
-            return true
-        }
-        return false
-    }
 
     override fun addStatus(clazz: Class<*>, status: ExtensionStatus) {
         if (status.intValue < 0) Selene.log().warn("Manually assigning deprecated status to [" + clazz.canonicalName + "]! " +

--- a/selene-core/src/main/kotlin/org/dockbox/selene/core/util/extension/ExtensionContext.kt
+++ b/selene-core/src/main/kotlin/org/dockbox/selene/core/util/extension/ExtensionContext.kt
@@ -24,14 +24,15 @@ interface ExtensionContext {
     var type: ComponentType
     var source: String
     var entryStatus: MutableMap<Class<*>, ExtensionStatus>
-    var classes: MutableMap<Extension, Class<*>>
+    var extensionClass: Class<*>
+    var extension: Extension
 
-    fun addComponentClass(clazz: Class<*>): Boolean
     fun addStatus(clazz: Class<*>, status: ExtensionStatus)
     fun getStatus(clazz: Class<*>): ExtensionStatus?
 
     enum class ComponentType(var string: String) {
-        EXTERNAL_JAR("External .jar file"), INTERNAL_CLASS("Internal class"), UNKNOWN("Unknown")
+        INTERNAL_CLASS("Internal class"),
+        UNKNOWN("Unknown")
     }
 
 }

--- a/selene-core/src/main/kotlin/org/dockbox/selene/core/util/extension/ExtensionManager.kt
+++ b/selene-core/src/main/kotlin/org/dockbox/selene/core/util/extension/ExtensionManager.kt
@@ -17,9 +17,7 @@
 
 package org.dockbox.selene.core.util.extension
 
-import java.nio.file.Path
 import java.util.*
-import org.jetbrains.annotations.NotNull
 
 interface ExtensionManager {
 
@@ -32,9 +30,7 @@ interface ExtensionManager {
     fun <T> getInstance(type: Class<T>): Optional<T>
     fun getInstance(id: String): Optional<*>
 
-    fun getExternalExtensions(): @NotNull MutableList<out ExtensionContext>
-    fun collectIntegratedExtensions(): List<ExtensionContext>
-    fun loadExternalExtension(file: Path): Optional<out ExtensionContext>
+    fun initialiseExtensions(): List<ExtensionContext>
 
     fun getRegisteredExtensionIds(): List<String>
 }


### PR DESCRIPTION
# Description
Due to technical limitations, causing the current version of Selene to be unable to render external types using internal resources, this PR removes the ability to load external extensions. This way no confusion can occur on whether or not Selene supports external extensions.

Fixes #83 

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
