### PR TITLE
Add KeyBuilder and RemovableKeyBuilder

### DIFF
--- a/hartshorn-keys/src/test/java/org/dockbox/hartshorn/keys/TestKeys.java
+++ b/hartshorn-keys/src/test/java/org/dockbox/hartshorn/keys/TestKeys.java
@@ -17,7 +17,6 @@
 
 package org.dockbox.hartshorn.keys;
 
-import org.dockbox.hartshorn.api.domain.Exceptional;
 import org.dockbox.hartshorn.api.keys.Key;
 import org.dockbox.hartshorn.api.keys.Keys;
 import org.dockbox.hartshorn.util.HartshornUtils;
@@ -28,13 +27,15 @@ public final class TestKeys {
 
     private static final Map<Object, String> localRegistry = HartshornUtils.emptyMap();
 
-    public static final Key<TestKeyHolder, String> HOLDER_KEY = Keys.of(
-            localRegistry::put,
-            testKeyHolder -> Exceptional.of(localRegistry.getOrDefault(testKeyHolder, null)));
+    public static final Key<TestKeyHolder, String> HOLDER_KEY = Keys.builder(TestKeyHolder.class, String.class)
+            .withSetter(localRegistry::put)
+            .withGetter(testKeyHolder -> localRegistry.getOrDefault(testKeyHolder, null))
+            .build();
 
-    public static final Key<TestNonKeyHolder, String> NON_HOLDER_KEY = Keys.of(
-            localRegistry::put,
-            testKeyHolder -> Exceptional.of(localRegistry.getOrDefault(testKeyHolder, null)));
+    public static final Key<TestNonKeyHolder, String> NON_HOLDER_KEY = Keys.builder(TestNonKeyHolder.class, String.class)
+            .withSetter(localRegistry::put)
+            .withGetter(testNonKeyHolder -> localRegistry.getOrDefault(testNonKeyHolder, null))
+            .build();
 
     private TestKeys() {
     }

--- a/hartshorn-minecraft/playersettings/src/main/java/org/dockbox/hartshorn/playersettings/Setting.java
+++ b/hartshorn-minecraft/playersettings/src/main/java/org/dockbox/hartshorn/playersettings/Setting.java
@@ -165,7 +165,7 @@ public class Setting<T> extends TypedPersistentDataKey<T> {
             if (this.description == null) throw new IllegalArgumentException("Description should be specified");
             if (this.defaultValue == null) throw new IllegalArgumentException("Default value should be specified");
             if (this.id == null) {
-                this.id = Keys.convertId(this.resource.plain(), this.owner);
+                this.id = Keys.id(this.resource.plain(), this.owner);
             }
 
             return new Setting<>(

--- a/hartshorn-minecraft/plots/src/main/java/org/dockbox/hartshorn/plots/PlotKeys.java
+++ b/hartshorn-minecraft/plots/src/main/java/org/dockbox/hartshorn/plots/PlotKeys.java
@@ -31,30 +31,59 @@ import java.util.Collection;
 
 public final class PlotKeys {
 
-    public static final Key<Location, Plot> PLOT = Keys.ofGetter(loc -> Hartshorn.context().get(PlotService.class).getPlotAt(loc));
-    public static final Key<Player, Plot> CURRENT_PLOT = Keys.ofGetter(player -> Hartshorn.context().get(PlotService.class).getCurrentPlot(player));
+    public static final Key<Location, Plot> PLOT = Keys.builder(Location.class, Plot.class)
+            .withGetterSafe(loc -> Hartshorn.context().get(PlotService.class).getPlotAt(loc))
+            .build();
+
+    public static final Key<Player, Plot> CURRENT_PLOT = Keys.builder(Player.class, Plot.class)
+            .withGetterSafe(player -> Hartshorn.context().get(PlotService.class).getCurrentPlot(player))
+            .build();
 
     // The filling of the plot between bedrock (if present) and the plot floor
-    public static final Key<Plot, Item> FILLING = Keys.ofSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)));
+    public static final Key<Plot, Item> FILLING = Keys.builder(Plot.class, Item.class)
+            .withSetter((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item))
+            .build();
+
     // The plot floor
-    public static final Key<Plot, Item> FLOOR = Keys.ofSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)));
+    public static final Key<Plot, Item> FLOOR = Keys.builder(Plot.class, Item.class)
+            .withSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)))
+            .build();
+
     // The filling of the plot between the plot floor and the build height limit
-    public static final Key<Plot, Item> AIR = Keys.ofSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)));
+    public static final Key<Plot, Item> AIR = Keys.builder(Plot.class, Item.class)
+            .withSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)))
+            .build();
+
     // The filling of the entire plot
-    public static final Key<Plot, Item> ALL = Keys.ofSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)));
+    public static final Key<Plot, Item> ALL = Keys.builder(Plot.class, Item.class)
+            .withSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)))
+            .build();
+
     // The filling of the top of the plot wall
-    public static final Key<Plot, Item> WALL_BORDER = Keys.ofSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)));
+    public static final Key<Plot, Item> WALL_BORDER = Keys.builder(Plot.class, Item.class)
+            .withSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)))
+            .build();
+
     // The filling of the plot wall between bedrock (if present) and the wall border
-    public static final Key<Plot, Item> WALL_FILLING = Keys.ofSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)));
+    public static final Key<Plot, Item> WALL_FILLING = Keys.builder(Plot.class, Item.class)
+            .withSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)))
+            .build();
+
     // The filling of the outer edges of the plot (including top) from the plot floor (inclusive)
