### PR TITLE
#815 Allow creation of concrete proxies of types with non-default constructor(s)

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ProxyConstructorFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ProxyConstructorFunction.java
@@ -17,8 +17,9 @@
 package org.dockbox.hartshorn.proxy;
 
 import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.reflect.ConstructorContext;
 
-@FunctionalInterface
 public interface ProxyConstructorFunction<T> {
     T create() throws ApplicationException;
+    T create(ConstructorContext<T> constructor, Object[] args) throws ApplicationException;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ProxyFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ProxyFactory.java
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.Result;
 import org.dockbox.hartshorn.util.collections.ConcurrentClassMap;
 import org.dockbox.hartshorn.util.collections.MultiMap;
+import org.dockbox.hartshorn.util.reflect.ConstructorContext;
 import org.dockbox.hartshorn.util.reflect.MethodContext;
 
 import java.lang.reflect.Method;
@@ -309,6 +310,23 @@ public interface ProxyFactory<T, F extends ProxyFactory<T, F>> extends Modifiabl
      * @throws ApplicationException If the proxy could not be created
      */
     Result<T> proxy() throws ApplicationException;
+
+    /**
+     * Creates a proxy instance of the given {@code type} and returns it. This will create a new proxy and
+     * invokes the given {@link ConstructorContext} to create the proxy instance. This also creates a new
+     * {@link ProxyManager} responsible for managing the proxy. The proxy will be created with all currently
+     * known behaviors.
+     *
+     * <p>If the proxy could not be created, {@link Result#empty()} will be returned. If the proxy is
+     * absent, an exception will not always be thrown. It is up to the implementation to decide whether to
+     * throw an {@link ApplicationException}, or use {@link Result#error()}.
+     *
+     * @param constructor The constructor to use
+     * @param args The arguments to pass to the constructor
+     * @return A proxy instance
+     * @throws ApplicationException If the proxy could not be created
+     */
+    Result<T> proxy(ConstructorContext<T> constructor, Object[] args) throws ApplicationException;
 
     /**
      * Gets the type of the proxy. This will return the original type, and not a proxy type.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyConstructorFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyConstructorFunction.java
@@ -1,0 +1,31 @@
+package org.dockbox.hartshorn.proxy.cglib;
+
+import net.sf.cglib.proxy.Enhancer;
+
+import org.dockbox.hartshorn.proxy.ProxyConstructorFunction;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.reflect.ConstructorContext;
+
+public class CglibProxyConstructorFunction<T> implements ProxyConstructorFunction<T> {
+
+    private final Class<T> type;
+    private final Enhancer enhancer;
+
+    public CglibProxyConstructorFunction(final Class<T> type, final Enhancer enhancer) {
+        this.type = type;
+        this.enhancer = enhancer;
+    }
+
+    @Override
+    public T create() throws ApplicationException {
+        final Object instance = this.enhancer.create();
+        return this.type.cast(instance);
+    }
+
+    @Override
+    public T create(final ConstructorContext<T> constructor, final Object[] args) throws ApplicationException {
+        final Class<?>[] parameterTypes = constructor.constructor().getParameterTypes();
+        final Object instance = this.enhancer.create(parameterTypes, args);
+        return this.type.cast(instance);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyConstructorFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyConstructorFunction.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.proxy.cglib;
 
 import net.sf.cglib.proxy.Enhancer;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyFactory.java
@@ -49,6 +49,6 @@ public class CglibProxyFactory<T> extends JDKInterfaceProxyFactory<T> {
             final Invokable proxyMethod = new ProxyMethodInvokable(proxy, obj, method);
             return interceptor.intercept(obj, realMethod, proxyMethod, args);
         });
-        return () -> this.type().cast(enhancer.create());
+        return new CglibProxyConstructorFunction<>(this.type(), enhancer);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistProxyConstructorFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistProxyConstructorFunction.java
@@ -1,0 +1,42 @@
+package org.dockbox.hartshorn.proxy.javassist;
+
+import org.dockbox.hartshorn.proxy.ProxyConstructorFunction;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.reflect.ConstructorContext;
+
+import java.lang.reflect.InvocationTargetException;
+
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+
+public class JavassistProxyConstructorFunction<T> implements ProxyConstructorFunction<T> {
+
+    private final Class<T> type;
+    private final ProxyFactory factory;
+    private final MethodHandler methodHandler;
+
+    public JavassistProxyConstructorFunction(final Class<T> type, final ProxyFactory factory, final MethodHandler methodHandler) {
+        this.type = type;
+        this.factory = factory;
+        this.methodHandler = methodHandler;
+    }
+
+    @Override
+    public T create() throws ApplicationException {
+        try {
+            return this.type.cast(this.factory.create(new Class<?>[0], new Object[0], this.methodHandler));
+        } catch (final RuntimeException | InvocationTargetException | NoSuchMethodException | InstantiationException | IllegalAccessException e) {
+            throw new ApplicationException(e);
+        }
+    }
+
+    @Override
+    public T create(final ConstructorContext<T> constructor, final Object[] args) throws ApplicationException {
+        try {
+            final Class<?>[] parameterTypes = constructor.constructor().getParameterTypes();
+            return this.type.cast(this.factory.create(parameterTypes, args, this.methodHandler));
+        } catch (final RuntimeException | InvocationTargetException | NoSuchMethodException | InstantiationException | IllegalAccessException e) {
+            throw new ApplicationException(e);
+        }
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistProxyConstructorFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistProxyConstructorFunction.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.proxy.javassist;
 
 import org.dockbox.hartshorn.proxy.ProxyConstructorFunction;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistProxyFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistProxyFactory.java
@@ -21,9 +21,6 @@ import org.dockbox.hartshorn.proxy.DefaultProxyFactory;
 import org.dockbox.hartshorn.proxy.JDKInterfaceProxyFactory;
 import org.dockbox.hartshorn.proxy.ProxyConstructorFunction;
 import org.dockbox.hartshorn.proxy.StandardMethodInterceptor;
-import org.dockbox.hartshorn.util.ApplicationException;
-
-import java.lang.reflect.InvocationTargetException;
 
 import javassist.util.proxy.MethodHandler;
 import javassist.util.proxy.ProxyFactory;
@@ -45,12 +42,6 @@ public class JavassistProxyFactory<T> extends JDKInterfaceProxyFactory<T> {
         factory.setInterfaces(this.proxyInterfaces(false));
 
         final MethodHandler methodHandler = new JavassistProxyMethodHandler<>(interceptor);
-        return () -> {
-            try {
-                return this.type().cast(factory.create(new Class<?>[0], new Object[0], methodHandler));
-            } catch (final RuntimeException | InvocationTargetException | NoSuchMethodException | InstantiationException | IllegalAccessException e) {
-                throw new ApplicationException(e);
-            }
-        };
+        return new JavassistProxyConstructorFunction<>(this.type(), factory, methodHandler);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/ExecutableElementContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/ExecutableElementContext.java
@@ -80,7 +80,7 @@ public abstract class ExecutableElementContext<A extends Executable, P> extends 
         return this.parent;
     }
 
-    protected Object[] arguments(final ApplicationContext context) {
+    public Object[] arguments(final ApplicationContext context) {
         final ParameterLoaderContext loaderContext = new ParameterLoaderContext(this, null, null, context);
         return this.parameterLoader.loadArguments(loaderContext).toArray();
     }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ConcreteProxyWithNonDefaultConstructor.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ConcreteProxyWithNonDefaultConstructor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.core.proxy;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+
+public class ConcreteProxyWithNonDefaultConstructor {
+
+    private final ApplicationContext applicationContext;
+
+    public ConcreteProxyWithNonDefaultConstructor(final ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    public ApplicationContext applicationContext() {
+        return this.applicationContext;
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
@@ -39,6 +39,8 @@ import org.dockbox.hartshorn.testsuite.InjectTest;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.Result;
 import org.dockbox.hartshorn.util.StringUtilities;
+import org.dockbox.hartshorn.util.reflect.ConstructorContext;
+import org.dockbox.hartshorn.util.reflect.TypeContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -144,6 +146,18 @@ public class ProxyTests {
 
         final InterfaceProxy proxyInstance = proxy.get();
         Assertions.assertEquals("concrete", proxyInstance.name());
+    }
+
+    @Test
+    void testConcreteProxyWithNonDefaultConstructorUsesConstructor() {
+        final StateAwareProxyFactory<ConcreteProxyWithNonDefaultConstructor, ?> factory = this.applicationContext.environment().manager().factory(ConcreteProxyWithNonDefaultConstructor.class);
+
+        final ConstructorContext<ConcreteProxyWithNonDefaultConstructor> constructor = TypeContext.of(ConcreteProxyWithNonDefaultConstructor.class).constructors().get(0);
+        final Result<ConcreteProxyWithNonDefaultConstructor> proxy = Assertions.assertDoesNotThrow(() -> factory.proxy(constructor, new Object[]{this.applicationContext}));
+        Assertions.assertTrue(proxy.present());
+
+        final ConcreteProxyWithNonDefaultConstructor proxyInstance = proxy.get();
+        Assertions.assertSame(this.applicationContext, proxyInstance.applicationContext());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
# Description
Currently all proxy factories assume there is either a default constructor, or no constructor at all present in the target type for the proxy. However, when a type is provided which does not meet this expectation, the proxy cannot be created (as there is not enough information to do so). A similar type may look like:
```java
public class ConcreteProxyWithNonDefaultConstructor {

    public ConcreteProxyWithNonDefaultConstructor(final ApplicationContext applicationContext) {
        // ...
    }
}
```

These changes allow us to provide a target constructor and set of arguments to create a proxy instance of a similar type. This has also been implemented in the component finalizer, so component provision uses the optimal (injectable) constructor.

Fixes #815

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
