### PR TITLE
#804 Condition matching for event listeners

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,6 @@ allprojects {
             resolutionStrategy.dependencySubstitution {
                 rootDir.listFiles()?.forEach {
                     if (it.isDirectory && File(it, "${it.name}.gradle.kts").exists()) {
-                        println("Substituting org.dockbox.hartshorn:${it.name} for ${it.name}")
                         substitute(module("org.dockbox.hartshorn:${it.name}"))
                             .using(project(":${it.name}"))
                     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ProvidedParameterContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ProvidedParameterContext.java
@@ -1,0 +1,42 @@
+package org.dockbox.hartshorn.component.condition;
+
+import org.dockbox.hartshorn.context.DefaultContext;
+import org.dockbox.hartshorn.util.reflect.ExecutableElementContext;
+import org.dockbox.hartshorn.util.reflect.ParameterContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ProvidedParameterContext extends DefaultContext {
+
+    private final Map<ParameterContext<?>, Object> arguments = new ConcurrentHashMap<>();
+
+    private ProvidedParameterContext(final Map<ParameterContext<?>, Object> arguments) {
+        this.arguments.putAll(arguments);
+    }
+
+    public static ProvidedParameterContext of(final Map<ParameterContext<?>, Object> arguments) {
+        return new ProvidedParameterContext(arguments);
+    }
+
+    public static ProvidedParameterContext of(final List<ParameterContext<?>> parameters, final List<Object> arguments) {
+        if (parameters.size() != arguments.size()) {
+            throw new IllegalArgumentException("Parameters and arguments must be of the same size");
+        }
+        final Map<ParameterContext<?>, Object> argumentMap = IntStream.range(0, parameters.size()).boxed()
+                .collect(Collectors.toMap(parameters::get, arguments::get, (a, b) -> b, ConcurrentHashMap::new));
+
+        return new ProvidedParameterContext(argumentMap);
+    }
+
+    public static ProvidedParameterContext of(final ExecutableElementContext<?, ?> executable, final List<Object> arguments) {
+        return of(executable.parameters(), arguments);
+    }
+
+    public Map<ParameterContext<?>, Object> arguments() {
+        return arguments;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ProvidedParameterContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ProvidedParameterContext.java
@@ -53,6 +53,6 @@ public class ProvidedParameterContext extends DefaultContext {
     }
 
     public Map<ParameterContext<?>, Object> arguments() {
-        return arguments;
+        return this.arguments;
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ProvidedParameterContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ProvidedParameterContext.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.component.condition;
 
 import org.dockbox.hartshorn.context.DefaultContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ConcurrentHashSingletonCache.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ConcurrentHashSingletonCache.java
@@ -32,7 +32,7 @@ public class ConcurrentHashSingletonCache implements SingletonCache {
 
     @Override
     public <T> T get(final Key<T> key) {
-        return (T) this.cache.get(key);
+        return key.type().cast(this.cache.get(key));
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/Parameter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/Parameter.java
@@ -1,0 +1,12 @@
+package org.dockbox.hartshorn.util.reflect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Parameter {
+    String value();
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/Parameter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/Parameter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.util.reflect;
 
 import java.lang.annotation.ElementType;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/ParameterContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/ParameterContext.java
@@ -54,7 +54,11 @@ public final class ParameterContext<T> extends AnnotatedElementContext<Parameter
     @Override
     public String name() {
         if (this.name == null) {
-            this.name = this.element().getName();
+            if (this.annotation(org.dockbox.hartshorn.util.reflect.Parameter.class).present()) {
+                this.name = this.annotation(org.dockbox.hartshorn.util.reflect.Parameter.class).get().value();
+            } else {
+                this.name = this.parameter.getName();
+            }
         }
         return this.name;
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/TypeContext.java
@@ -702,4 +702,9 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
     public boolean isInstance(final Object object) {
         return this.type().isInstance(object);
     }
+
+    public T cast(final Object object) {
+        if (isInstance(object)) return this.type.cast(object);
+        else throw new ClassCastException("Cannot cast '%s' to '%s'".formatted(object, this.type));
+    }
 }

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBus.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBus.java
@@ -16,13 +16,11 @@
 
 package org.dockbox.hartshorn.events;
 
-import org.dockbox.hartshorn.inject.Key;
-import org.dockbox.hartshorn.util.reflect.MethodContext;
-import org.dockbox.hartshorn.util.Result;
 import org.dockbox.hartshorn.events.parents.Event;
+import org.dockbox.hartshorn.inject.Key;
+import org.dockbox.hartshorn.util.Result;
+import org.dockbox.hartshorn.util.reflect.MethodContext;
 
-import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 public interface EventBus {
@@ -34,8 +32,6 @@ public interface EventBus {
     void post(Event event, Key<?> target);
 
     void post(Event event);
-
-    Map<Key<?>, Set<EventWrapper>> invokers();
 
     void addValidationRule(Function<MethodContext<?, ?>, Result<Boolean>> validator);
 }

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.events;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.events.annotations.Listener;
@@ -131,12 +130,6 @@ public class EventBusImpl implements EventBus {
     @Override
     public void post(final Event event) {
         this.post(event, null);
-    }
-
-    @NonNull
-    @Override
-    public Map<Key<?>, Set<EventWrapper>> invokers() {
-        return this.listenerToInvokers;
     }
 
     @Override

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterBeanListener.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterBeanListener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.events;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterBeanListener.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterBeanListener.java
@@ -1,0 +1,24 @@
+package org.dockbox.hartshorn.events;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.beans.BeanContext;
+import org.dockbox.hartshorn.beans.BeanObserver;
+import org.dockbox.hartshorn.component.Service;
+import org.dockbox.hartshorn.component.condition.RequiresActivator;
+import org.dockbox.hartshorn.events.annotations.UseEvents;
+import org.dockbox.hartshorn.events.handle.EventExecutionFilter;
+import org.dockbox.hartshorn.util.reflect.TypeContext;
+
+
+@Service
+@RequiresActivator(UseEvents.class)
+public class EventExecutionFilterBeanListener implements BeanObserver {
+
+    @Override
+    public void onBeansCollected(final ApplicationContext applicationContext, final BeanContext beanContext) {
+        beanContext.provider().all(EventExecutionFilter.class).forEach(filter -> {
+            applicationContext.log().debug("Adding filter " + TypeContext.of(filter).name() + " to event context");
+            applicationContext.first(EventExecutionFilterContext.class).get().add(filter);
+        });
+    }
+}

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterContext.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterContext.java
@@ -1,0 +1,35 @@
+package org.dockbox.hartshorn.events;
+
+import org.dockbox.hartshorn.context.AutoCreating;
+import org.dockbox.hartshorn.context.DefaultContext;
+import org.dockbox.hartshorn.events.handle.EventExecutionFilter;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@AutoCreating
+public class EventExecutionFilterContext extends DefaultContext {
+
+    private final Set<EventExecutionFilter> executionFilters = ConcurrentHashMap.newKeySet();
+
+    public boolean contains(final EventExecutionFilter o) {
+        return executionFilters.contains(o);
+    }
+
+    public boolean add(final EventExecutionFilter eventExecutionFilter) {
+        return executionFilters.add(eventExecutionFilter);
+    }
+
+    public boolean remove(final EventExecutionFilter o) {
+        return executionFilters.remove(o);
+    }
+
+    public boolean addAll(final Collection<? extends EventExecutionFilter> c) {
+        return executionFilters.addAll(c);
+    }
+
+    public Set<EventExecutionFilter> filters() {
+        return Set.copyOf(this.executionFilters);
+    }
+}

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterContext.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterContext.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.events;
 
 import org.dockbox.hartshorn.context.AutoCreating;

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventProviders.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventProviders.java
@@ -16,9 +16,12 @@
 
 package org.dockbox.hartshorn.events;
 
+import org.dockbox.hartshorn.beans.Bean;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.processing.Provider;
 import org.dockbox.hartshorn.component.Service;
+import org.dockbox.hartshorn.events.handle.ConditionMatcherEventExecutionFilter;
+import org.dockbox.hartshorn.events.handle.EventExecutionFilter;
 import org.dockbox.hartshorn.util.parameter.ParameterLoader;
 import org.dockbox.hartshorn.events.annotations.UseEvents;
 import org.dockbox.hartshorn.events.handle.EventParameterLoader;
@@ -38,5 +41,10 @@ public class EventProviders {
     @Provider("event_loader")
     public ParameterLoader eventParameterLoader() {
         return new EventParameterLoader();
+    }
+
+    @Bean
+    public static EventExecutionFilter conditionMatchingExecutionFilter() {
+        return new ConditionMatcherEventExecutionFilter();
     }
 }

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/ConditionMatcherEventExecutionFilter.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/ConditionMatcherEventExecutionFilter.java
@@ -24,6 +24,13 @@ public class ConditionMatcherEventExecutionFilter extends DefaultContext impleme
 
     private Context[] matcherContexts(final Event event, final EventWrapper wrapper) {
         final Set<Context> contexts = new HashSet<>(this.contexts);
+        if (this.first(ProvidedParameterContext.class).absent()) {
+            if (wrapper.method().parameterCount() != 1) {
+                throw new IllegalArgumentException("Method " + wrapper.method() + " has " + wrapper.method().parameterCount() + " parameters, but only one is allowed");
+            }
+            final ProvidedParameterContext parameterContext = ProvidedParameterContext.of(wrapper.method(), Collections.singletonList(event));
+            contexts.add(parameterContext);
+        }
         return contexts.toArray(new Context[0]);
     }
 }

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/ConditionMatcherEventExecutionFilter.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/ConditionMatcherEventExecutionFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.events.handle;
 
 import org.dockbox.hartshorn.component.Component;

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/ConditionMatcherEventExecutionFilter.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/ConditionMatcherEventExecutionFilter.java
@@ -1,0 +1,29 @@
+package org.dockbox.hartshorn.events.handle;
+
+import org.dockbox.hartshorn.component.Component;
+import org.dockbox.hartshorn.component.condition.ConditionMatcher;
+import org.dockbox.hartshorn.component.condition.ProvidedParameterContext;
+import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.context.DefaultContext;
+import org.dockbox.hartshorn.events.EventWrapper;
+import org.dockbox.hartshorn.events.parents.Event;
+import org.dockbox.hartshorn.inject.Key;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@Component
+public class ConditionMatcherEventExecutionFilter extends DefaultContext implements EventExecutionFilter {
+
+    @Override
+    public boolean accept(final Event event, final EventWrapper wrapper, final Key<?> target) {
+        final ConditionMatcher matcher = event.applicationContext().get(ConditionMatcher.class);
+        return matcher.match(wrapper.method(), this.matcherContexts(event, wrapper));
+    }
+
+    private Context[] matcherContexts(final Event event, final EventWrapper wrapper) {
+        final Set<Context> contexts = new HashSet<>(this.contexts);
+        return contexts.toArray(new Context[0]);
+    }
+}

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventExecutionFilter.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventExecutionFilter.java
@@ -1,0 +1,9 @@
+package org.dockbox.hartshorn.events.handle;
+
+import org.dockbox.hartshorn.events.EventWrapper;
+import org.dockbox.hartshorn.events.parents.Event;
+import org.dockbox.hartshorn.inject.Key;
+
+public interface EventExecutionFilter {
+    boolean accept(Event event, EventWrapper wrapper, Key<?> target);
+}

--- a/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/EventBusTests.java
+++ b/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/EventBusTests.java
@@ -41,60 +41,54 @@ import jakarta.inject.Inject;
 public class EventBusTests {
 
     @Inject
-    private EventBusImpl eventBus;
+    private TestEventBus bus;
     
     @Test
     public void testTypesCanSubscribe() {
-        final EventBus bus = this.eventBus;
-        bus.subscribe(Key.of(BasicEventListener.class));
-        Assertions.assertTrue(bus.invokers().containsKey(Key.of(BasicEventListener.class)));
+        this.bus.subscribe(Key.of(BasicEventListener.class));
+        Assertions.assertTrue(this.bus.invokers().containsKey(Key.of(BasicEventListener.class)));
     }
 
     @Test
     public void testNonStaticMethodsCanListen() {
-        final EventBus bus = this.eventBus;
-        bus.subscribe(Key.of(BasicEventListener.class));
-        bus.post(new SampleEvent());
+        this.bus.subscribe(Key.of(BasicEventListener.class));
+        this.bus.post(new SampleEvent());
         Assertions.assertTrue(BasicEventListener.fired);
     }
 
     @Test
     public void testStaticMethodsCanListen() {
-        final EventBus bus = this.eventBus;
-        bus.subscribe(Key.of(StaticEventListener.class));
-        bus.post(new SampleEvent());
+        this.bus.subscribe(Key.of(StaticEventListener.class));
+        this.bus.post(new SampleEvent());
         Assertions.assertTrue(StaticEventListener.fired);
     }
 
     @Test
     public void testEventsArePostedInCorrectPriorityOrder() {
-        final EventBus bus = this.eventBus;
-        bus.subscribe(Key.of(PriorityEventListener.class));
-        bus.post(new SampleEvent());
+        this.bus.subscribe(Key.of(PriorityEventListener.class));
+        this.bus.post(new SampleEvent());
         Assertions.assertEquals(Priority.LAST, PriorityEventListener.last());
     }
 
     @Test
     void testGenericEventsAreFiltered() {
-        final EventBus bus = this.eventBus;
-        bus.subscribe(Key.of(GenericEventListener.class));
+        this.bus.subscribe(Key.of(GenericEventListener.class));
         final Event event = new GenericEvent<>("String") {
         };
-        Assertions.assertDoesNotThrow(() -> bus.post(event));
+        Assertions.assertDoesNotThrow(() -> this.bus.post(event));
     }
 
     @Test
     void testGenericWildcardsArePosted() {
-        final EventBus bus = this.eventBus;
         // Ensure the values have not been affected by previous tests
         GenericEventListener.objects.clear();
-        bus.subscribe(Key.of(GenericEventListener.class));
+        this.bus.subscribe(Key.of(GenericEventListener.class));
         final Event stringEvent = new GenericEvent<>("String") {
         };
         final Event integerEvent = new GenericEvent<>(1) {
         };
-        bus.post(stringEvent);
-        bus.post(integerEvent);
+        this.bus.post(stringEvent);
+        this.bus.post(integerEvent);
         final List<Object> objects = List.copyOf(GenericEventListener.objects);
         Assertions.assertEquals(2, objects.size());
         Assertions.assertEquals("String", objects.get(0));
@@ -103,21 +97,19 @@ public class EventBusTests {
 
     @Test
     void testConditionEventIsNotFiredIfMismatch() {
-        final EventBus bus = this.eventBus;
-        bus.subscribe(Key.of(ConditionalEventListener.class));
+        this.bus.subscribe(Key.of(ConditionalEventListener.class));
 
-        final SampleNamedEvent nullNameEvent = new SampleNamedEvent(null);
-        bus.post(nullNameEvent);
+        final Event nullNameEvent = new SampleNamedEvent(null);
+        this.bus.post(nullNameEvent);
         Assertions.assertFalse(ConditionalEventListener.fired);
     }
 
     @Test
     void testConditionEventIsFiredIfMatch() {
-        final EventBus bus = this.eventBus;
-        bus.subscribe(Key.of(ConditionalEventListener.class));
+        this.bus.subscribe(Key.of(ConditionalEventListener.class));
 
-        final SampleNamedEvent nameEvent = new SampleNamedEvent("name");
-        bus.post(nameEvent);
+        final Event nameEvent = new SampleNamedEvent("name");
+        this.bus.post(nameEvent);
         Assertions.assertTrue(ConditionalEventListener.fired);
     }
 

--- a/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/SampleNamedEvent.java
+++ b/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/SampleNamedEvent.java
@@ -14,12 +14,21 @@
  * limitations under the License.
  */
 
-apply { 
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.events;
 
-dependencies {
-    api("org.dockbox.hartshorn:hartshorn-core")
-    // For expression evaluation
-    testImplementation("org.dockbox.hartshorn:hartshorn-hsl")
+import org.dockbox.hartshorn.events.parents.ContextCarrierEvent;
+import org.dockbox.hartshorn.util.Named;
+
+public class SampleNamedEvent extends ContextCarrierEvent implements Named {
+
+    private final String name;
+
+    public SampleNamedEvent(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String name() {
+        return this.name;
+    }
 }

--- a/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/TestEventBus.java
+++ b/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/TestEventBus.java
@@ -17,11 +17,13 @@
 package org.dockbox.hartshorn.events;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.inject.Key;
 
 import java.util.Map;
 import java.util.Set;
 
+@Component(singleton = true)
 public class TestEventBus extends EventBusImpl {
 
     public @NonNull Map<Key<?>, Set<EventWrapper>> invokers() {

--- a/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/TestEventBus.java
+++ b/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/TestEventBus.java
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
-package org.dockbox.hartshorn.events.handle;
+package org.dockbox.hartshorn.events;
 
-import org.dockbox.hartshorn.events.EventWrapper;
-import org.dockbox.hartshorn.events.parents.Event;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.inject.Key;
 
-public interface EventExecutionFilter {
-    boolean accept(Event event, EventWrapper wrapper, Key<?> target);
+import java.util.Map;
+import java.util.Set;
+
+public class TestEventBus extends EventBusImpl {
+
+    @Override
+    public @NonNull Map<Key<?>, Set<EventWrapper>> invokers() {
+        return this.listenerToInvokers;
+    }
 }

--- a/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/TestEventBus.java
+++ b/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/TestEventBus.java
@@ -24,7 +24,6 @@ import java.util.Set;
 
 public class TestEventBus extends EventBusImpl {
 
-    @Override
     public @NonNull Map<Key<?>, Set<EventWrapper>> invokers() {
         return this.listenerToInvokers;
     }

--- a/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/listeners/ConditionalEventListener.java
+++ b/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/listeners/ConditionalEventListener.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.events.listeners;
+
+import org.dockbox.hartshorn.component.Service;
+import org.dockbox.hartshorn.events.SampleNamedEvent;
+import org.dockbox.hartshorn.events.annotations.Listener;
+import org.dockbox.hartshorn.hsl.condition.RequiresExpression;
+
+@Service
+public class ConditionalEventListener {
+
+    public static boolean fired;
+
+    @Listener
+    @RequiresExpression("event.name() != null")
+    public void on(final SampleNamedEvent event) {
+        if (event.name() == null) {
+            throw new IllegalArgumentException("Event name is null");
+        }
+        ConditionalEventListener.fired = true;
+    }
+}

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ExpressionCondition.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ExpressionCondition.java
@@ -20,6 +20,7 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.condition.Condition;
 import org.dockbox.hartshorn.component.condition.ConditionContext;
 import org.dockbox.hartshorn.component.condition.ConditionResult;
+import org.dockbox.hartshorn.component.condition.ProvidedParameterContext;
 import org.dockbox.hartshorn.hsl.ScriptEvaluationError;
 import org.dockbox.hartshorn.hsl.customizer.ScriptContext;
 import org.dockbox.hartshorn.hsl.runtime.ScriptRuntime;
@@ -70,6 +71,11 @@ public class ExpressionCondition implements Condition {
     }
 
     protected ValidateExpressionRuntime enhance(final ValidateExpressionRuntime runtime, final ConditionContext context) {
+        // Load parameters first, so they can be overwritten by the customizers and imports.
+        context.first(ProvidedParameterContext.class).present(parameterContext -> {
+            parameterContext.arguments().forEach((parameter, value) -> runtime.global(parameter.name(), value));
+        });
+
         context.first(ExpressionConditionContext.class).present(expressionContext -> {
 
             runtime.customizers(expressionContext.customizers());


### PR DESCRIPTION
# Description
Recently we added support for condition matching on annotated elements. This is currently used to allow filtering of active components and providers. However, this is not yet supported in event listeners.

This PR adds support for condition matching in event listeners. Additionally, it adds the `ProvidedParameterContext`, to allow provided parameters to be provided to other validators like condition matchers.

Fixes #804

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
