### PR TITLE
Rename sendPagination to meet naming scheme

### DIFF
--- a/modules/integrated/src/main/java/org/dockbox/selene/integrated/DefaultServer.java
+++ b/modules/integrated/src/main/java/org/dockbox/selene/integrated/DefaultServer.java
@@ -86,7 +86,7 @@ public class DefaultServer implements Server {
             pb.title(DefaultServerResources.PAGINATION_TITLE.translate(source).asText());
             pb.content(content);
 
-            source.sendPagination(pb.build());
+            source.send(pb.build());
         });
     }
 

--- a/selene-common/src/testFixtures/java/org/dockbox/selene/test/objects/JUnitConsole.java
+++ b/selene-common/src/testFixtures/java/org/dockbox/selene/test/objects/JUnitConsole.java
@@ -39,7 +39,7 @@ public class JUnitConsole extends Console {
     }
 
     @Override
-    public void sendPagination(Pagination pagination) {
+    public void send(Pagination pagination) {
         // TODO: Test implementation, mocking client?
     }
 }

--- a/selene-common/src/testFixtures/java/org/dockbox/selene/test/objects/JUnitDiscordCommandSource.java
+++ b/selene-common/src/testFixtures/java/org/dockbox/selene/test/objects/JUnitDiscordCommandSource.java
@@ -62,7 +62,7 @@ public class JUnitDiscordCommandSource implements DiscordCommandSource {
     }
 
     @Override
-    public void sendPagination(Pagination pagination) {
+    public void send(Pagination pagination) {
         // TODO: Test implementation, mocking client?
     }
 }

--- a/selene-common/src/testFixtures/java/org/dockbox/selene/test/objects/living/JUnitPlayer.java
+++ b/selene-common/src/testFixtures/java/org/dockbox/selene/test/objects/living/JUnitPlayer.java
@@ -244,7 +244,7 @@ public class JUnitPlayer extends Player implements JUnitPersistentDataHolder {
     }
 
     @Override
-    public void sendPagination(Pagination pagination) {
+    public void send(Pagination pagination) {
         // TODO: Test implementation, mocking client?
     }
 

--- a/selene-core/src/main/java/org/dockbox/selene/api/objects/targets/MessageReceiver.java
+++ b/selene-core/src/main/java/org/dockbox/selene/api/objects/targets/MessageReceiver.java
@@ -31,5 +31,5 @@ public interface MessageReceiver extends Target {
 
     void sendWithPrefix(Text text);
 
-    void sendPagination(Pagination pagination);
+    void send(Pagination pagination);
 }

--- a/sponge-7/src/main/java/org/dockbox/selene/sponge/objects/discord/MagiBridgeCommandSource.java
+++ b/sponge-7/src/main/java/org/dockbox/selene/sponge/objects/discord/MagiBridgeCommandSource.java
@@ -70,7 +70,7 @@ public class MagiBridgeCommandSource implements DiscordCommandSource {
     }
 
     @Override
-    public void sendPagination(@NotNull Pagination pagination) {
+    public void send(@NotNull Pagination pagination) {
         throw new UnsupportedOperationException("Pagination not supported for virtual command source");
     }
 }

--- a/sponge-7/src/main/java/org/dockbox/selene/sponge/objects/targets/SpongeConsole.java
+++ b/sponge-7/src/main/java/org/dockbox/selene/sponge/objects/targets/SpongeConsole.java
@@ -51,7 +51,7 @@ public final class SpongeConsole extends Console {
     }
 
     @Override
-    public void sendPagination(@NotNull Pagination pagination) {
+    public void send(@NotNull Pagination pagination) {
         SpongeConversionUtil.toSponge(pagination).sendTo(Sponge.getServer().getConsole());
     }
 }

--- a/sponge-7/src/main/java/org/dockbox/selene/sponge/objects/targets/SpongePlayer.java
+++ b/sponge-7/src/main/java/org/dockbox/selene/sponge/objects/targets/SpongePlayer.java
@@ -241,7 +241,7 @@ public class SpongePlayer extends Player implements SpongeComposite, Wrapper<org
     }
 
     @Override
-    public void sendPagination(@NotNull Pagination pagination) {
+    public void send(@NotNull Pagination pagination) {
         if (this.referenceExists()) {
             SpongeConversionUtil.toSponge(pagination).sendTo(this.getReference().get());
         }

--- a/sponge-7/src/main/java/org/dockbox/selene/sponge/text/navigation/SpongePagination.java
+++ b/sponge-7/src/main/java/org/dockbox/selene/sponge/text/navigation/SpongePagination.java
@@ -45,7 +45,7 @@ public class SpongePagination implements Pagination {
 
     @Override
     public void send(@NotNull MessageReceiver receiver) {
-        receiver.sendPagination(this);
+        receiver.send(this);
     }
 
     @NotNull


### PR DESCRIPTION
Renames the `sendPagination` method to `send`. This follows the common naming scheme of existing receiver methods, and puts the change of responsibility in the parameter, rather than the method name.