### PR TITLE
#790 Add context object for function parameters

### DIFF
--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/ast/statement/ConstructorStatement.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/ast/statement/ConstructorStatement.java
@@ -29,7 +29,7 @@ public class ConstructorStatement extends ParametricExecutableStatement {
 
     public ConstructorStatement(final Token keyword,
                                 final Token className,
-                                final List<Token> params,
+                                final List<Parameter> params,
                                 final BlockStatement body) {
         super(keyword, params, body);
         this.keyword = keyword;

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/ast/statement/FunctionStatement.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/ast/statement/FunctionStatement.java
@@ -27,7 +27,7 @@ public class FunctionStatement extends ParametricExecutableStatement implements 
     private final Token name;
 
     public FunctionStatement(final Token name,
-                             final List<Token> params,
+                             final List<Parameter> params,
                              final BlockStatement body) {
         super(name, params, body);
         this.name = name;

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/ast/statement/NativeFunctionStatement.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/ast/statement/NativeFunctionStatement.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.hsl.ast.statement;
 
 import org.dockbox.hartshorn.hsl.ast.NamedNode;
+import org.dockbox.hartshorn.hsl.ast.statement.ParametricExecutableStatement.Parameter;
 import org.dockbox.hartshorn.hsl.token.Token;
 import org.dockbox.hartshorn.hsl.visitors.StatementVisitor;
 import org.dockbox.hartshorn.util.reflect.MethodContext;
@@ -28,9 +29,9 @@ public class NativeFunctionStatement extends Function implements NamedNode {
     private final Token name;
     private final Token moduleName;
     private final MethodContext<?, ?> method;
-    private final List<Token> params;
+    private final List<Parameter> params;
 
-    public NativeFunctionStatement(final Token name, final Token moduleName, final MethodContext<?, ?> method, final List<Token> params) {
+    public NativeFunctionStatement(final Token name, final Token moduleName, final MethodContext<?, ?> method, final List<Parameter> params) {
         super(name);
         this.name = name;
         this.moduleName = moduleName;
@@ -47,7 +48,7 @@ public class NativeFunctionStatement extends Function implements NamedNode {
         return this.moduleName;
     }
 
-    public List<Token> params() {
+    public List<Parameter> params() {
         return this.params;
     }
 

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/ast/statement/ParametricExecutableStatement.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/ast/statement/ParametricExecutableStatement.java
@@ -22,16 +22,16 @@ import java.util.List;
 
 public abstract class ParametricExecutableStatement extends Function {
 
-    private final List<Token> params;
+    private final List<Parameter> params;
     private final BlockStatement body;
 
-    protected ParametricExecutableStatement(final Token token, final List<Token> params, final BlockStatement body) {
+    protected ParametricExecutableStatement(final Token token, final List<Parameter> params, final BlockStatement body) {
         super(token);
         this.params = params;
         this.body = body;
     }
 
-    public List<Token> parameters() {
+    public List<Parameter> parameters() {
         return this.params;
     }
 
@@ -40,6 +40,19 @@ public abstract class ParametricExecutableStatement extends Function {
     }
 
     public BlockStatement body() {
-        return body;
+        return this.body;
+    }
+
+    public static class Parameter {
+
+        private final Token name;
+
+        public Parameter(final Token name) {
+            this.name = name;
+        }
+
+        public Token name() {
+            return this.name;
+        }
     }
 }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Interpreter.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Interpreter.java
@@ -945,7 +945,7 @@ public class Interpreter implements ExpressionVisitor<Object>, StatementVisitor<
         final FunctionStatement functionStatement = statement.functionStatement();
         final VirtualFunction extension = new VirtualFunction(functionStatement, extensionClass.variableScope(), false);
         if (extensionClass.method(functionStatement.name().lexeme()) != null) {
-            throw new RuntimeException(extensionClass.name() + " class already have method with same name = " + functionStatement.name().lexeme());
+            throw new ScriptEvaluationError("Duplicate method " + extensionClass.name() + "." + functionStatement.name().lexeme(), Phase.INTERPRETING, statement.functionStatement().name());
         }
         extensionClass.addMethod(functionStatement.name().lexeme(), extension);
         return null;

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AbstractNativeModule.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AbstractNativeModule.java
@@ -17,10 +17,11 @@
 package org.dockbox.hartshorn.hsl.modules;
 
 import org.dockbox.hartshorn.hsl.ast.statement.NativeFunctionStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ParametricExecutableStatement.Parameter;
+import org.dockbox.hartshorn.hsl.interpreter.Interpreter;
 import org.dockbox.hartshorn.hsl.objects.NativeExecutionException;
 import org.dockbox.hartshorn.hsl.objects.external.ExecutableLookup;
 import org.dockbox.hartshorn.hsl.objects.external.ExternalInstance;
-import org.dockbox.hartshorn.hsl.interpreter.Interpreter;
 import org.dockbox.hartshorn.hsl.runtime.RuntimeError;
 import org.dockbox.hartshorn.hsl.token.Token;
 import org.dockbox.hartshorn.hsl.token.TokenType;
@@ -113,9 +114,10 @@ public abstract class AbstractNativeModule implements NativeModule {
                 if (!method.isPublic()) continue;
                 final Token token = new Token(TokenType.IDENTIFIER, method.name(), -1, -1);
 
-                final List<Token> parameters = new ArrayList<>();
+                final List<Parameter> parameters = new ArrayList<>();
                 for (final ParameterContext<?> parameter : method.parameters()) {
-                    parameters.add(new Token(TokenType.IDENTIFIER, parameter.name(), -1, -1));
+                    final Token parameterName = new Token(TokenType.IDENTIFIER, parameter.name(), -1, -1);
+                    parameters.add(new Parameter(parameterName));
                 }
                 final NativeFunctionStatement functionStatement = new NativeFunctionStatement(token, moduleName, method, parameters);
                 functionStatements.add(functionStatement);

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/virtual/VirtualFunction.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/virtual/VirtualFunction.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.hsl.objects.virtual;
 
 import org.dockbox.hartshorn.hsl.ast.statement.ParametricExecutableStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ParametricExecutableStatement.Parameter;
 import org.dockbox.hartshorn.hsl.interpreter.Interpreter;
 import org.dockbox.hartshorn.hsl.interpreter.VariableScope;
 import org.dockbox.hartshorn.hsl.objects.AbstractFinalizable;
@@ -72,7 +73,7 @@ public class VirtualFunction extends AbstractFinalizable implements MethodRefere
     @Override
     public Object call(final Token at, final Interpreter interpreter, final InstanceReference instance, final List<Object> arguments) {
         final VariableScope variableScope = new VariableScope(this.closure);
-        final List<Token> parameters = this.declaration.parameters();
+        final List<Parameter> parameters = this.declaration.parameters();
         if (parameters.size() != arguments.size()) {
             throw new RuntimeError(at, "Expected %d %s, but got %d".formatted(
                     parameters.size(),
@@ -80,7 +81,7 @@ public class VirtualFunction extends AbstractFinalizable implements MethodRefere
                     arguments.size()));
         }
         for (int i = 0; i < parameters.size(); i++) {
-            variableScope.define(parameters.get(i).lexeme(), arguments.get(i));
+            variableScope.define(parameters.get(i).name().lexeme(), arguments.get(i));
         }
         try {
             interpreter.execute(this.declaration.statements(), variableScope);

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/semantic/Resolver.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/semantic/Resolver.java
@@ -60,6 +60,7 @@ import org.dockbox.hartshorn.hsl.ast.statement.IfStatement;
 import org.dockbox.hartshorn.hsl.ast.statement.ModuleStatement;
 import org.dockbox.hartshorn.hsl.ast.statement.NativeFunctionStatement;
 import org.dockbox.hartshorn.hsl.ast.statement.ParametricExecutableStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ParametricExecutableStatement.Parameter;
 import org.dockbox.hartshorn.hsl.ast.statement.PrintStatement;
 import org.dockbox.hartshorn.hsl.ast.statement.RepeatStatement;
 import org.dockbox.hartshorn.hsl.ast.statement.ReturnStatement;
@@ -624,9 +625,9 @@ public class Resolver implements ExpressionVisitor<Void>, StatementVisitor<Void>
         this.currentFunction = type;
 
         this.beginScope();
-        for (final Token param : executable.parameters()) {
-            this.declare(param);
-            this.define(param);
+        for (final Parameter param : executable.parameters()) {
+            this.declare(param.name());
+            this.define(param.name());
         }
         this.resolve(executable.statements());
         this.endScope();


### PR DESCRIPTION
# Description
Currently parameters are directly exposed as `Token`s. While this is fine in the current implementation, it limits future expansion.

These changes add a dedicated `Parameter` object. This currently only wraps around the `Token`, but will be used in the future to support strong typing as well.

Fixes #790

## Type of change
- [x] Refactor (code changes that do not affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
