### PR TITLE
S308 jooq startup

### DIFF
--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/JOOQInit.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/JOOQInit.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.persistence.service;
+
+import org.dockbox.hartshorn.api.annotations.PostBootstrap;
+import org.dockbox.hartshorn.api.annotations.UseBootstrap;
+import org.dockbox.hartshorn.di.annotations.Service;
+import org.dockbox.hartshorn.persistence.annotations.UsePersistence;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DefaultDSLContext;
+
+@Service(activators = { UseBootstrap.class, UsePersistence.class })
+public class JOOQInit {
+
+    @PostBootstrap
+    public void init() {
+        new DefaultDSLContext(SQLDialect.SQLITE).selectZero();
+    }
+}


### PR DESCRIPTION
# Description
Optimizes jOOQ startup. This causes Hartshorn startup to go up in time, but greatly decreases the init time when end-users interact with database entries.

Fixes #308 

## Type of change
- [x] Enhancement of existing functionality

# How Has This Been Tested?
- [x] Unit testing (tested using JUnit)
- [x] Run testing (tested by running on a platform)

**Test Configuration**:
* Platform: Sponge
* Platform API version:  8.0.0
* Java version: 16.0.1