### PR TITLE
#279 Simplify application activator

### DIFF
--- a/selene-bootstrap/src/main/java/org/dockbox/selene/api/SeleneApplication.java
+++ b/selene-bootstrap/src/main/java/org/dockbox/selene/api/SeleneApplication.java
@@ -39,7 +39,7 @@ public class SeleneApplication {
         try {
             final long start = System.currentTimeMillis();
             final Activator annotation = verifyActivator(activator);
-            final Class<? extends InjectableBootstrap> bootstrap = annotation.bootstrap();
+            final Class<? extends InjectableBootstrap> bootstrap = annotation.value();
             final InjectableBootstrap injectableBootstrap = instance(bootstrap);
 
             String prefix = "".equals(annotation.prefix()) ? activator.getPackage().getName() : annotation.prefix();

--- a/selene-bootstrap/src/test/java/org/dockbox/selene/api/activators/AbstractActivator.java
+++ b/selene-bootstrap/src/test/java/org/dockbox/selene/api/activators/AbstractActivator.java
@@ -18,9 +18,8 @@
 package org.dockbox.selene.api.activators;
 
 import org.dockbox.selene.api.SampleBootstrap;
-import org.dockbox.selene.di.adapter.InjectSource;
 import org.dockbox.selene.di.annotations.Activator;
 
-@Activator(inject = InjectSource.GUICE, bootstrap = SampleBootstrap.class)
+@Activator(SampleBootstrap.class)
 public abstract class AbstractActivator {
 }

--- a/selene-bootstrap/src/test/java/org/dockbox/selene/api/activators/InterfaceActivator.java
+++ b/selene-bootstrap/src/test/java/org/dockbox/selene/api/activators/InterfaceActivator.java
@@ -18,9 +18,8 @@
 package org.dockbox.selene.api.activators;
 
 import org.dockbox.selene.api.SampleBootstrap;
-import org.dockbox.selene.di.adapter.InjectSource;
 import org.dockbox.selene.di.annotations.Activator;
 
-@Activator(inject = InjectSource.GUICE, bootstrap = SampleBootstrap.class)
+@Activator(SampleBootstrap.class)
 public interface InterfaceActivator {
 }

--- a/selene-bootstrap/src/test/java/org/dockbox/selene/api/activators/ValidActivator.java
+++ b/selene-bootstrap/src/test/java/org/dockbox/selene/api/activators/ValidActivator.java
@@ -18,9 +18,8 @@
 package org.dockbox.selene.api.activators;
 
 import org.dockbox.selene.api.SampleBootstrap;
-import org.dockbox.selene.di.adapter.InjectSource;
 import org.dockbox.selene.di.annotations.Activator;
 
-@Activator(inject = InjectSource.GUICE, bootstrap = SampleBootstrap.class)
+@Activator(SampleBootstrap.class)
 public class ValidActivator {
 }

--- a/selene-di/src/main/java/org/dockbox/selene/di/annotations/Activator.java
+++ b/selene-di/src/main/java/org/dockbox/selene/di/annotations/Activator.java
@@ -29,8 +29,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Activator {
-    InjectSource inject();
-    Class<? extends InjectableBootstrap> bootstrap();
+    InjectSource inject() default InjectSource.GUICE;
+    Class<? extends InjectableBootstrap> value();
     String prefix() default "";
     InjectConfig[] configs() default {};
     ServiceSource services() default ServiceSource.DEFAULT;

--- a/selene-sponge-7/src/main/java/org/dockbox/selene/sponge/Sponge7Application.java
+++ b/selene-sponge-7/src/main/java/org/dockbox/selene/sponge/Sponge7Application.java
@@ -27,7 +27,6 @@ import org.dockbox.selene.api.i18n.annotations.UseResources;
 import org.dockbox.selene.cache.annotations.UseCaching;
 import org.dockbox.selene.commands.annotations.UseCommands;
 import org.dockbox.selene.config.annotations.UseConfigurations;
-import org.dockbox.selene.di.adapter.InjectSource;
 import org.dockbox.selene.di.annotations.Activator;
 import org.dockbox.selene.di.annotations.InjectConfig;
 import org.dockbox.selene.di.annotations.InjectPhase;
@@ -73,8 +72,7 @@ import org.spongepowered.api.plugin.PluginContainer;
 @UseEvents
 @UseProxying
 @Activator(
-        inject = InjectSource.GUICE,
-        bootstrap = MinecraftServerBootstrap.class,
+        value = MinecraftServerBootstrap.class,
         prefix = SeleneInformation.PACKAGE_PREFIX,
         configs = {
                 @InjectConfig(SpongeEarlyInjector.class),

--- a/selene-test/src/testFixtures/java/org/dockbox/selene/test/JUnit5Application.java
+++ b/selene-test/src/testFixtures/java/org/dockbox/selene/test/JUnit5Application.java
@@ -21,7 +21,6 @@ import org.dockbox.selene.api.SeleneApplication;
 import org.dockbox.selene.api.SeleneInformation;
 import org.dockbox.selene.di.ApplicationContextAware;
 import org.dockbox.selene.di.Modifier;
-import org.dockbox.selene.di.adapter.InjectSource;
 import org.dockbox.selene.di.annotations.Activator;
 import org.dockbox.selene.di.annotations.InjectConfig;
 import org.dockbox.selene.di.annotations.InjectPhase;
@@ -33,8 +32,7 @@ import java.lang.reflect.Field;
 import lombok.Getter;
 
 @Activator(
-        inject = InjectSource.GUICE,
-        bootstrap = JUnit5Bootstrap.class,
+        value = JUnit5Bootstrap.class,
         prefix = SeleneInformation.PACKAGE_PREFIX,
         configs = {
                 @InjectConfig(JUnitInjector.class),


### PR DESCRIPTION
# Description
Changes the default injector configuration to Guice, and renames `bootstrap()` to `value()` so it can be used inline.

Fixes #279 