-    public static final Key<Plot, Item> OUTLINE = Keys.ofSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)));
+    public static final Key<Plot, Item> OUTLINE = Keys.builder(Plot.class, Item.class)
+            .withSetter(((plot, item) -> Hartshorn.context().get(PlotService.class).setFilling(plot, item)))
+            .build();
+
     // The size of the plot, excluding plot borders
-    public static final Key<Plot, Integer> SIZE = Keys.ofGetter(plot -> Exceptional.of(Hartshorn.context().get(PlotService.class).getSize(plot)));
+    public static final Key<Plot, Integer> SIZE = Keys.builder(Plot.class, Integer.class)
+            .withGetterSafe(plot -> Exceptional.of(Hartshorn.context().get(PlotService.class).getSize(plot)))
+            .build();
+
     // The name of the plot
-    public static final Key<Plot, Text> ALIAS = Keys.of(
-            (plot, text) -> Hartshorn.context().get(PlotService.class).setAlias(plot, text),
-            plot -> Exceptional.of(Hartshorn.context().get(PlotService.class).getAlias(plot))
-    );
+    public static final Key<Plot, Text> ALIAS = Keys.builder(Plot.class, Text.class)
+            .withSetter((plot, text) -> Hartshorn.context().get(PlotService.class).setAlias(plot, text))
+            .withGetterSafe(plot -> Exceptional.of(Hartshorn.context().get(PlotService.class).getAlias(plot)))
+            .build();
 
     public static Collection<Key<Plot, ?>> persistentDataKeys() {
         return HartshornUtils.asUnmodifiableList(FILLING, FLOOR, AIR, ALL, WALL_BORDER, WALL_FILLING, OUTLINE, SIZE, ALIAS);

--- a/hartshorn-minecraft/toolbinding/src/main/java/org/dockbox/hartshorn/toolbinding/ToolBinding.java
+++ b/hartshorn-minecraft/toolbinding/src/main/java/org/dockbox/hartshorn/toolbinding/ToolBinding.java
@@ -43,11 +43,12 @@ public class ToolBinding {
     static final PersistentDataKey<String> PERSISTENT_TOOL = Keys.persistent(String.class, "Tool Binding", ToolBinding.class);
     private static ToolBinding instance;
 
-    public static final RemovableKey<Item, ItemTool> TOOL = Keys.removable(
-            // Not possible to use method references here due to instance being initialized later
-            (item, tool) -> instance.setTool(item, tool),
-            item -> instance.getTool(item),
-            item -> instance.removeTool(item));
+    public static final RemovableKey<Item, ItemTool> TOOL_REMOVABLE_KEY = Keys.builder(Item.class, ItemTool.class)
+            .withSetter((item, tool) -> instance.setTool(item, tool))
+            .withGetterSafe(item -> instance.getTool(item))
+            .withRemover(item -> instance.removeTool(item))
+            .build();
+
     private final Map<String, ItemTool> registry = HartshornUtils.emptyConcurrentMap();
 
     public ToolBinding() {

--- a/hartshorn-minecraft/worldedit/src/main/java/org/dockbox/hartshorn/worldedit/WorldEditKeys.java
+++ b/hartshorn-minecraft/worldedit/src/main/java/org/dockbox/hartshorn/worldedit/WorldEditKeys.java
@@ -26,14 +26,15 @@ import org.dockbox.hartshorn.worldedit.region.Region;
 
 public final class WorldEditKeys {
 
-    public static final Key<Player, Region> SELECTION = Keys.of(
-            (player, region) -> Hartshorn.context().get(WorldEditService.class).setPlayerSelection(player, region),
-            player -> Hartshorn.context().get(WorldEditService.class).getPlayerSelection(player)
-    );
+    public static final Key<Player, Region> SELECTION = Keys.builder(Player.class, Region.class)
+            .withSetter((player, region) -> Hartshorn.context().get(WorldEditService.class).setPlayerSelection(player, region))
+            .withGetterSafe(player -> Hartshorn.context().get(WorldEditService.class).getPlayerSelection(player))
+            .build();
 
-    public static final Key<Player, Clipboard> CLIPBOARD = Keys.of(
-            (player, clipboard) -> Hartshorn.context().get(WorldEditService.class).setPlayerClipboard(player, clipboard),
-            player -> Hartshorn.context().get(WorldEditService.class).getPlayerClipboard(player));
+    public static final Key<Player, Clipboard> CLIPBOARD = Keys.builder(Player.class, Clipboard.class)
+            .withSetter((player, clipboard) -> Hartshorn.context().get(WorldEditService.class).setPlayerClipboard(player, clipboard))
+            .withGetterSafe(player -> Hartshorn.context().get(WorldEditService.class).getPlayerClipboard(player))
+            .build();
 
     private WorldEditKeys() {}
 }


### PR DESCRIPTION
# Description
Currently the process to create a (non-persistent) `Key` instance is questionable at best. With a large amount of 'builder' methods which take variations of removers, getters, and setters. These changes introduce a new `KeyBuilder` and `RemovableKeyBuilder`, to allow for more dynamic `Key` building. 

For example:
```java
public static final RemovableKey<KeyHolder, ValueType> TOOL_REMOVABLE_KEY = Keys.builder(KeyHolder.class, ValueType.class)
            .withSetter((holder, value) -> ...)
            .withGetter(holder -> ...)
            .withRemover(holder -> ...)
            .build();
```

## Type of change
- [x] Enhancement of existing functionality

# How Has This Been Tested?
- [x] Unit testing (tested using JUnit)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
