### PR TITLE
#799 Add `@PostConstruct` support for managed components

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ slf4jVersion=1.7.36
 logbackVersion=1.2.11
 reflectionsVersion=0.10.2
 jakartaInjectVersion=2.0.1
-
+jakartaAnnotationVersion=2.1.1
 javassistVersion=3.28.0-GA
 cglibVersion=3.3.0
 

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
@@ -26,7 +26,6 @@ import org.dockbox.hartshorn.commands.extension.CommandExecutorExtension;
 import org.dockbox.hartshorn.commands.extension.CommandExtensionContext;
 import org.dockbox.hartshorn.commands.extension.ExtensionResult;
 import org.dockbox.hartshorn.component.Component;
-import org.dockbox.hartshorn.component.Enableable;
 import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.util.ArrayListMultiMap;
 import org.dockbox.hartshorn.util.MultiMap;
@@ -40,13 +39,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
 /**
  * Simple implementation of {@link CommandGateway}.
  */
 @Component
-public class CommandGatewayImpl implements CommandGateway, Enableable {
+public class CommandGatewayImpl implements CommandGateway {
 
     private final transient MultiMap<String, CommandExecutorContext> contexts = new ArrayListMultiMap<>();
     private final transient List<CommandExecutorExtension> extensions = new CopyOnWriteArrayList<>();
@@ -66,17 +66,14 @@ public class CommandGatewayImpl implements CommandGateway, Enableable {
         return this.extensions;
     }
 
-    @Override
-    public boolean canEnable() {
-        return this.extensions.isEmpty();
-    }
-
-    @Override
+    @PostConstruct
     public void enable() {
-        final CommandExtensionContext extensionContext = this.context.first(CommandExtensionContext.class).get();
-        for (final CommandExecutorExtension extension : extensionContext.extensions()) {
-            this.context.log().debug("Adding extension " + TypeContext.of(extension).name() + " to command gateway");
-            this.add(extension);
+        if (this.extensions.isEmpty()) {
+            final CommandExtensionContext extensionContext = this.context.first(CommandExtensionContext.class).get();
+            for (final CommandExecutorExtension extension : extensionContext.extensions()) {
+                this.context.log().debug("Adding extension " + TypeContext.of(extension).name() + " to command gateway");
+                this.add(extension);
+            }
         }
     }
 

--- a/hartshorn-core/hartshorn-core.gradle
+++ b/hartshorn-core/hartshorn-core.gradle
@@ -18,6 +18,7 @@ apply from: "$project.rootDir/gradle/publications.gradle"
 
 dependencies {
     api "jakarta.inject:jakarta.inject-api:$jakartaInjectVersion"
+    api "jakarta.annotation:jakarta.annotation-api:$jakartaAnnotationVersion"
 
     implementation "org.reflections:reflections:$reflectionsVersion"
     implementation "ch.qos.logback:logback-classic:$logbackVersion"

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/AbstractApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/AbstractApplicationFactory.java
@@ -26,6 +26,7 @@ import org.dockbox.hartshorn.application.environment.ClasspathResourceLocator;
 import org.dockbox.hartshorn.application.scan.PrefixContext;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.ComponentPopulator;
+import org.dockbox.hartshorn.component.ComponentPostConstructor;
 import org.dockbox.hartshorn.component.ComponentProvider;
 import org.dockbox.hartshorn.component.condition.ConditionMatcher;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
@@ -153,6 +154,12 @@ public abstract class AbstractApplicationFactory<Self extends ApplicationFactory
     @Override
     public Self componentLocator(final Initializer<ComponentLocator> componentLocator) {
         this.configuration.componentLocator = componentLocator.cached();
+        return this.self();
+    }
+
+    @Override
+    public Self componentPostConstructor(final Initializer<ComponentPostConstructor> componentPostConstructor) {
+        this.configuration.componentPostConstructor = componentPostConstructor.cached();
         return this.self();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationContextConfiguration.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationContextConfiguration.java
@@ -24,6 +24,7 @@ import org.dockbox.hartshorn.application.environment.ClasspathResourceLocator;
 import org.dockbox.hartshorn.application.scan.PrefixContext;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.ComponentPopulator;
+import org.dockbox.hartshorn.component.ComponentPostConstructor;
 import org.dockbox.hartshorn.component.ComponentProvider;
 import org.dockbox.hartshorn.component.condition.ConditionMatcher;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
@@ -47,6 +48,7 @@ public class ApplicationContextConfiguration {
     protected Initializer<ApplicationLogger> applicationLogger;
     protected Initializer<ApplicationEnvironment> applicationEnvironment;
     protected Initializer<ComponentLocator> componentLocator;
+    protected Initializer<ComponentPostConstructor> componentPostConstructor;
     protected Initializer<ClasspathResourceLocator> resourceLocator;
     protected Initializer<MetaProvider> metaProvider;
     protected Initializer<ComponentProvider> componentProvider;
@@ -98,6 +100,10 @@ public class ApplicationContextConfiguration {
 
     public ComponentLocator componentLocator(final InitializingContext context) {
         return this.componentLocator.initialize(context);
+    }
+
+    public ComponentPostConstructor componentPostConstructor(final InitializingContext context) {
+        return this.componentPostConstructor.initialize(context);
     }
 
     public ClasspathResourceLocator resourceLocator(final InitializingContext context) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationFactory.java
@@ -25,6 +25,7 @@ import org.dockbox.hartshorn.application.environment.ClasspathResourceLocator;
 import org.dockbox.hartshorn.application.scan.PrefixContext;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.ComponentPopulator;
+import org.dockbox.hartshorn.component.ComponentPostConstructor;
 import org.dockbox.hartshorn.component.ComponentProvider;
 import org.dockbox.hartshorn.component.condition.ConditionMatcher;
 import org.dockbox.hartshorn.component.processing.ActivatorFiltered;
@@ -161,6 +162,17 @@ public interface ApplicationFactory<Self extends ApplicationFactory<Self, C>, C 
      * @see ComponentLocator
      */
     Self componentLocator(Initializer<ComponentLocator> componentLocator);
+
+    /**
+     * Sets the {@link ComponentPostProcessor} to use. The post constructor is responsible for invoking actions on a
+     * component after it has been constructed. The provider used a {@link Function} as the post constructor should
+     * typically be bound to a given {@link ApplicationContext}. The {@link ComponentPostProcessor} is created by the
+     * {@link ComponentProvider}.
+     *
+     * @param componentPostConstructor The component post constructor to use.
+     * @return The {@link ApplicationFactory} instance.
+     */
+    Self componentPostConstructor(Initializer<ComponentPostConstructor> componentPostConstructor);
 
     /**
      * Sets the {@link MetaProvider} to use. The meta provider is responsible for providing meta information about types.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/InitializingContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/InitializingContext.java
@@ -25,6 +25,7 @@ import org.dockbox.hartshorn.application.environment.ClasspathResourceLocator;
 import org.dockbox.hartshorn.application.scan.PrefixContext;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.ComponentPopulator;
+import org.dockbox.hartshorn.component.ComponentPostConstructor;
 import org.dockbox.hartshorn.component.ComponentProvider;
 import org.dockbox.hartshorn.component.condition.ConditionMatcher;
 import org.dockbox.hartshorn.inject.MetaProvider;
@@ -103,6 +104,10 @@ public record InitializingContext(ApplicationEnvironment environment, Applicatio
 
     public ComponentProvider componentProvider() {
         return this.configuration.componentProvider(this);
+    }
+
+    public ComponentPostConstructor componentPostConstructor() {
+        return this.configuration.componentPostConstructor(this);
     }
 
     public ComponentPopulator componentPopulator() {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationFactory.java
@@ -25,6 +25,7 @@ import org.dockbox.hartshorn.application.environment.StandardApplicationArgument
 import org.dockbox.hartshorn.application.scan.ReflectionsPrefixContext;
 import org.dockbox.hartshorn.beans.UseBeanScanning;
 import org.dockbox.hartshorn.component.ComponentLocatorImpl;
+import org.dockbox.hartshorn.component.ComponentPostConstructorImpl;
 import org.dockbox.hartshorn.component.ContextualComponentPopulator;
 import org.dockbox.hartshorn.component.HierarchicalApplicationComponentProvider;
 import org.dockbox.hartshorn.component.condition.ConditionMatcher;
@@ -94,6 +95,7 @@ public class StandardApplicationFactory extends AbstractApplicationFactory<Stand
         this.require(this.configuration().applicationProxier, "Application proxier");
         this.require(this.configuration().exceptionHandler, "Exception handler");
         this.require(this.configuration().componentLocator, "Component locator");
+        this.require(this.configuration().componentPostConstructor, "Component post-constructor");
         this.require(this.configuration().resourceLocator, "Resource locator");
         this.require(this.configuration().metaProvider, "Meta provider");
         this.require(this.configuration().applicationFSProvider, "Filesystem provider");
@@ -126,9 +128,10 @@ public class StandardApplicationFactory extends AbstractApplicationFactory<Stand
                 .exceptionHandler(ctx -> new LoggingExceptionHandler())
                 .prefixContext(ctx -> new ReflectionsPrefixContext(ctx.manager()))
                 .componentLocator(ComponentLocatorImpl::new)
+                .componentPostConstructor(ComponentPostConstructorImpl::new)
                 .resourceLocator(ctx -> new ClassLoaderClasspathResourceLocator(ctx.applicationContext()))
                 .metaProvider(ctx -> new InjectorMetaProvider(ctx.applicationContext()))
-                .componentProvider(ctx -> new HierarchicalApplicationComponentProvider(ctx.applicationContext(), ctx.componentLocator(), ctx.metaProvider()))
+                .componentProvider(HierarchicalApplicationComponentProvider::new)
                 .componentPopulator(ctx -> new ContextualComponentPopulator(ctx.applicationContext()))
                 .argumentParser(ctx -> new StandardApplicationArgumentParser())
                 .activatorHolder(ctx -> new StandardActivatorHolder(ctx.applicationContext()))

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
@@ -30,6 +30,7 @@ import org.dockbox.hartshorn.application.lifecycle.LifecycleObserver;
 import org.dockbox.hartshorn.application.lifecycle.ObservableApplicationManager;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.ComponentPopulator;
+import org.dockbox.hartshorn.component.ComponentPostConstructor;
 import org.dockbox.hartshorn.component.ComponentProvider;
 import org.dockbox.hartshorn.component.HierarchicalComponentProvider;
 import org.dockbox.hartshorn.component.StandardComponentProvider;
@@ -100,6 +101,7 @@ public abstract class DelegatingApplicationContext extends DefaultApplicationAwa
 
     protected void registerDefaultBindings(final InitializingContext context) {
         this.bind(ComponentPopulator.class).singleton(this.componentPopulator);
+        this.bind(ComponentPostConstructor.class).singleton(context.componentPostConstructor());
         this.bind(ComponentProvider.class).singleton(this);
         this.bind(ExceptionHandler.class).singleton(this);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentPostConstructor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentPostConstructor.java
@@ -18,18 +18,6 @@ package org.dockbox.hartshorn.component;
 
 import org.dockbox.hartshorn.util.ApplicationException;
 
-@FunctionalInterface
-public interface Enableable {
-
-    default boolean canEnable() {
-        return true;
-    }
-
-    void enable() throws ApplicationException;
-
-    static void enable(final Object object) throws ApplicationException {
-        if (object instanceof Enableable enableable && enableable.canEnable()) {
-            enableable.enable();
-        }
-    }
+public interface ComponentPostConstructor {
+    <T> T doPostConstruct(T type) throws ApplicationException;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentPostConstructorImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentPostConstructorImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.component;
+
+import org.dockbox.hartshorn.application.InitializingContext;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.Result;
+import org.dockbox.hartshorn.util.reflect.MethodContext;
+import org.dockbox.hartshorn.util.reflect.TypeContext;
+
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+
+public class ComponentPostConstructorImpl implements ComponentPostConstructor {
+
+    private final ApplicationContext applicationContext;
+
+    public ComponentPostConstructorImpl(final InitializingContext context) {
+        this.applicationContext = context.applicationContext();
+    }
+
+    @Override
+    public <T> T doPostConstruct(final T type) throws ApplicationException {
+        final TypeContext<T> unproxiedType = TypeContext.unproxy(this.applicationContext, type);
+        final List<MethodContext<?, T>> postConstructMethods = unproxiedType.methods(PostConstruct.class);
+        for (final MethodContext<?, T> postConstructMethod : postConstructMethods) {
+            final Result<?> result = postConstructMethod.invoke(this.applicationContext, type);
+            if (result.caught()) {
+                final Throwable error = result.error();
+                if (error instanceof ApplicationException applicationException) {
+                    throw applicationException;
+                } else {
+                    throw new ApplicationException(error);
+                }
+            }
+        }
+        return type;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentProvider.java
@@ -20,6 +20,7 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.util.reflect.TypeContext;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Named;
 
 /**
@@ -63,10 +64,11 @@ public interface ComponentProvider {
     <T> T get(Key<T> key);
 
     /**
-     * Returns the component for the given key. Unlike {@link #get(Key)}, this method will not run {@link Enableable#enable()}
-     * on the component if {@code enable} is false.
+     * Returns the component for the given key. Unlike {@link #get(Key)}, this method will not run methods
+     * annotated with {@link PostConstruct} if {@code enable} is {@code false}.
+     *
      * @param key The key of the component to return.
-     * @param enable Whether to enable the component if it is an implementation of {@link Enableable}.
+     * @param enable Whether to enable the component if it contains {@link PostConstruct} methods.
      * @param <T> The type of the component to return.
      * @return The component for the given key.
      */

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/FactoryServicePostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/FactoryServicePostProcessor.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.component.factory;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentPopulator;
-import org.dockbox.hartshorn.component.Enableable;
+import org.dockbox.hartshorn.component.ComponentPostConstructor;
 import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.component.processing.ProcessingOrder;
 import org.dockbox.hartshorn.inject.Enable;
@@ -70,10 +70,12 @@ public class FactoryServicePostProcessor extends ServiceAnnotatedMethodIntercept
     }
 
     private <T> T processInstance(final ApplicationContext context, final T instance, final boolean enable) throws ApplicationException {
-        context.get(ComponentPopulator.class).populate(instance);
-
-        if (enable) Enableable.enable(instance);
-        return instance;
+        T out = instance;
+        out = context.get(ComponentPopulator.class).populate(out);
+        if (enable) {
+            out = context.get(ComponentPostConstructor.class).doPostConstruct(out);
+        }
+        return out;
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Enable.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Enable.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.inject;
 
+import org.dockbox.hartshorn.component.ComponentPostConstructor;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
 
 import java.lang.annotation.ElementType;
@@ -24,16 +25,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that the value of a field or method should be enabled through
- * {@link org.dockbox.hartshorn.component.Enableable#enable(Object)}.
+ * Indicates that the value of a field or method should be processed by the specific
+ * {@link ComponentPostConstructor}.
  *
  * <p>If the annotated element is a field, the value of the field will be enabled,
  * if it is not {@code null}.
  *
  * <p>If the annotated element is a method, the behavior is different depending on the
- * responsible {@link ComponentPostProcessor} which
- * handles the method. Typically, this will indicate that the result of the method will
- * be enabled.
+ * responsible {@link ComponentPostProcessor} which handles the method. Typically,
+ * this will indicate that the result of the method will be enabled.
  *
  * <p>If the value of {@link #value()} is {@code true}, the annotated element will be
  * enabled. If the value is {@code false}, the annotated element will be not be enabled

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SingletonEnableable.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SingletonEnableable.java
@@ -16,19 +16,18 @@
 
 package org.dockbox.hartshorn.core.types;
 
-import org.dockbox.hartshorn.component.Enableable;
-
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Singleton;
 
 @Singleton
-public class SingletonEnableable implements Enableable {
+public class SingletonEnableable {
     private int enabled;
 
     public int enabled() {
         return this.enabled;
     }
 
-    @Override
+    @PostConstruct
     public void enable() {
         this.enabled++;
     }

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateDataSourceList.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateDataSourceList.java
@@ -18,17 +18,17 @@ package org.dockbox.hartshorn.data.hibernate;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
-import org.dockbox.hartshorn.component.Enableable;
 import org.dockbox.hartshorn.data.remote.DataSourceConfiguration;
 import org.dockbox.hartshorn.data.remote.RefreshableDataSourceList;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
 @Component(singleton = true)
-public class HibernateDataSourceList implements RefreshableDataSourceList, Enableable {
+public class HibernateDataSourceList implements RefreshableDataSourceList {
 
     @Inject
     private HibernateDataSourceConfigurationObject sources;
@@ -56,7 +56,7 @@ public class HibernateDataSourceList implements RefreshableDataSourceList, Enabl
         return this.get("default");
     }
 
-    @Override
+    @PostConstruct
     public void enable() {
         this.configurations.clear();
         this.configurations.putAll(this.sources.sources());

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
@@ -18,7 +18,6 @@ package org.dockbox.hartshorn.data.hibernate;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
-import org.dockbox.hartshorn.component.Enableable;
 import org.dockbox.hartshorn.data.jpa.EntityManagerCarrier;
 import org.dockbox.hartshorn.data.jpa.EntityManagerJpaRepository;
 import org.dockbox.hartshorn.data.remote.DataSourceConfiguration;
@@ -29,11 +28,12 @@ import org.dockbox.hartshorn.util.ApplicationException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 
 @Component
-public class HibernateJpaRepository<T, ID> extends EntityManagerJpaRepository<T, ID> implements Enableable {
+public class HibernateJpaRepository<T, ID> extends EntityManagerJpaRepository<T, ID> {
 
     private final DataSourceConfiguration connection;
 
@@ -84,16 +84,11 @@ public class HibernateJpaRepository<T, ID> extends EntityManagerJpaRepository<T,
         return this.manager().beginTransaction();
     }
 
-    @Override
-    public boolean canEnable() {
+    @PostConstruct
+    public void enable() throws ApplicationException {
         if (this.connection != null && this.entityManager.configuration() == null) {
             this.entityManager.configuration(this.connection);
         }
-        return this.entityManager.canEnable();
-    }
-
-    @Override
-    public void enable() throws ApplicationException {
         this.entityManager.enable();
     }
 }

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SqlServiceTest.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SqlServiceTest.java
@@ -21,17 +21,17 @@ import com.mysql.cj.jdbc.Driver;
 
 import org.apache.derby.jdbc.EmbeddedDriver;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.component.Enableable;
+import org.dockbox.hartshorn.component.ComponentPostConstructor;
 import org.dockbox.hartshorn.data.annotations.UseConfigurations;
 import org.dockbox.hartshorn.data.annotations.UsePersistence;
 import org.dockbox.hartshorn.data.config.PropertyHolder;
+import org.dockbox.hartshorn.data.hibernate.HibernateDataSourceConfiguration;
 import org.dockbox.hartshorn.data.hibernate.HibernateJpaRepository;
 import org.dockbox.hartshorn.data.jpa.EntityManagerCarrier;
 import org.dockbox.hartshorn.data.jpa.EntityManagerJpaRepository;
 import org.dockbox.hartshorn.data.jpa.JpaRepository;
 import org.dockbox.hartshorn.data.remote.DataSourceConfiguration;
 import org.dockbox.hartshorn.data.remote.DataSourceList;
-import org.dockbox.hartshorn.data.hibernate.HibernateDataSourceConfiguration;
 import org.dockbox.hartshorn.data.remote.RefreshableDataSourceList;
 import org.dockbox.hartshorn.data.service.JpaRepositoryFactory;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
@@ -216,7 +216,6 @@ class SqlServiceTest {
 
         final PropertyHolder propertyHolder = this.applicationContext.get(PropertyHolder.class);
 
-
         // Data API specific
         propertyHolder.set("hartshorn.data.sources.default.username", mySql.getUsername());
         propertyHolder.set("hartshorn.data.sources.default.password", mySql.getPassword());
@@ -233,12 +232,14 @@ class SqlServiceTest {
             refreshable.refresh();
         }
 
-        ((Enableable) repository).enable();
+        final ComponentPostConstructor componentPostConstructor = applicationContext.get(ComponentPostConstructor.class);
+        componentPostConstructor.doPostConstruct(repository);
 
-        final Session session = ((HibernateJpaRepository<User, ?>) repository).manager();
+        final HibernateJpaRepository<User, ?> jpaRepository = (HibernateJpaRepository<User, ?>) repository;
+        final Session session = jpaRepository.manager();
         Assertions.assertNotNull(session);
 
-        ((HibernateJpaRepository<User, ?>) repository).close();
+        jpaRepository.close();
     }
 
     @Test

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
@@ -16,27 +16,27 @@
 
 package org.dockbox.hartshorn.web;
 
-import org.dockbox.hartshorn.component.Enableable;
-import org.dockbox.hartshorn.inject.binding.Bound;
 import org.dockbox.hartshorn.application.Hartshorn;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.util.reflect.MethodContext;
-import org.dockbox.hartshorn.util.Result;
-import org.dockbox.hartshorn.util.ApplicationException;
-import org.dockbox.hartshorn.util.parameter.ParameterLoader;
 import org.dockbox.hartshorn.data.annotations.Value;
 import org.dockbox.hartshorn.data.mapping.ObjectMapper;
+import org.dockbox.hartshorn.inject.binding.Bound;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.Result;
+import org.dockbox.hartshorn.util.parameter.ParameterLoader;
+import org.dockbox.hartshorn.util.reflect.MethodContext;
 import org.dockbox.hartshorn.web.annotations.http.HttpRequest;
 import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 
 import java.io.IOException;
 import java.util.List;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-public class ServletHandler implements Enableable {
+public class ServletHandler {
 
     private final HttpWebServer starter;
     private final HttpMethod httpMethod;
@@ -65,7 +65,7 @@ public class ServletHandler implements Enableable {
         return this.mapper;
     }
 
-    @Override
+    @PostConstruct
     public void enable() throws ApplicationException {
         final MediaType mediaType = this.httpRequest.produces();
         if (!mediaType.isSerializable()) throw new ApplicationException("Provided media type '" + mediaType.value() + "' is not serializable");


### PR DESCRIPTION
# Description
Originally, `Enableable` was added as a simple way to allow actions to be performed after injection was performed, but before the component was put in use. However, this could be simplified (and streamlined) by supporting the `@PostConstruct` annotation instead.

This PR implements these changes to replace `Enableable` with `@PostConstruct` support. Instead of deprecating `Enableable`, it was removed as it was only used in very few places, and known third-party usages are currently not commonly using this.

Fixes #799

## Type of change
- [x] New feature (non-breaking change that does affect the code)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
