### PR TITLE
#812 Verify JVM language compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,28 @@
 # Generic build outputs
 build
 subject
+lib
+out
+hartshorn-assembly/publications
+*/generated
+
 # Project specifics
 .gradle/
 .idea/
 *.iml
 *.hprof
 dependency-reduced-pom.xml
+
 # Generated directories
 servers
 hartshorn-assembly/distributions
+
 # Test resources
 module/src/test/resources/storage.db-journal
 */.mixin.out
 */testRuns
 */logs
 *.log
+
+# Miscellaneous
 .jpb
-hartshorn-assembly/publications
-*/generated

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,13 @@ allprojects {
     license {
         header.set(resources.text.fromFile(rootProject.file("HEADER.txt")))
         ignoreFailures.set(false)
-        include("**/*.java")
+        include(
+                "**/*.java",
+                "**/*.kt",
+                "**/*.yml",
+                "**/*.properties",
+                "**/*.toml",
+        )
     }
 
     java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,7 @@ allprojects {
         include(
                 "**/*.java",
                 "**/*.kt",
+                "**/*.scala",
                 "**/*.yml",
                 "**/*.properties",
                 "**/*.toml",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,7 @@ allprojects {
         include(
                 "**/*.java",
                 "**/*.kt",
+                "**/*.groovy",
                 "**/*.scala",
                 "**/*.yml",
                 "**/*.properties",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,8 @@ mssql = "11.2.0.jre17"
 mysql = "8.0.30"
 postgresql = "42.5.0"
 reflections = "0.10.2"
-slf4j = "2.0.0"
+scala = "2.13.8"
+slf4j = "1.7.36"
 test-containers = "1.17.3"
 woodstox = "4.4.1"
 
@@ -109,6 +110,7 @@ mssql = { module = "com.microsoft.sqlserver:mssql-jdbc", version.ref = "mssql" }
 mysql = { module = "mysql:mysql-connector-java", version.ref = "mysql" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 reflections = { module = "org.reflections:reflections", version.ref = "reflections" }
+scala = { module = "org.scala-lang:scala-library", version.ref = "scala" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 woodstox = { module = "org.codehaus.woodstox:woodstox-core-asl", version.ref = "woodstox" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ caffeine = "3.1.1"
 cglib = "3.3.0"
 derby = "10.16.1.1"
 freemarker = "2.3.31"
+groovy = "4.0.2"
 hamcrest = "2.2"
 hibernate = "6.1.2.Final"
 httpclient = "4.5.13"
@@ -99,6 +100,7 @@ cglib = { module = "cglib:cglib", version.ref = "cglib" }
 derby = { module = "org.apache.derby:derby", version.ref = "derby" }
 derby-tools = { module = "org.apache.derby:derbytools", version.ref = "derby" }
 freemarker = { module = "org.freemarker:freemarker", version.ref = "freemarker" }
+groovy = { module = "org.apache.groovy:groovy-all", version.ref = "groovy" }
 hamcrest = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }
 hibernate-core = { module = "org.hibernate:hibernate-core", version.ref = "hibernate" }
 httpclient = { module = "org.apache.httpcomponents:httpclient", version.ref = "httpclient" }

--- a/hartshorn-core/src/test/groovy/org/dockbox/hartshorn/core/groovy/GroovyClassComponent.groovy
+++ b/hartshorn-core/src/test/groovy/org/dockbox/hartshorn/core/groovy/GroovyClassComponent.groovy
@@ -14,24 +14,10 @@
  * limitations under the License.
  */
 
-apply {
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.core.groovy
 
-plugins {
-    kotlin("jvm") version "1.7.10"
-    scala
-    groovy
-}
+import org.dockbox.hartshorn.component.Component
 
-dependencies {
-    api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
-
-    implementation(libs.reflections)
-    implementation(libs.logback)
-
-    testImplementation(libs.scala)
-    testImplementation(libs.groovy)
+@Component
+class GroovyClassComponent {
 }

--- a/hartshorn-core/src/test/groovy/org/dockbox/hartshorn/core/groovy/GroovyComponentTests.groovy
+++ b/hartshorn-core/src/test/groovy/org/dockbox/hartshorn/core/groovy/GroovyComponentTests.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.core.groovy
+
+import jakarta.inject.Inject
+import org.dockbox.hartshorn.application.context.ApplicationContext
+import org.dockbox.hartshorn.component.ComponentLocator
+import org.dockbox.hartshorn.testsuite.HartshornTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+import java.util.stream.Stream
+
+/**
+ * Tests compatibility with Groovy classes, traits and interfaces.
+ * This is similar to the tests seen in {@code KotlinComponentTests} and {@code ScalaComponentsTests}.
+ * Instead of using a common test class for all three languages, each language has its own test class.
+ * This is done to provide a simple example of how to use Hartshorn's Test Suite with each language.
+ *
+ * @author Guus Lieben
+ * @since 22.5
+ */
+@HartshornTest
+class GroovyComponentTests {
+
+    @Inject
+    private ApplicationContext applicationContext
+
+    @Inject
+    private ComponentLocator componentLocator
+
+    @ParameterizedTest
+    @MethodSource("components")
+    <T> void testComponent(Class<T> componentType) {
+        def component = this.applicationContext.get(componentType)
+        Assertions.assertNotNull(component)
+
+        def container = this.componentLocator.container(componentType)
+        Assertions.assertNotNull(container)
+        Assertions.assertTrue(container.present())
+    }
+
+    static Stream<Arguments> components() {
+        return Stream.of(
+                Arguments.of(GroovyInterfaceComponent.class),
+                Arguments.of(GroovyTraitComponent.class),
+                Arguments.of(GroovyClassComponent.class),
+        )
+    }
+}

--- a/hartshorn-core/src/test/groovy/org/dockbox/hartshorn/core/groovy/GroovyInterfaceComponent.groovy
+++ b/hartshorn-core/src/test/groovy/org/dockbox/hartshorn/core/groovy/GroovyInterfaceComponent.groovy
@@ -14,24 +14,10 @@
  * limitations under the License.
  */
 
-apply {
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.core.groovy
 
-plugins {
-    kotlin("jvm") version "1.7.10"
-    scala
-    groovy
-}
+import org.dockbox.hartshorn.component.Component
 
-dependencies {
-    api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
-
-    implementation(libs.reflections)
-    implementation(libs.logback)
-
-    testImplementation(libs.scala)
-    testImplementation(libs.groovy)
+@Component
+interface GroovyInterfaceComponent {
 }

--- a/hartshorn-core/src/test/groovy/org/dockbox/hartshorn/core/groovy/GroovyTraitComponent.groovy
+++ b/hartshorn-core/src/test/groovy/org/dockbox/hartshorn/core/groovy/GroovyTraitComponent.groovy
@@ -14,24 +14,10 @@
  * limitations under the License.
  */
 
-apply {
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.core.groovy
 
-plugins {
-    kotlin("jvm") version "1.7.10"
-    scala
-    groovy
-}
+import org.dockbox.hartshorn.component.Component
 
-dependencies {
-    api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
-
-    implementation(libs.reflections)
-    implementation(libs.logback)
-
-    testImplementation(libs.scala)
-    testImplementation(libs.groovy)
+@Component
+trait GroovyTraitComponent {
 }

--- a/hartshorn-core/src/test/kotlin/org/dockbox/hartshorn/core/KotlinClassComponent.kt
+++ b/hartshorn-core/src/test/kotlin/org/dockbox/hartshorn/core/KotlinClassComponent.kt
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
-apply {
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.kotlin
 
-plugins {
-    kotlin("jvm") version "1.7.10"
-}
+import org.dockbox.hartshorn.component.Component
 
-dependencies {
-    api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
-
-    implementation(libs.reflections)
-    implementation(libs.logback)
-}
+@Component
+class KotlinClassComponent

--- a/hartshorn-core/src/test/kotlin/org/dockbox/hartshorn/core/KotlinComponentTests.kt
+++ b/hartshorn-core/src/test/kotlin/org/dockbox/hartshorn/core/KotlinComponentTests.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.core
+
+import jakarta.inject.Inject
+import org.dockbox.hartshorn.application.context.ApplicationContext
+import org.dockbox.hartshorn.component.ComponentLocator
+import org.dockbox.hartshorn.kotlin.KotlinClassComponent
+import org.dockbox.hartshorn.kotlin.KotlinInterfaceComponent
+import org.dockbox.hartshorn.kotlin.KotlinObjectComponent
+import org.dockbox.hartshorn.kotlin.KotlinSealedInterfaceComponent
+import org.dockbox.hartshorn.testsuite.HartshornTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+/**
+ * Tests compatibility with Kotlin classes, interfaces, objects and sealed interfaces.
+ * This is similar to the tests seen in {@code GroovyComponentTests} and {@code ScalaComponentsTests}.
+ * Instead of using a common test class for all three languages, each language has its own test class.
+ * This is done to provide a simple example of how to use Hartshorn's Test Suite with each language.
+ *
+ * @author Guus Lieben
+ * @since 22.5
+ */
+@HartshornTest
+class KotlinComponentTests {
+
+    @Inject
+    private lateinit var applicationContext: ApplicationContext
+
+    @Inject
+    private lateinit var componentLocator: ComponentLocator
+
+    @ParameterizedTest
+    @MethodSource("components")
+    fun <T> testComponent(componentType: Class<T>) {
+        val component: T = this.applicationContext.get(componentType)
+        Assertions.assertNotNull(component)
+
+        val container = this.componentLocator.container(componentType)
+        Assertions.assertNotNull(container)
+        Assertions.assertTrue(container.present())
+    }
+
+    companion object {
+        @JvmStatic
+        fun components(): Stream<Arguments> = Stream.of(
+                Arguments.of(KotlinClassComponent::class.java),
+                Arguments.of(KotlinInterfaceComponent::class.java),
+                Arguments.of(KotlinObjectComponent::class.java),
+                Arguments.of(KotlinSealedInterfaceComponent::class.java),
+        )
+    }
+}

--- a/hartshorn-core/src/test/kotlin/org/dockbox/hartshorn/core/KotlinInterfaceComponent.kt
+++ b/hartshorn-core/src/test/kotlin/org/dockbox/hartshorn/core/KotlinInterfaceComponent.kt
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
-apply {
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.kotlin
 
-plugins {
-    kotlin("jvm") version "1.7.10"
-}
+import org.dockbox.hartshorn.component.Component
 
-dependencies {
-    api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
-
-    implementation(libs.reflections)
-    implementation(libs.logback)
-}
+@Component
+interface KotlinInterfaceComponent

--- a/hartshorn-core/src/test/kotlin/org/dockbox/hartshorn/core/KotlinObjectComponent.kt
+++ b/hartshorn-core/src/test/kotlin/org/dockbox/hartshorn/core/KotlinObjectComponent.kt
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
-apply {
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.kotlin
 
-plugins {
-    kotlin("jvm") version "1.7.10"
-}
+import org.dockbox.hartshorn.component.Component
 
-dependencies {
-    api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
-
-    implementation(libs.reflections)
-    implementation(libs.logback)
-}
+@Component
+object KotlinObjectComponent

--- a/hartshorn-core/src/test/kotlin/org/dockbox/hartshorn/core/KotlinSealedInterfaceComponent.kt
+++ b/hartshorn-core/src/test/kotlin/org/dockbox/hartshorn/core/KotlinSealedInterfaceComponent.kt
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
-apply {
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.kotlin
 
-plugins {
-    kotlin("jvm") version "1.7.10"
-}
+import org.dockbox.hartshorn.component.Component
 
-dependencies {
-    api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
-
-    implementation(libs.reflections)
-    implementation(libs.logback)
-}
+@Component
+sealed interface KotlinSealedInterfaceComponent

--- a/hartshorn-core/src/test/scala/org/dockbox/hartshorn/core/scala/ScalaCaseClassComponent.scala
+++ b/hartshorn-core/src/test/scala/org/dockbox/hartshorn/core/scala/ScalaCaseClassComponent.scala
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-apply {
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.core.scala
 
-plugins {
-    kotlin("jvm") version "1.7.10"
-    scala
-}
+import org.dockbox.hartshorn.component.Component
 
-dependencies {
-    api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
-
-    implementation(libs.reflections)
-    implementation(libs.logback)
-
-    testImplementation(libs.scala)
-}
+@Component
+case class ScalaCaseClassComponent()

--- a/hartshorn-core/src/test/scala/org/dockbox/hartshorn/core/scala/ScalaClassComponent.scala
+++ b/hartshorn-core/src/test/scala/org/dockbox/hartshorn/core/scala/ScalaClassComponent.scala
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-apply {
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.core.scala
 
-plugins {
-    kotlin("jvm") version "1.7.10"
-    scala
-}
+import org.dockbox.hartshorn.component.Component
 
-dependencies {
-    api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
-
-    implementation(libs.reflections)
-    implementation(libs.logback)
-
-    testImplementation(libs.scala)
-}
+@Component
+class ScalaClassComponent

--- a/hartshorn-core/src/test/scala/org/dockbox/hartshorn/core/scala/ScalaComponentTests.scala
+++ b/hartshorn-core/src/test/scala/org/dockbox/hartshorn/core/scala/ScalaComponentTests.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.core.scala
+
+import jakarta.inject.Inject
+import org.dockbox.hartshorn.application.context.ApplicationContext
+import org.dockbox.hartshorn.component.ComponentLocator
+import org.dockbox.hartshorn.testsuite.HartshornTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.{Arguments, MethodSource}
+
+import java.util.stream.Stream
+
+/**
+ * Tests compatibility with Scala (case) classes, objects and traits
+ * This is similar to the tests seen in <pre>GroovyComponentTests</pre> and <pre>KotlinComponentsTests</pre>.
+ * Instead of using a common test class for all three languages, each language has its own test class.
+ * This is done to provide a simple example of how to use Hartshorn's Test Suite with each language.
+ *
+ * @author Guus Lieben
+ * @since 22.5
+ */
+@HartshornTest
+class ScalaComponentTests {
+
+  @Inject
+  private var applicationContext: ApplicationContext = _
+
+  @Inject
+  private var componentLocator: ComponentLocator = _
+
+  @ParameterizedTest
+  @MethodSource(Array("components"))
+  def testComponent[T](componentType: Class[T]): Unit = {
+    val component = this.applicationContext.get(componentType)
+    Assertions.assertNotNull(component)
+
+    val container = this.componentLocator.container(componentType)
+    Assertions.assertNotNull(container)
+    Assertions.assertTrue(container.present())
+  }
+}
+
+object ScalaComponentTests {
+
+  def components(): Stream[Arguments] = Stream.of(
+      Arguments.of(classOf[ScalaCaseClassComponent]),
+      Arguments.of(classOf[ScalaClassComponent]),
+      Arguments.of(ScalaObjectComponent.getClass),
+      Arguments.of(classOf[ScalaTraitComponent])
+    )
+}

--- a/hartshorn-core/src/test/scala/org/dockbox/hartshorn/core/scala/ScalaObjectComponent.scala
+++ b/hartshorn-core/src/test/scala/org/dockbox/hartshorn/core/scala/ScalaObjectComponent.scala
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-apply {
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.core.scala
 
-plugins {
-    kotlin("jvm") version "1.7.10"
-    scala
-}
+import org.dockbox.hartshorn.component.Component
 
-dependencies {
-    api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
-
-    implementation(libs.reflections)
-    implementation(libs.logback)
-
-    testImplementation(libs.scala)
-}
+@Component
+object ScalaObjectComponent

--- a/hartshorn-core/src/test/scala/org/dockbox/hartshorn/core/scala/ScalaTraitComponent.scala
+++ b/hartshorn-core/src/test/scala/org/dockbox/hartshorn/core/scala/ScalaTraitComponent.scala
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-apply {
-    from("${project.rootDir}/gradle/publications.gradle.kts")
-}
+package org.dockbox.hartshorn.core.scala
 
-plugins {
-    kotlin("jvm") version "1.7.10"
-    scala
-}
+import org.dockbox.hartshorn.component.Component
 
-dependencies {
-    api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
-
-    implementation(libs.reflections)
-    implementation(libs.logback)
-
-    testImplementation(libs.scala)
-}
+@Component
+trait ScalaTraitComponent

--- a/hartshorn-data/src/test/resources/junit.properties
+++ b/hartshorn-data/src/test/resources/junit.properties
@@ -1,1 +1,17 @@
+#
+# Copyright 2019-2022 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 junit.number=1

--- a/hartshorn-data/src/test/resources/junit.yml
+++ b/hartshorn-data/src/test/resources/junit.yml
@@ -1,3 +1,19 @@
+#
+# Copyright 2019-2022 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 junit:
   cp: "This is a value"
   list:

--- a/hartshorn-i18n/src/test/resources/i18n/en_us.yml
+++ b/hartshorn-i18n/src/test/resources/i18n/en_us.yml
@@ -1,2 +1,18 @@
+#
+# Copyright 2019-2022 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 lang:
   name: 'English'


### PR DESCRIPTION
# Description
Currently we 'know' other JVM languages are supported by Hartshorn, but this knowledge is not backed by tests. This PR adds tests for the following languages, to verify their supported data types are compatible with Hartshorn:
- Kotlin 1.7.10
- Scala 2.13.8
- Groovy 4.0.2

Minor note: downgrades SLF4J from 2.0.0 to 1.7.36 due to compatibility issues with Logback.

Fixes #812

## Type of change
- [x] Test (changes to tests)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
