### PR TITLE
#369 Paginated panes

### DIFF
--- a/hartshorn-minecraft/server/src/main/java/org/dockbox/hartshorn/server/minecraft/inventory/builder/PaginatedPaneBuilder.java
+++ b/hartshorn-minecraft/server/src/main/java/org/dockbox/hartshorn/server/minecraft/inventory/builder/PaginatedPaneBuilder.java
@@ -17,17 +17,120 @@
 
 package org.dockbox.hartshorn.server.minecraft.inventory.builder;
 
-import org.dockbox.hartshorn.server.minecraft.inventory.context.ClickContext;
+import org.dockbox.hartshorn.api.domain.tuple.Tuple;
+import org.dockbox.hartshorn.api.exceptions.ApplicationException;
+import org.dockbox.hartshorn.di.properties.Attribute;
+import org.dockbox.hartshorn.i18n.text.Text;
 import org.dockbox.hartshorn.server.minecraft.inventory.Element;
+import org.dockbox.hartshorn.server.minecraft.inventory.InventoryLayout;
+import org.dockbox.hartshorn.server.minecraft.inventory.InventoryType;
+import org.dockbox.hartshorn.server.minecraft.inventory.context.ClickContext;
 import org.dockbox.hartshorn.server.minecraft.inventory.pane.PaginatedPane;
