### PR TITLE
Remove external slot validation for armor stand equipment

### DIFF
--- a/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/game/entity/SpongeArmorStandInventory.java
+++ b/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/game/entity/SpongeArmorStandInventory.java
@@ -26,6 +26,7 @@ import org.dockbox.hartshorn.sponge.util.SpongeConvert;
 import org.dockbox.hartshorn.util.HartshornUtils;
 import org.spongepowered.api.data.type.HandTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.equipment.EquipmentType;
 
 import java.util.Collection;
 import java.util.List;
@@ -82,14 +83,8 @@ public class SpongeArmorStandInventory implements SpongeInventory, ArmorStandInv
     public void slot(Item item, Slot slot) {
         this.stand.entity().present(entity -> {
             final ItemStack itemStack = SpongeConvert.toSponge(item);
-            switch (slot) {
-                case HELMET -> entity.setHead(itemStack);
-                case CHESTPLATE -> entity.setChest(itemStack);
-                case LEGGINGS -> entity.setLegs(itemStack);
-                case BOOTS -> entity.setFeet(itemStack);
-                case MAIN_HAND -> entity.setItemInHand(HandTypes.MAIN_HAND, itemStack);
-                case OFF_HAND -> entity.setItemInHand(HandTypes.OFF_HAND, itemStack);
-            }
+            final EquipmentType type = SpongeConvert.toSponge(slot);
+            entity.equipment().slot(type).ifPresent(equipmentSlot -> equipmentSlot.set(itemStack));
         });
     }
 }


### PR DESCRIPTION
# Motivation
It is currently not possible to set non-equipment items in armor stand equipment slots.

# Changes
By bypassing the direct slot accessor, external slot validation is skipped which allows you to set the item directly to the slot.

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Integration testing

**Test Configuration**:
* Platform: Sponge
* Java version: 16.0.1

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
