### PR TITLE
#280 Add method context provider

### DIFF
--- a/selene-proxy/src/main/java/org/dockbox/selene/proxy/annotations/Provided.java
+++ b/selene-proxy/src/main/java/org/dockbox/selene/proxy/annotations/Provided.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.selene.proxy.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Provided {
+    String value() default "";
+}

--- a/selene-proxy/src/main/java/org/dockbox/selene/proxy/service/ContextMethodModifier.java
+++ b/selene-proxy/src/main/java/org/dockbox/selene/proxy/service/ContextMethodModifier.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.selene.proxy.service;
+
+import org.dockbox.selene.api.Selene;
+import org.dockbox.selene.di.context.ApplicationContext;
+import org.dockbox.selene.di.properties.BindingMetaProperty;
+import org.dockbox.selene.proxy.annotations.Provided;
+import org.dockbox.selene.proxy.annotations.UseProxying;
+import org.dockbox.selene.proxy.handle.ProxyFunction;
+import org.dockbox.selene.util.Reflect;
+
+public class ContextMethodModifier extends ServiceAnnotatedMethodModifier<Provided, UseProxying> {
+    @Override
+    public Class<UseProxying> activator() {
+        return UseProxying.class;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T, R> ProxyFunction<T, R> process(ApplicationContext context, MethodProxyContext<T> methodContext) {
+        return (instance, args, proxyContext) -> {
+            final Provided annotation = methodContext.getAnnotation(Provided.class);
+            final String name = annotation.value();
+            if ("".equals(name)) {
+                return (R) Selene.context().get(methodContext.getReturnType());
+            } else {
+                return (R) Selene.context().get(methodContext.getReturnType(), BindingMetaProperty.of(name));
+            }
+        };
+    }
+
+    @Override
+    public <T> boolean preconditions(ApplicationContext context, MethodProxyContext<T> methodContext) {
+        return Reflect.isNotVoid(methodContext.getReturnType());
+    }
+
+    @Override
+    public Class<Provided> annotation() {
+        return Provided.class;
+    }
+}

--- a/selene-proxy/src/test/java/org/dockbox/selene/proxy/ProxyTests.java
+++ b/selene-proxy/src/test/java/org/dockbox/selene/proxy/ProxyTests.java
@@ -22,6 +22,8 @@ import org.dockbox.selene.proxy.handle.ProxyHandler;
 import org.dockbox.selene.proxy.types.ConcreteProxyTarget;
 import org.dockbox.selene.proxy.types.FinalProxyTarget;
 import org.dockbox.selene.proxy.types.GlobalProxyTarget;
+import org.dockbox.selene.proxy.types.ProviderService;
+import org.dockbox.selene.proxy.types.SampleType;
 import org.dockbox.selene.test.SeleneJUnit5Runner;
 import org.dockbox.selene.util.Reflect;
 import org.junit.jupiter.api.Assertions;
@@ -84,4 +86,10 @@ public class ProxyTests {
         Assertions.assertEquals("GlobalSelene", target.getName());
     }
 
+    @Test
+    void testProviderService() {
+        ProviderService service = Selene.context().get(ProviderService.class);
+        final SampleType type = service.get();
+        Assertions.assertNotNull(type);
+    }
 }

--- a/selene-proxy/src/test/java/org/dockbox/selene/proxy/types/ProviderService.java
+++ b/selene-proxy/src/test/java/org/dockbox/selene/proxy/types/ProviderService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.selene.proxy.types;
+
+import org.dockbox.selene.di.annotations.Service;
+import org.dockbox.selene.proxy.annotations.Provided;
+
+@Service
+public interface ProviderService {
+
+    @Provided
+    SampleType get();
+
+}

--- a/selene-proxy/src/test/java/org/dockbox/selene/proxy/types/SampleType.java
+++ b/selene-proxy/src/test/java/org/dockbox/selene/proxy/types/SampleType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.selene.proxy.types;
+
+public class SampleType {
+}


### PR DESCRIPTION
# Description
Adds the ability to provide context types through method providers (in addition to the existing constructor, field, and manual wiring). This is not part of native DI, as it relies on proxying. 

```java
@Service
public interface SampleService {
    @Provided
    SampleObject get(); // Returns SampleObjectImpl

    @Provided("name")
    SampleObject getNamed(); // Returns NamedSampleObjectImpl
}
```

Fixes #280 

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing (tested using JUnit)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
