### PR TITLE
Make permissions required for all command definitions

### DIFF
--- a/examples/src/main/java/org/dockbox/selene/sample/SampleModule.java
+++ b/examples/src/main/java/org/dockbox/selene/sample/SampleModule.java
@@ -47,7 +47,7 @@ public final class SampleModule {
     }
 
     // Uses the Custom Parameter from the Cuboid class, with a nested Shape parameter
-    @Command(aliases = "demo", usage = "demo <cuboid{Cuboid}>")
+    @Command(aliases = "demo", usage = "demo <cuboid{Cuboid}>", permission = "selene.demo")
     public void buildCuboid(Cuboid cuboid) {
         Selene.log().info("Cuboid: " + cuboid);
     }

--- a/modules/dave/src/main/java/org/dockbox/selene/dave/DaveModule.java
+++ b/modules/dave/src/main/java/org/dockbox/selene/dave/DaveModule.java
@@ -42,7 +42,7 @@ import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-@Command(aliases = "dave", usage = "dave")
+@Command(aliases = "dave", usage = "dave", permission = "dave")
 @Module(id = "dave", name = "Dave", description = "", authors = "GuusLieben")
 public class DaveModule implements InjectableType {
 
@@ -50,12 +50,12 @@ public class DaveModule implements InjectableType {
     private DaveTriggers triggers = new DaveTriggers();
     private DaveConfig config = new DaveConfig();
 
-    @Command(aliases = "mute", usage = "mute")
+    @Command(aliases = "mute", usage = "mute", permission = DaveResources.DAVE_MUTE)
     public void mute(Player player) {
         DaveUtils.toggleMute(player);
     }
 
-    @Command(aliases = "triggers", usage = "triggers")
+    @Command(aliases = "triggers", usage = "triggers", permission = DaveResources.DAVE_TRIGGERS)
     public void triggers(CommandSource source) {
         Selene.provide(PaginationBuilder.class)
                 .title(DaveResources.DAVE_TRIGGER_HEADER.asText())
@@ -69,7 +69,7 @@ public class DaveModule implements InjectableType {
                 .send(source);
     }
 
-    @Command(aliases = "run", usage = "run <trigger{String}>")
+    @Command(aliases = "run", usage = "run <trigger{String}>", permission = DaveResources.DAVE_TRIGGER_RUN)
     public void run(Player source, CommandContext context) {
         String triggerId = context.get("trigger");
         this.triggers.findById(triggerId)
@@ -77,7 +77,7 @@ public class DaveModule implements InjectableType {
                 .absent(() -> source.send(DaveResources.NO_MATCHING_TRIGGER.format(triggerId)));
     }
 
-    @Command(aliases = "refresh", usage = "refresh")
+    @Command(aliases = "refresh", usage = "refresh", permission = DaveResources.DAVE_REFRESH)
     public void refresh(CommandSource source) {
         this.stateEnabling();
         source.sendWithPrefix(DaveResources.DAVE_RELOADED_USER);

--- a/modules/dave/src/main/java/org/dockbox/selene/dave/DaveResources.java
+++ b/modules/dave/src/main/java/org/dockbox/selene/dave/DaveResources.java
@@ -34,5 +34,10 @@ public final class DaveResources {
     public static final Resource DAVE_TRIGGER_HEADER = new Resource("$1Triggers", "dave.trigger.header");
     public static final Resource NO_MATCHING_TRIGGER = new Resource("$4No trigger with id '{0}' exists.", "dave.trigger.notfound");
 
+    public static final String DAVE_MUTE = "dave.mute";
+    public static final String DAVE_REFRESH = "dave.refresh";
+    public static final String DAVE_TRIGGERS = "dave.triggers.list";
+    public static final String DAVE_TRIGGER_RUN = "dave.triggers.run";
+
     private DaveResources() {}
 }

--- a/modules/integrated/src/main/java/org/dockbox/selene/integrated/DefaultServer.java
+++ b/modules/integrated/src/main/java/org/dockbox/selene/integrated/DefaultServer.java
@@ -54,12 +54,12 @@ import java.util.List;
         description = "Integrated features of Selene",
         authors = "GuusLieben"
 )
-@Command(aliases = SeleneInformation.PROJECT_ID, usage = SeleneInformation.PROJECT_ID)
+@Command(aliases = SeleneInformation.PROJECT_ID, usage = SeleneInformation.PROJECT_ID, permission = DefaultServerResources.SELENE_ADMIN)
 @Singleton
 public class DefaultServer implements Server {
 
     // Parent command
-    @Command(aliases = "", usage = "")
+    @Command(aliases = "", usage = "", permission = DefaultServerResources.SELENE_ADMIN)
     public static void debugModules(MessageReceiver source) {
         Reflect.with(ModuleManager.class, em -> {
             PaginationBuilder pb = Selene.provide(PaginationBuilder.class);
@@ -104,7 +104,7 @@ public class DefaultServer implements Server {
         return line;
     }
 
-    @Command(aliases = "module", usage = "module <id{Module}>")
+    @Command(aliases = "module", usage = "module <id{Module}>", permission = DefaultServerResources.SELENE_ADMIN)
     public static void debugModule(MessageReceiver src, CommandContext ctx) {
         ModuleContainer container = ctx.get("id");
 
@@ -115,7 +115,7 @@ public class DefaultServer implements Server {
         ));
     }
 
-    @Command(aliases = "reload", usage = "reload [id{Module}]", confirm = true)
+    @Command(aliases = "reload", usage = "reload [id{Module}]", confirm = true, permission = DefaultServerResources.SELENE_ADMIN)
     public static void reload(MessageReceiver src, CommandContext ctx) {
         EventBus eb = Selene.provide(EventBus.class);
         if (ctx.has("id")) {
@@ -134,7 +134,7 @@ public class DefaultServer implements Server {
         }
     }
 
-    @Command(aliases = { "lang", "language" }, usage = "language <language{Language}> [player{Player}]", inherit = false)
+    @Command(aliases = { "lang", "language" }, usage = "language <language{Language}> [player{Player}]", inherit = false, permission = SeleneInformation.GLOBAL_PERMITTED)
     public static void switchLang(MessageReceiver src, CommandContext ctx, Language language, Player player) {
         if (null == player) {
             if (src instanceof Player) {
@@ -154,7 +154,7 @@ public class DefaultServer implements Server {
         player.sendWithPrefix(DefaultServerResources.LANG_SWITCHED.format(languageLocalized));
     }
 
-    @Command(aliases = "platform", usage = "platform")
+    @Command(aliases = "platform", usage = "platform", permission = DefaultServerResources.SELENE_ADMIN)
     public static void platform(MessageReceiver src) {
         ServerType st = Selene.getServer().getServerType();
         String platformVersion = Selene.getServer().getPlatformVersion();
@@ -170,7 +170,7 @@ public class DefaultServer implements Server {
     }
 
     @Override
-    @Command(aliases = "confirm", usage = "confirm <cooldownId{String}>")
+    @Command(aliases = "confirm", usage = "confirm <cooldownId{String}>", permission = SeleneInformation.GLOBAL_PERMITTED)
     public void confirm(MessageReceiver src, CommandContext ctx) {
         if (!(src instanceof AbstractIdentifiable)) {
             src.send(DefaultServerResources.CONFIRM_WRONG_SOURCE);

--- a/modules/integrated/src/main/java/org/dockbox/selene/integrated/DefaultServerResources.java
+++ b/modules/integrated/src/main/java/org/dockbox/selene/integrated/DefaultServerResources.java
@@ -21,6 +21,7 @@ import org.dockbox.selene.api.annotations.i18n.Resources;
 import org.dockbox.selene.api.i18n.common.ResourceEntry;
 import org.dockbox.selene.api.i18n.entry.DefaultResource;
 import org.dockbox.selene.api.i18n.entry.Resource;
+import org.dockbox.selene.api.server.SeleneInformation;
 import org.dockbox.selene.api.util.SeleneUtils;
 
 @SuppressWarnings({ "StaticMethodOnlyUsedInOneClass", "ClassWithTooManyFields" })
@@ -74,4 +75,6 @@ enum DefaultServerResources {
                     + "$2JVM: $1{5} $3(version: {6}, vendor: {7})\n"
                     + "$2Runtime: $1{8} $3(class version: {9})",
             "selene.info.platform");
+
+    static final String SELENE_ADMIN = SeleneInformation.PROJECT_ID + ".admin";
 }

--- a/modules/palswap/src/main/java/org/dockbox/selene/palswap/BlockRegistryModule.java
+++ b/modules/palswap/src/main/java/org/dockbox/selene/palswap/BlockRegistryModule.java
@@ -29,6 +29,7 @@ import org.dockbox.selene.api.events.server.ServerStartedEvent;
 import org.dockbox.selene.api.events.server.ServerStoppingEvent;
 import org.dockbox.selene.api.files.FileManager;
 import org.dockbox.selene.api.files.FileType;
+import org.dockbox.selene.api.server.SeleneInformation;
 import org.dockbox.selene.common.files.FileTypeProperty;
 import org.dockbox.selene.api.i18n.common.Language;
 import org.dockbox.selene.api.objects.Exceptional;
@@ -46,7 +47,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 @Disabled(reason = "Under development")
-@Command(aliases = "registry", usage = "registry")
+@Command(aliases = "registry", usage = "registry", permission = SeleneInformation.GLOBAL_BYPASS)
 @Module(id = "blockregistrygenerator", name = "Block Registry Generator",
         description = "Generates the block identifiers and a registry of all the blocks",
         authors = "pumbas600")
@@ -95,7 +96,7 @@ public class BlockRegistryModule {
         fm.write(path, blockRegistry);
     }
 
-    @Command(aliases = "generateblockidentifiers", usage = "generateblockidentifiers")
+    @Command(aliases = "generateblockidentifiers", usage = "generateblockidentifiers", permission = SeleneInformation.GLOBAL_BYPASS)
     public void generateBlockIdentifiers(CommandSource src) {
         try {
             FileManager fileManager = Selene.provide(FileManager.class);
@@ -113,7 +114,7 @@ public class BlockRegistryModule {
         }
     }
 
-    @Command(aliases = "generate", usage = "generate")
+    @Command(aliases = "generate", usage = "generate", permission = SeleneInformation.GLOBAL_BYPASS)
     public void generateBlockRegistry(CommandSource src) {
         for (BlockIdentifier blockIdentifier : BlockIdentifier.values()) {
             blockRegistry.addColumn(blockIdentifier, new Registry<>());
@@ -134,17 +135,17 @@ public class BlockRegistryModule {
         this.logger.info(blockRegistry.toString());
     }
 
-    @Command(aliases = "save", usage = "save")
+    @Command(aliases = "save", usage = "save", permission = SeleneInformation.GLOBAL_BYPASS)
     public void serializeBlockRegistry(CommandSource src) {
         saveBlockRegistry();
     }
 
-    @Command(aliases = "load", usage = "load")
+    @Command(aliases = "load", usage = "load", permission = SeleneInformation.GLOBAL_BYPASS)
     public void deserializeBlockRegistry(CommandSource src) {
         blockRegistry = loadBlockRegistry();
     }
 
-    @Command(aliases = "add", usage = "add <item>")
+    @Command(aliases = "add", usage = "add <item>", permission = SeleneInformation.GLOBAL_BYPASS)
     public void addItem(CommandSource src, CommandContext context) {
         String baseBlock = context.get("item");
         addItem(Item.of(baseBlock));
@@ -183,7 +184,7 @@ public class BlockRegistryModule {
         }
     }
 
-    @Command(aliases = "add", usage = "add")
+    @Command(aliases = "add", usage = "add", permission = SeleneInformation.GLOBAL_BYPASS)
     public void addItemInHand(Player src, CommandSource context) {
         addItem(src.getInventory().getSlot(Slot.MAIN_HAND));
     }

--- a/modules/palswap/src/main/java/org/dockbox/selene/palswap/BlockRegistryTestModule.java
+++ b/modules/palswap/src/main/java/org/dockbox/selene/palswap/BlockRegistryTestModule.java
@@ -28,6 +28,7 @@ import org.dockbox.selene.api.i18n.common.Language;
 import org.dockbox.selene.api.objects.Exceptional;
 import org.dockbox.selene.api.objects.item.Item;
 import org.dockbox.selene.api.objects.player.Player;
+import org.dockbox.selene.api.server.SeleneInformation;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
@@ -46,7 +47,7 @@ public class BlockRegistryTestModule {
         instance = this;
     }
 
-    @Command(aliases = "blockid", usage = "blockid <id>")
+    @Command(aliases = "blockid", usage = "blockid <id>", permission = SeleneInformation.GLOBAL_BYPASS)
     public void blockID(@NotNull Player player, CommandContext context) {
         Exceptional<CommandParameter<String>> eID = context.argument("id");
 
@@ -60,7 +61,7 @@ public class BlockRegistryTestModule {
         player.getInventory().give(Item.of(id));
     }
 
-    @Command(aliases = "blockmeta", usage = "blockmeta <id> <meta{Integer}>")
+    @Command(aliases = "blockmeta", usage = "blockmeta <id> <meta{Integer}>", permission = SeleneInformation.GLOBAL_BYPASS)
     public void blockMeta(@NotNull Player player, CommandContext context) {
 
         String id = context.get("id");

--- a/modules/worldmanagement/src/main/java/org/dockbox/selene/worldmanagement/WorldManagement.java
+++ b/modules/worldmanagement/src/main/java/org/dockbox/selene/worldmanagement/WorldManagement.java
@@ -34,7 +34,7 @@ import org.dockbox.selene.api.tasks.TaskRunner;
 
 import java.util.concurrent.TimeUnit;
 
-@Command(aliases = {"unloader", "wu"}, usage = "unloader")
+@Command(aliases = {"unloader", "wu"}, usage = "unloader", permission = WorldManagementResources.WORLD_MANAGER)
 @Module(id = "worldmanagement", name = "World Management", description = "Manages several aspects of the various worlds on a server", authors = "GuusLieben")
 public class WorldManagement {
 
@@ -59,7 +59,7 @@ public class WorldManagement {
         }
     }
 
-    @Command(aliases = "blacklist", usage = "blacklist <world{String}>")
+    @Command(aliases = "blacklist", usage = "blacklist <world{String}>", permission = WorldManagementResources.WORLD_MANAGER)
     public void blacklist(CommandSource src, String world) {
         if (Selene.provide(Worlds.class).hasWorld(world)) {
             this.config.getUnloadBlacklist().add(world);

--- a/modules/worldmanagement/src/main/java/org/dockbox/selene/worldmanagement/WorldManagementResources.java
+++ b/modules/worldmanagement/src/main/java/org/dockbox/selene/worldmanagement/WorldManagementResources.java
@@ -27,4 +27,6 @@ public class WorldManagementResources {
     public static final ResourceEntry WORLD_BLACKLIST_ADDED = new Resource("$2{0} $1was added to the blacklist and will not be unloaded", "worldmanagement.unloader.blacklist.added");
     public static final ResourceEntry WORLD_BLACKLIST_FAILED = new Resource("$2{0} $1could not be blacklisted, are you sure it exists?", "worldmanagement.unloader.blacklist.failed");
 
+    public static final String WORLD_MANAGER = "selene.worlds";
+
 }

--- a/selene-common/src/test/java/org/dockbox/selene/common/command/DefaultCommandBusTests.java
+++ b/selene-common/src/test/java/org/dockbox/selene/common/command/DefaultCommandBusTests.java
@@ -85,23 +85,23 @@ class DefaultCommandBusTests {
 
     @Command(
             aliases = { "example", "sample" },
-            usage = "example")
+            usage = "example", permission = "example")
     private static class ExampleCommandClass {
 
-        @Command(aliases = "", usage = "")
+        @Command(aliases = "", usage = "", permission = "example")
         public void mainCommand() {}
 
-        @Command(aliases = "child", usage = "child")
+        @Command(aliases = "child", usage = "child", permission = "example")
         public void subCommand() {}
 
-        @Command(aliases = "noninherit", usage = "noninherit", inherit = false)
+        @Command(aliases = "noninherit", usage = "noninherit", inherit = false, permission = "example")
         public void nonInheritedChild() {}
     }
 
-    @Command(aliases = "sample", usage = "sample", extend = true)
+    @Command(aliases = "sample", usage = "sample", extend = true, permission = "example")
     private static class ExampleExtendingCommandClass {
 
-        @Command(aliases = "extended", usage = "extended")
+        @Command(aliases = "extended", usage = "extended", permission = "example")
         public void extendedCommand() {}
     }
 }

--- a/selene-core/src/main/java/org/dockbox/selene/api/annotations/command/Command.java
+++ b/selene-core/src/main/java/org/dockbox/selene/api/annotations/command/Command.java
@@ -17,8 +17,6 @@
 
 package org.dockbox.selene.api.annotations.command;
 
-import org.dockbox.selene.api.server.SeleneInformation;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -50,12 +48,11 @@ public @interface Command {
     String usage();
 
     /**
-     * The permissions for the command. Defaults to {@link SeleneInformation#GLOBAL_BYPASS} if not
-     * defined.
+     * The permissions for the command.
      *
      * @return the permission required for the command.
      */
-    String permission() default SeleneInformation.GLOBAL_BYPASS;
+    String permission();
 
     /**
      * The duration in the {@link Command#cooldownUnit() cooldown unit}. Defaults to -1 if not

--- a/selene-core/src/main/java/org/dockbox/selene/api/server/SeleneInformation.java
+++ b/selene-core/src/main/java/org/dockbox/selene/api/server/SeleneInformation.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 public final class SeleneInformation {
 
     public static final String GLOBAL_BYPASS = "selene.admin.bypass-all";
+    public static final String GLOBAL_PERMITTED = "selene.global.permitted";
     public static final String PACKAGE_PREFIX = "org.dockbox.selene";
     public static final List<UUID> GLOBALLY_PERMITTED = SeleneUtils.asList(
             UUID.fromString("6047d264-7769-4e50-a11e-c8b83f65ccc4"),

--- a/selene-core/src/main/java/org/dockbox/selene/api/server/Server.java
+++ b/selene-core/src/main/java/org/dockbox/selene/api/server/Server.java
@@ -30,6 +30,6 @@ import org.dockbox.selene.api.util.Reflect;
 @SuppressWarnings("InterfaceMayBeAnnotatedFunctional")
 public interface Server {
 
-    @Command(aliases = "confirm", usage = "confirm <cooldownId{String}>")
+    @Command(aliases = "confirm", usage = "confirm <cooldownId{String}>", permission = SeleneInformation.GLOBAL_PERMITTED)
     void confirm(MessageReceiver src, CommandContext ctx);
 }


### PR DESCRIPTION
# Description
Previously all command definitions defaulted to using the global bypass permission. This lead to several missing permissions, forgotten during development. These changes make it mandatory to fill in permissions, and update existing definitions.

## Type of change
- [x] Enhancement of existing functionality

## Status
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
