### PR TITLE
Update workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 	<h3 align="center">Hartshorn</h3>
 	<p align="center">Agnostic plugin/extension framework.</p>
 	<p align="center">
-		<a href="https://guuslieben.github.io/Hartshorn/"><img src="https://github.com/GuusLieben/Hartshorn/workflows/JavaDocs/badge.svg"></a>
-		<img src="https://github.com/GuusLieben/Hartshorn/workflows/Build/badge.svg">
-		<img src="https://github.com/GuusLieben/Hartshorn/workflows/Tests/badge.svg"><br>
         <a href="https://www.codefactor.io/repository/github/guuslieben/hartshorn"><img src="https://www.codefactor.io/repository/github/guuslieben/hartshorn/badge?s=5e09ccbb31604049271c18af0d20c1237d9816f2" alt="CodeFactor" /></a>
-		<a href="https://www.gnu.org/licenses/lgpl-2.1"><img src="https://img.shields.io/badge/license-LGPL%20v2.1-0CAB6B"></a>
+		<a href="https://www.gnu.org/licenses/lgpl-2.1"><img src="https://img.shields.io/badge/license-LGPL%20v2.1-0CAB6B"></a><br>
+        <img src="https://github.com/GuusLieben/Hartshorn/actions/workflows/hartshorn.yml/badge.svg">
 	</p>
 </p>
 


### PR DESCRIPTION
# Description
Removes the now-invalid badges for tests, javadocs, and build workflows. These have been merged into a single `Hartshorn` workflow, which is reflected by the badge changes in this PR.