### PR TITLE
Fix Sponge portal type detection

### DIFF
--- a/selene-core/src/main/java/org/dockbox/selene/api/objects/special/PortalType.java
+++ b/selene-core/src/main/java/org/dockbox/selene/api/objects/special/PortalType.java
@@ -19,5 +19,6 @@ package org.dockbox.selene.api.objects.special;
 
 public enum PortalType {
     END,
+    UNKOWN,
     NETHER
 }


### PR DESCRIPTION
# Description
Fixes Sponge's event listener not providing the correct portal type for `PlayerPortalEvent`. As Sponge does not expose this natively, we check the block position of the player (with a maximum offset of +1) and compare it to the `Portal` and `EndPortal` block types.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Run testing (tested by running on a platform)

**Test Configuration**:
* Platform: SpongeForge
* Platform API version:  7.2.2 (Integrated)
* Forge version: Integrated
* Java version: 1.8

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
