### PR TITLE
Add rotation property to Player

### DIFF
--- a/hartshorn-minecraft/server/src/main/java/org/dockbox/hartshorn/server/minecraft/players/Player.java
+++ b/hartshorn-minecraft/server/src/main/java/org/dockbox/hartshorn/server/minecraft/players/Player.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.api.Hartshorn;
 import org.dockbox.hartshorn.api.domain.AbstractIdentifiable;
 import org.dockbox.hartshorn.api.domain.Exceptional;
 import org.dockbox.hartshorn.api.domain.tuple.Tristate;
+import org.dockbox.hartshorn.api.domain.tuple.Vector3N;
 import org.dockbox.hartshorn.api.i18n.PermissionHolder;
 import org.dockbox.hartshorn.api.i18n.common.Language;
 import org.dockbox.hartshorn.api.i18n.permissions.Permission;
@@ -182,4 +183,6 @@ public abstract class Player extends AbstractIdentifiable implements CommandSour
     public abstract PlayerInventory inventory();
 
     public abstract GameSettings gameSettings();
+
+    public abstract Vector3N rotation();
 }

--- a/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/game/SpongePlayer.java
+++ b/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/game/SpongePlayer.java
@@ -22,6 +22,7 @@ import net.kyori.adventure.sound.Sound.Source;
 
 import org.dockbox.hartshorn.api.domain.Exceptional;
 import org.dockbox.hartshorn.api.domain.tuple.Tristate;
+import org.dockbox.hartshorn.api.domain.tuple.Vector3N;
 import org.dockbox.hartshorn.api.exceptions.Except;
 import org.dockbox.hartshorn.api.exceptions.NotImplementedException;
 import org.dockbox.hartshorn.api.i18n.common.Language;
@@ -267,6 +268,12 @@ public class SpongePlayer extends Player implements SpongeEntity<net.minecraft.s
             final Language language = Language.of(locale);
             return new SimpleGameSettings(language);
         }).orElse(() -> new SimpleGameSettings(Language.EN_US)).get();
+    }
+
+    @Override
+    public Vector3N rotation() {
+        return this.player().map(player -> SpongeConvert.fromSponge(player.headRotation().get()))
+                .or(Vector3N.empty());
     }
 
     private Exceptional<User> user() {

--- a/hartshorn-test/src/testFixtures/java/org/dockbox/hartshorn/test/objects/living/JUnitPlayer.java
+++ b/hartshorn-test/src/testFixtures/java/org/dockbox/hartshorn/test/objects/living/JUnitPlayer.java
@@ -18,6 +18,7 @@
 package org.dockbox.hartshorn.test.objects.living;
 
 import org.dockbox.hartshorn.api.Hartshorn;
+import org.dockbox.hartshorn.api.domain.tuple.Vector3N;
 import org.dockbox.hartshorn.api.exceptions.NotImplementedException;
 import org.dockbox.hartshorn.api.domain.Exceptional;
 import org.dockbox.hartshorn.api.domain.tuple.Tristate;
@@ -79,6 +80,8 @@ public class JUnitPlayer extends Player implements JUnitPersistentDataHolder {
     private boolean invulnerable = false;
     @Setter
     private boolean gravity = true;
+    @Getter @Setter
+    private Vector3N rotation;
 
     public JUnitPlayer(@NotNull UUID uniqueId, @NotNull String name) {
         super(uniqueId, name);


### PR DESCRIPTION
Closes #333

# Changes
Adds a `rotation` property to `Player` which represents the head rotation represented by a vector where:
- x = pitch
- y = yaw
- z = roll

# How Has This Been Tested?
- [x] Integration testing

**Test Configuration**:
* Platform: Sponge
* Java version: 16.0.1

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
