### PR TITLE
Reuse proxy handlers when modifying services

### DIFF
--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/handle/ProxyInterfaceHandler.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/handle/ProxyInterfaceHandler.java
@@ -21,8 +21,11 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
+import lombok.Getter;
+
 public class ProxyInterfaceHandler<T> implements InvocationHandler {
 
+    @Getter
     private final ProxyHandler<T> handler;
 
     public ProxyInterfaceHandler(ProxyHandler<T> handler) {

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/service/ServiceAnnotatedMethodModifier.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/service/ServiceAnnotatedMethodModifier.java
@@ -25,11 +25,14 @@ import org.dockbox.hartshorn.proxy.ProxyProperty;
 import org.dockbox.hartshorn.proxy.exception.ProxyMethodBindingException;
 import org.dockbox.hartshorn.proxy.handle.ProxyFunction;
 import org.dockbox.hartshorn.proxy.handle.ProxyHandler;
+import org.dockbox.hartshorn.proxy.handle.ProxyInterfaceHandler;
 import org.dockbox.hartshorn.util.Reflect;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Collection;
 
 import javassist.util.proxy.MethodHandler;
@@ -47,11 +50,20 @@ public abstract class ServiceAnnotatedMethodModifier<M extends Annotation, A ext
         final Collection<Method> methods = Reflect.methods(type, this.annotation());
 
         ProxyHandler<T> handler = null;
-        if (instance != null && ProxyFactory.isProxyClass(instance.getClass())) {
-            final MethodHandler methodHandler = ProxyFactory.getHandler((javassist.util.proxy.Proxy) instance);
-            if (methodHandler instanceof ProxyHandler proxyHandler) {
-                //noinspection unchecked
-                handler = (ProxyHandler<T>) proxyHandler;
+        if (instance != null) {
+            if (ProxyFactory.isProxyClass(instance.getClass())) {
+                final MethodHandler methodHandler = ProxyFactory.getHandler((javassist.util.proxy.Proxy) instance);
+                if (methodHandler instanceof ProxyHandler proxyHandler) {
+                    //noinspection unchecked
+                    handler = (ProxyHandler<T>) proxyHandler;
+                }
+            }
+            else if (Proxy.isProxyClass(instance.getClass())) {
+                final InvocationHandler invocationHandler = Proxy.getInvocationHandler(instance);
+                if (invocationHandler instanceof ProxyInterfaceHandler proxyInterfaceHandler) {
+                    //noinspection unchecked
+                    handler = proxyInterfaceHandler.handler();
+                }
             }
         }
 
@@ -66,7 +78,8 @@ public abstract class ServiceAnnotatedMethodModifier<M extends Annotation, A ext
                     ProxyProperty<T, ?> property = ProxyProperty.of(type, method, function);
                     handler.delegate(property);
                 }
-            } else {
+            }
+            else {
                 if (this.failOnPrecondition()) {
                     throw new ProxyMethodBindingException(method);
                 }


### PR DESCRIPTION
# Motivation
Currently service modifiers create a new proxy for each new service, even if the modified instance is already a proxied type. This causes continuous nesting within proxies, which can affect performance when multiple proxies delegate a method to the underlying method (e.g. `proxyA:call` -> `proxyB:call` -> `realInstance:call`).

# Changes
Before a new `ProxyHandler` is created, the modifier first checks if the type is a proxy. If it is, its existing handler is looked up, and re-used if it is a `ProxyHandler` (internal). The lookup affects both `ProxyHandler` directly, and the delegated `ProxyInterfaceHandler`.

## Type of change
- [x] Enhancement of existing functionality

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
