### PR TITLE
#789 Range shorthand expression

### DIFF
--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/ast/expression/RangeExpression.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/ast/expression/RangeExpression.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.hsl.ast.expression;
+
+import org.dockbox.hartshorn.hsl.token.Token;
+import org.dockbox.hartshorn.hsl.visitors.ExpressionVisitor;
+
+public class RangeExpression extends Expression {
+
+    private final Expression leftExp;
+    private final Token operator;
+    private final Expression rightExp;
+
+    public RangeExpression(final Expression leftExp, final Token operator, final Expression rightExp) {
+        super(operator);
+        this.leftExp = leftExp;
+        this.operator = operator;
+        this.rightExp = rightExp;
+    }
+
+    public Expression leftExpression() {
+        return this.leftExp;
+    }
+
+    public Token operator() {
+        return this.operator;
+    }
+
+    public Expression rightExpression() {
+        return this.rightExp;
+    }
+
+    @Override
+    public <R> R accept(final ExpressionVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Interpreter.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Interpreter.java
@@ -36,6 +36,7 @@ import org.dockbox.hartshorn.hsl.ast.expression.LogicalAssignExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.LogicalExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.PostfixExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.PrefixExpression;
+import org.dockbox.hartshorn.hsl.ast.expression.RangeExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.SetExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.SuperExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.TernaryExpression;
@@ -284,6 +285,24 @@ public class Interpreter implements ExpressionVisitor<Object>, StatementVisitor<
             }
         }
         return null;
+    }
+
+    @Override
+    public Object visit(final RangeExpression expr) {
+        final Object start = unwrap(this.evaluate(expr.leftExpression()));
+        final Object end = unwrap(this.evaluate(expr.rightExpression()));
+
+        checkNumberOperands(expr.operator(), start, end);
+
+        final int min = ((Number) start).intValue();
+        final int max = ((Number) end).intValue();
+
+        final int length = max - min + 1;
+        final Object[] result = new Object[length];
+        for (int i = 0; i < length; i++) {
+            result[i] = (double) min + i;
+        }
+        return new Array(result);
     }
 
     @Override

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/lexer/Lexer.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/lexer/Lexer.java
@@ -103,7 +103,10 @@ public class Lexer {
                 this.addToken(TokenType.COMMA);
                 break;
             case TokenConstants.DOT:
-                this.addToken(TokenType.DOT);
+                this.addToken(this.match(TokenConstants.DOT)
+                        ? TokenType.RANGE
+                        : TokenType.DOT
+                );
                 break;
             case TokenConstants.MINUS:
                 if (this.match(TokenConstants.MINUS)) {

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/Parser.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/Parser.java
@@ -23,7 +23,6 @@ import org.dockbox.hartshorn.hsl.ast.expression.ArrayLiteralExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.ArraySetExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.AssignExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.BinaryExpression;
-import org.dockbox.hartshorn.hsl.ast.expression.LogicalAssignExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.BitwiseExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.ElvisExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.Expression;
@@ -32,9 +31,11 @@ import org.dockbox.hartshorn.hsl.ast.expression.GetExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.GroupingExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.InfixExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.LiteralExpression;
+import org.dockbox.hartshorn.hsl.ast.expression.LogicalAssignExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.LogicalExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.PostfixExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.PrefixExpression;
+import org.dockbox.hartshorn.hsl.ast.expression.RangeExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.SetExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.SuperExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.TernaryExpression;
@@ -537,10 +538,14 @@ public class Parser {
     }
 
     private Expression equality() {
-        return this.logicalOrBitwise(this::logicalAssign, BinaryExpression::new,
+        return this.logicalOrBitwise(this::range, BinaryExpression::new,
                 TokenType.BANG_EQUAL,
                 TokenType.EQUAL_EQUAL
         );
+    }
+
+    private Expression range() {
+        return this.logicalOrBitwise(this::logicalAssign, RangeExpression::new, TokenType.RANGE);
     }
 
     private Expression logicalAssign() {

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/semantic/Resolver.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/semantic/Resolver.java
@@ -37,6 +37,7 @@ import org.dockbox.hartshorn.hsl.ast.expression.LogicalAssignExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.LogicalExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.PostfixExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.PrefixExpression;
+import org.dockbox.hartshorn.hsl.ast.expression.RangeExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.SetExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.SuperExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.TernaryExpression;
@@ -121,6 +122,13 @@ public class Resolver implements ExpressionVisitor<Void>, StatementVisitor<Void>
 
     @Override
     public Void visit(final BinaryExpression expr) {
+        this.resolve(expr.leftExpression());
+        this.resolve(expr.rightExpression());
+        return null;
+    }
+
+    @Override
+    public Void visit(final RangeExpression expr) {
         this.resolve(expr.leftExpression());
         this.resolve(expr.rightExpression());
         return null;

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenType.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenType.java
@@ -64,6 +64,7 @@ public enum TokenType {
     MINUS_MINUS(builder -> builder.repeats(MINUS).ok()),
     SHIFT_RIGHT(builder -> builder.repeats(GREATER).ok()),
     SHIFT_LEFT(builder -> builder.repeats(LESS).ok()),
+    RANGE(builder -> builder.repeats(DOT).ok()),
     LOGICAL_SHIFT_RIGHT(builder -> builder.combines(GREATER, GREATER, GREATER).ok()),
     AND(builder -> builder.repeats(BITWISE_AND).ok()),
     OR(builder -> builder.repeats(BITWISE_OR).ok()),

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/visitors/ExpressionVisitor.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/visitors/ExpressionVisitor.java
@@ -33,6 +33,7 @@ import org.dockbox.hartshorn.hsl.ast.expression.LiteralExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.LogicalExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.PostfixExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.PrefixExpression;
+import org.dockbox.hartshorn.hsl.ast.expression.RangeExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.SetExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.SuperExpression;
 import org.dockbox.hartshorn.hsl.ast.expression.TernaryExpression;
@@ -49,6 +50,8 @@ import org.dockbox.hartshorn.hsl.ast.expression.VariableExpression;
  */
 public interface ExpressionVisitor<R> {
     R visit(BinaryExpression expr);
+
+    R visit(RangeExpression expr);
 
     R visit(GroupingExpression expr);
 

--- a/hartshorn-hsl/src/test/resources/array/array_range.hsl
+++ b/hartshorn-hsl/src/test/resources/array/array_range.hsl
@@ -1,0 +1,4 @@
+var array = 1..10; // Inclusive range, [1, .., 10]
+for (var i in array) {
+    print(i);
+}


### PR DESCRIPTION
# Description
Currently if you wish to quickly populate a list with increasing values (e.g. `[1,2,3,..8,9,10]`), the best approach is to create an empty array, and loop until it is populated:
```js
var array = [null] * 10;
for (var i=0; i<10; i++) {
    array[i] = i+1;
}
```
While this is fine, HSL is intended to be compact so it can be used easily in short expressions.

These changes add a shorthand for the sample above, a typical example of this would be:
```js
for (var i in 1..10) {
    print(i);
}
```
Both the min and max are inclusive. For example, the sample above yields `[1,2,3,4,5,6,7,8,9,10]`

Fixes #789

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