+import org.dockbox.hartshorn.server.minecraft.inventory.properties.LayoutAttribute;
+import org.dockbox.hartshorn.server.minecraft.item.Item;
+import org.dockbox.hartshorn.server.minecraft.item.ItemTypes;
+import org.dockbox.hartshorn.util.HartshornUtils;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.function.Function;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
 
 public abstract class PaginatedPaneBuilder extends DefaultPaneBuilder<PaginatedPane, PaginatedPaneBuilder> {
 
-    public abstract PaginatedPaneBuilder elements(Collection<Element> elements);
+    @Getter(AccessLevel.PROTECTED)
+    private InventoryLayout layout;
 
+    @Setter
+    @Getter(AccessLevel.PROTECTED)
+    private Text title;
+
+    @Getter(AccessLevel.PROTECTED)
+    private final Collection<Element> elements = HartshornUtils.emptyList();
+
+    public static final Function<PaginatedPane, Element> FIRST = paginated -> Element.of(
+            Item.of(ItemTypes.PAPER).displayName(Text.of("First")).amount(1),
+            ctx -> handle(ctx, pane -> 0)
+    );
+    public static final Function<PaginatedPane, Element> PREVIOUS = paginated -> {
+        final int previous = Math.max(paginated.page() - 1, 0);
+        return Element.of(
+                Item.of(ItemTypes.PAPER).displayName(Text.of("Previous")).amount(previous + 1),
+                ctx -> handle(ctx, pane -> previous)
+        );
+    };
+    public static final Function<PaginatedPane, Element> CURRENT = paginated -> Element.of(
+            Item.of(ItemTypes.PAPER).displayName(Text.of("Current")).amount(paginated.page() + 1),
+            ctx -> handle(ctx, PaginatedPane::page)
+    );
+    public static final Function<PaginatedPane, Element> NEXT = paginated -> {
+        final int next = Math.min(paginated.page() + 1, paginated.pages() - 1);
+        return Element.of(
+                Item.of(ItemTypes.PAPER).displayName(Text.of("Next")).amount(next + 1),
+                ctx -> handle(ctx, pane -> next)
+        );
+    };
+    public static final Function<PaginatedPane, Element> LAST = paginated -> Element.of(
+            Item.of(ItemTypes.PAPER).displayName(Text.of("Last")).amount(paginated.pages()),
+            ctx -> handle(ctx, pane -> pane.pages() - 1)
+    );
+
+    @Getter(AccessLevel.PROTECTED)
+    private final Map<Integer, Function<PaginatedPane, Element>> actions = HartshornUtils.ofEntries(
+            Tuple.of(2, FIRST),
+            Tuple.of(3, PREVIOUS),
+            Tuple.of(4, CURRENT),
+            Tuple.of(5, NEXT),
+            Tuple.of(6, LAST)
+    );
+
+    private static boolean handle(final ClickContext context, final Function<PaginatedPane, Integer> action) {
+        if (context.pane() instanceof PaginatedPane paginated) {
+            paginated.open(context.player(), action.apply(paginated));
+            return false;
+        } else {
+            throw new IllegalStateException("Pagination action used in non-paginated pane");
+        }
+    }
+
+    @Override
+    public void apply(final Attribute<?> property) {
+        if (property instanceof LayoutAttribute layoutAttribute) {
+            final InventoryLayout layout = layoutAttribute.value();
+            final InventoryType type = layout.inventoryType();
+
+            // One row is reserved for pagination actions, and should be a full-sized inventory (9 columns).
+            if (type.rows() < 2) throw new IllegalArgumentException("Paginated panes should contain at least 2 rows");
+            if (type.columns() < 9) throw new IllegalArgumentException("Paginated panes should contain at least 9 columns");
+
+            this.layout = layout;
+        }
+    }
+
+    @Override
+    public void enable() throws ApplicationException {
+        if (this.layout == null) throw new ApplicationException("Missing attribute for InventoryLayout");
+    }
+
+    public PaginatedPaneBuilder actions(final Map<Integer, Function<PaginatedPane, Element>> elements) {
+        this.actions.clear();
+        this.actions.putAll(elements);
+        return this;
+    }
+
+    public PaginatedPaneBuilder action(final int index, final Function<PaginatedPane, Element> element) {
+        this.actions.put(index, element);
+        return this;
+    }
+
+    public PaginatedPaneBuilder elements(final Collection<Element> elements) {
+        this.elements.clear();
+        this.elements.addAll(elements);
+        return this;
+    }
 
     @Override
     public PaginatedPaneBuilder onClickOutput(final Function<ClickContext, Boolean> onClick) {

--- a/hartshorn-minecraft/server/src/main/java/org/dockbox/hartshorn/server/minecraft/inventory/builder/StaticPaneBuilder.java
+++ b/hartshorn-minecraft/server/src/main/java/org/dockbox/hartshorn/server/minecraft/inventory/builder/StaticPaneBuilder.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.server.minecraft.inventory.builder;
 
 import org.dockbox.hartshorn.api.exceptions.ApplicationException;
 import org.dockbox.hartshorn.di.properties.Attribute;
+import org.dockbox.hartshorn.i18n.text.Text;
 import org.dockbox.hartshorn.server.minecraft.inventory.context.ClickContext;
 import org.dockbox.hartshorn.server.minecraft.inventory.InventoryLayout;
 import org.dockbox.hartshorn.server.minecraft.inventory.pane.StaticPane;
@@ -28,12 +29,17 @@ import java.util.function.Function;
 
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 
 @SuppressWarnings("EmptyClass")
 public abstract class StaticPaneBuilder extends DefaultPaneBuilder<StaticPane, StaticPaneBuilder> {
 
     @Getter(AccessLevel.PROTECTED)
     private InventoryLayout layout;
+
+    @Setter
+    @Getter(AccessLevel.PROTECTED)
+    private Text title;
 
     @Override
     public void apply(final Attribute<?> property) {

--- a/hartshorn-minecraft/server/src/main/java/org/dockbox/hartshorn/server/minecraft/inventory/pane/PaginatedPane.java
+++ b/hartshorn-minecraft/server/src/main/java/org/dockbox/hartshorn/server/minecraft/inventory/pane/PaginatedPane.java
@@ -40,7 +40,7 @@ public interface PaginatedPane extends Pane {
      *
      * @return The builder
      */
-    static PaginatedPaneBuilder builder(InventoryLayout layout) {
+    static PaginatedPaneBuilder builder(final InventoryLayout layout) {
         return Hartshorn.context().get(PaginatedPaneBuilder.class, new LayoutAttribute(layout));
     }
 
@@ -61,4 +61,7 @@ public interface PaginatedPane extends Pane {
      *         The elements
      */
     void elements(Collection<Element> elements);
+
+    int page();
+    int pages();
 }

--- a/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/inventory/panes/SpongePaginatedPane.java
+++ b/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/inventory/panes/SpongePaginatedPane.java
@@ -17,39 +17,155 @@
 
 package org.dockbox.hartshorn.sponge.inventory.panes;
 
-import org.dockbox.hartshorn.server.minecraft.inventory.context.ClickContext;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+
+import org.dockbox.hartshorn.api.domain.Exceptional;
 import org.dockbox.hartshorn.server.minecraft.inventory.Element;
+import org.dockbox.hartshorn.server.minecraft.inventory.InventoryType;
+import org.dockbox.hartshorn.server.minecraft.inventory.context.ClickContext;
 import org.dockbox.hartshorn.server.minecraft.inventory.pane.PaginatedPane;
+import org.dockbox.hartshorn.server.minecraft.item.Item;
+import org.dockbox.hartshorn.server.minecraft.item.ItemTypes;
 import org.dockbox.hartshorn.server.minecraft.players.Player;
+import org.dockbox.hartshorn.sponge.util.SpongeConvert;
+import org.dockbox.hartshorn.util.HartshornUtils;
+import org.spongepowered.api.entity.living.player.server.ServerPlayer;
+import org.spongepowered.api.item.inventory.Container;
+import org.spongepowered.api.item.inventory.menu.InventoryMenu;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-// TODO: #369 Implement this
 public class SpongePaginatedPane implements PaginatedPane {
+
+    protected final InventoryMenu menu;
+    private final InventoryType type;
+    private final Map<Integer, Function<PaginatedPane, Element>> actions;
+    private final Multimap<Integer, Function<ClickContext, Boolean>> listeners = ArrayListMultimap.create();
+    private final Map<Integer, List<Element>> pages = HartshornUtils.emptyConcurrentMap();
+    private int page = 0;
+
+    public SpongePaginatedPane(final InventoryMenu menu, final InventoryType type, final BiConsumer<Player, PaginatedPane> onClose, final Map<Integer, Function<PaginatedPane, Element>> actions) {
+        this.menu = menu;
+        this.type = type;
+        this.actions = actions;
+
+        this.menu.registerSlotClick((cause, container, slot, slotIndex, clickType) -> {
+            if (this.listeners.containsKey(slotIndex)) {
+                final Optional<ServerPlayer> player = cause.first(ServerPlayer.class);
+                if (player.isEmpty()) return false;
+
+                final Player origin = SpongeConvert.fromSponge(player.get());
+                final Item item = Exceptional.of(slot.peekAt(0))
+                        .map(SpongeConvert::fromSponge)
+                        .map(Item.class::cast)
+                        .orElse(ItemTypes.AIR::item)
+                        .get();
+
+                final ClickContext context = new ClickContext(origin, item, this);
+                boolean permit = true;
+                final List<Function<ClickContext, Boolean>> functions = HartshornUtils.asUnmodifiableList(this.listeners.get(slotIndex));
+                for (final Function<ClickContext, Boolean> function : functions) {
+                    if (!function.apply(context)) permit = false;
+                }
+                return permit;
+            }
+            return true;
+        });
+
+        this.menu.registerClose((cause, container) -> {
+            final Optional<ServerPlayer> player = cause.first(ServerPlayer.class);
+            if (player.isEmpty()) return;
+            final Player origin = SpongeConvert.fromSponge(player.get());
+            onClose.accept(origin, this);
+        });
+    }
+
+    private void registerActions() {
+        for (final Entry<Integer, Function<PaginatedPane, Element>> entry : this.actions.entrySet()) {
+            final int index = entry.getKey();
+            final Element element = entry.getValue().apply(this);
+
+            // Imagine a 3x9 inventory, the total size will be 27. The amount of
+            // columns is 9, so size - columns = 27 - 9 = 18. 18 will be the first
+            // index on the last row. As indices are counted from zero, we can then
+            // simply add the index to the row offset to get the right results.
+            // Visualized inventory:
+            // 0  1  2  3  4  5  6  7  8
+            // 9  10 11 12 13 14 15 16 17
+            // 18 19 20 21 22 23 24 25 26
+            final int offset = this.type.size() - this.type.columns();
+
+            this.menu.inventory().set(offset + index, SpongeConvert.toSponge(element.item()));
+            this.onClick(offset + index, element::perform);
+        }
+    }
 
     @Override
     public void open(final Player player, final int page) {
+        final Exceptional<ServerPlayer> serverPlayer = SpongeConvert.toSponge(player);
+        if (serverPlayer.present() && this.pages.containsKey(page)) {
+            this.listeners.clear();
+            this.page = page;
 
+            final List<Element> elements = this.pages.get(page);
+
+            for (int i = 0; i < elements.size(); i++) {
+                final Element element = elements.get(i);
+                final Item item = element.item();
+
+                this.menu.inventory().set(i, SpongeConvert.toSponge(item));
+                if (element.listening()) this.onClick(i, element::perform);
+            }
+
+            this.registerActions();
+
+            final ServerPlayer spongePlayer = serverPlayer.get();
+
+            final Exceptional<Container> open = Exceptional.of(spongePlayer.openInventory());
+            if (open.absent() || !open.get().containsInventory(this.menu.inventory()))
+                this.menu.open(spongePlayer);
+        }
     }
 
     @Override
     public void elements(final Collection<Element> elements) {
+        final int capacity = this.type.size() - this.type.columns();
+        final List<List<Element>> pages = Lists.partition(HartshornUtils.asList(elements), capacity);
+        for (int i = 0; i < pages.size(); i++) {
+            this.pages.put(i, pages.get(i));
+        }
+    }
 
+    @Override
+    public int page() {
+        return this.page;
+    }
+
+    @Override
+    public int pages() {
+        return this.pages.size();
     }
 
     @Override
     public void open(final Player player) {
-
+        this.open(player, 0);
     }
 
     @Override
     public void onClick(final int index, final Function<ClickContext, Boolean> onClick) {
-
+        this.listeners.put(index, onClick);
     }
 
     @Override
     public void close(final Player player) {
-
+        SpongeConvert.toSponge(player).present(ServerPlayer::closeInventory);
     }
 }

--- a/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/inventory/panes/SpongePaginatedPaneBuilder.java
+++ b/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/inventory/panes/SpongePaginatedPaneBuilder.java
@@ -17,27 +17,37 @@
 
 package org.dockbox.hartshorn.sponge.inventory.panes;
 
-import org.dockbox.hartshorn.i18n.text.Text;
-import org.dockbox.hartshorn.server.minecraft.inventory.Element;
+import org.dockbox.hartshorn.di.annotations.inject.Binds;
 import org.dockbox.hartshorn.server.minecraft.inventory.builder.PaginatedPaneBuilder;
 import org.dockbox.hartshorn.server.minecraft.inventory.pane.PaginatedPane;
+import org.dockbox.hartshorn.sponge.util.SpongeConvert;
+import org.spongepowered.api.item.inventory.menu.InventoryMenu;
+import org.spongepowered.api.item.inventory.type.ViewableInventory;
 
-import java.util.Collection;
-
-// TODO: #369 Implement this
+@Binds(PaginatedPaneBuilder.class)
 public class SpongePaginatedPaneBuilder extends PaginatedPaneBuilder {
-    @Override
-    public PaginatedPaneBuilder elements(Collection<Element> elements) {
-        return null;
-    }
-
-    @Override
-    public PaginatedPaneBuilder title(Text text) {
-        return null;
-    }
 
     @Override
     public PaginatedPane build() {
-        return null;
+        final InventoryMenu menu = ViewableInventory.builder()
+                .type(SpongeConvert.toSponge(this.layout().inventoryType()))
+                .completeStructure()
+                .build().asMenu();
+
+        if (this.title() != null) menu.setTitle(SpongeConvert.toSponge(this.title()));
+
+        final PaginatedPane pane = new SpongePaginatedPane(menu, this.layout().inventoryType(), this.onClose(), this.actions());
+
+        if (this.lock()) {
+            for (int i = 0; i < this.layout().inventoryType().size(); i++) {
+                pane.onClick(i, context -> false);
+            }
+        }
+
+        this.listeners().forEach(pane::onClick);
+
+        pane.elements(this.elements());
+
+        return pane;
     }
 }

--- a/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/inventory/panes/SpongeStaticPaneBuilder.java
+++ b/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/inventory/panes/SpongeStaticPaneBuilder.java
@@ -18,19 +18,14 @@
 package org.dockbox.hartshorn.sponge.inventory.panes;
 
 import org.dockbox.hartshorn.di.annotations.inject.Binds;
-import org.dockbox.hartshorn.i18n.text.Text;
 import org.dockbox.hartshorn.server.minecraft.inventory.builder.StaticPaneBuilder;
 import org.dockbox.hartshorn.server.minecraft.inventory.pane.StaticPane;
 import org.dockbox.hartshorn.sponge.util.SpongeConvert;
 import org.spongepowered.api.item.inventory.menu.InventoryMenu;
 import org.spongepowered.api.item.inventory.type.ViewableInventory;
 
-import lombok.Setter;
-
 @Binds(StaticPaneBuilder.class)
 public class SpongeStaticPaneBuilder extends StaticPaneBuilder {
-
-    @Setter private Text title;
 
     @Override
     public StaticPane build() {
@@ -39,7 +34,7 @@ public class SpongeStaticPaneBuilder extends StaticPaneBuilder {
                 .completeStructure()
                 .build().asMenu();
 
-        if (this.title != null) menu.setTitle(SpongeConvert.toSponge(this.title));
+        if (this.title() != null) menu.setTitle(SpongeConvert.toSponge(this.title()));
 
         // Containers which exist solely to function while open cannot be rendered early, so we need to use a delayed populating panel.
         final StaticPane pane = switch (this.layout().inventoryType()) {


### PR DESCRIPTION
Adds to #369

# Changes
Implements the `PaginatedPane` on Sponge. This includes minor API changes to add methods to get the current page, and total page count from a paginated pane. Also specific actions can now be added to the pane, which can be modified based on the modified state of the pane (e.g. current page). Default actions are:
- First page
- Previous page
- Current page
- Next page
- Last page

## Example
The following example generates 54 elements, increasing the amount of each element based on its position in the list. These are then used as elements for the paginated pane, which is a 4x9 generic inventory. As the bottom row is reserved for actions, this means that the pagination space is 3x9, so 27 spaces. This means the result should be 2 full pages of elements.
```java
List<Element> elements = HartshornUtils.emptyList();
for (int i = 0; i < 54; i++) {
    final Item item = Item.of(ItemTypes.STONE).amount(i + 1);
    int finalI = i;
    final Element element = Element.of(item, ctx -> {
        System.out.println("Clicked on: " + finalI);
        return false;
    });
    elements.add(element);
}
final PaginatedPane paginated = InventoryLayout.builder(InventoryType.GENERIC_4_ROWS)
        .toPaginatedPaneBuilder()
        .elements(elements)
        .build();
paginated.open(source);
```
And the result:  

https://user-images.githubusercontent.com/10957963/129476726-cb536b13-95c9-45ae-9542-3bf7f544064a.mp4

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Integration testing

**Test Configuration**:
* Platform: Sponge
* Java version: 16.0.1

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes