### PR TITLE
Type provision performance enhancements

### DIFF
--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/binding/Bindings.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/binding/Bindings.java
@@ -57,6 +57,8 @@ public final class Bindings {
      * @return The nullable property value
      */
     public static <T> Exceptional<T> value(@NonNls String key, Class<T> expectedType, InjectorProperty<?>... properties) {
+        if (properties.length == 0) return Exceptional.empty();
+
         InjectorProperty<T> property = Bindings.property(key, expectedType, properties);
         // As the object is provided by a supplier this cannot currently be simplified to #of
         if (null != property) {

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/guice/GuiceInjector.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/guice/GuiceInjector.java
@@ -205,7 +205,6 @@ public class GuiceInjector implements Injector {
     @Override
     public <T> T populate(T instance) {
         if (null != instance) {
-            this.rebuild().injectMembers(instance);
             for (Field field : Reflect.fields(instance.getClass(), Wired.class)) {
                 Object fieldInstance = ApplicationContextAware.instance().context().get(field.getType());
                 Reflect.set(field, instance, fieldInstance);


### PR DESCRIPTION
# Motivation
Type provisioning is already quite optimized, and can perform about 340.000 raw provisions per second. I made some minor changes which remove duplicate behavior, and improve the speed by skipping behavior when specific expectations are not met (e.g. property lookup when the provided set is empty).  
This increases the amount of provisions per second to about 410.000 raw provisions per second. However one major improvement has been made regarding singletons. By checking the instance type for a singleton state as well, more types are validated early on as singletons. This allows us to provide 12.500.000 singletons per second. This only affects non-service types, as those were already optimized.

## Type of change
- [x] Enhancement of existing functionality

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
