### PR TITLE
#444 Generate `module.pom` artifacts instead of `module-pom.xml`

### DIFF
--- a/gradle/publications.gradle
+++ b/gradle/publications.gradle
@@ -75,11 +75,11 @@ task copyPublications {
                     includes: "$project.name-$version*"
         }
 
-        file("$POM_SRC_DIR/pom-default.xml").renameTo(file("$POM_SRC_DIR/$project.name-pom.xml"))
+        file("$POM_SRC_DIR/pom-default.xml").renameTo(file("$POM_SRC_DIR/${project.name}.pom"))
 
         ant.copy(todir: DIST_DEST_DIR) {
             fileset dir: POM_SRC_DIR,
-                    includes: "$project.name-pom.xml"
+                    includes: "${project.name}.pom"
         }
 
     }


### PR DESCRIPTION
Fixes #444

# Motivation
When uploading to Maven Central the expected POM is either a `pom.xml` file, named exactly that, or any file ending in `.pom`. As all publication artifacts are relocated to the same version assembly this means each file needs to be renamed before it's uploaded. To make this process easier, we now generate the POMs as `module.pom` instead of `module-pom.xml`. The content of the POMs does not need to be modified for this purpose.

## Type of change
- [x] Enhancement of existing functionality