### PR TITLE
Add URL support to ObjectMapper

### DIFF
--- a/hartshorn-persistence/src/impl/java/org/dockbox/hartshorn/persistence/DefaultObjectMapper.java
+++ b/hartshorn-persistence/src/impl/java/org/dockbox/hartshorn/persistence/DefaultObjectMapper.java
@@ -32,8 +32,9 @@ public abstract class DefaultObjectMapper implements ObjectMapper {
     }
 
     @Override
-    public void fileType(FileType fileType) {
+    public ObjectMapper fileType(FileType fileType) {
         this.fileType = fileType;
+        return this;
     }
 
     @Override

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/mapping/ObjectMapper.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/mapping/ObjectMapper.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.api.domain.Exceptional;
 import org.dockbox.hartshorn.di.properties.AttributeHolder;
 import org.dockbox.hartshorn.persistence.FileType;
 
+import java.net.URL;
 import java.nio.file.Path;
 
 public interface ObjectMapper extends AttributeHolder {
@@ -29,15 +30,19 @@ public interface ObjectMapper extends AttributeHolder {
 
     <T> Exceptional<T> read(Path path, Class<T> type);
 
+    <T> Exceptional<T> read(URL url, Class<T> type);
+
     <T> Exceptional<T> read(String content, GenericType<T> type);
 
     <T> Exceptional<T> read(Path path, GenericType<T> type);
+
+    <T> Exceptional<T> read(URL url, GenericType<T> type);
 
     <T> Exceptional<Boolean> write(Path path, T content);
 
     <T> Exceptional<String> write(T content);
 
-    void fileType(FileType fileType);
+    ObjectMapper fileType(FileType fileType);
 
     FileType fileType();
 


### PR DESCRIPTION
# Changes
Adds `URL` support to the `ObjectMapper`. This allows reading data from e.g. web APIs.

## Type of change
- [x] New core feature

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
