### PR TITLE
#834 Enforce type checking on method interceptors

### DIFF
--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodPostProcessor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodPostProcessor.java
@@ -44,7 +44,7 @@ public class CacheEvictionMethodPostProcessor extends CacheServicePostProcessor<
     }
 
     @Override
-    protected <T, R> MethodInterceptor<T> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final CacheContext cacheContext) {
+    protected <T, R> MethodInterceptor<T, R> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final CacheContext cacheContext) {
         return interceptorContext -> {
             try {
                 cacheContext.manager().get(cacheContext.cacheName()).present(Cache::invalidate);

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheServicePostProcessor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheServicePostProcessor.java
@@ -47,7 +47,7 @@ import java.util.function.Supplier;
 public abstract class CacheServicePostProcessor<A extends Annotation> extends ServiceAnnotatedMethodInterceptorPostProcessor<A> {
 
     @Override
-    public <T, R> MethodInterceptor<T> process(final ApplicationContext context, final MethodProxyContext<T> proxyContext, final ComponentProcessingContext<T> processingContext) {
+    public <T, R> MethodInterceptor<T, R> process(final ApplicationContext context, final MethodProxyContext<T> proxyContext, final ComponentProcessingContext<T> processingContext) {
         final CacheMethodContext cacheMethodContext = this.context(proxyContext);
         final CacheManager manager = context.get(CacheManager.class);
 
@@ -92,7 +92,7 @@ public abstract class CacheServicePostProcessor<A extends Annotation> extends Se
 
     protected abstract CacheMethodContext context(MethodProxyContext<?> context);
 
-    protected abstract <T, R> MethodInterceptor<T> process(ApplicationContext context, MethodProxyContext<T> methodContext, CacheContext cacheContext);
+    protected abstract <T, R> MethodInterceptor<T, R> process(ApplicationContext context, MethodProxyContext<T> methodContext, CacheContext cacheContext);
 
     @Override
     public <T> boolean preconditions(final ApplicationContext context, final MethodProxyContext<T> methodContext, final ComponentProcessingContext<T> processingContext) {

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodPostProcessor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodPostProcessor.java
@@ -44,7 +44,7 @@ public class CacheUpdateMethodPostProcessor extends CacheServicePostProcessor<Up
     }
 
     @Override
-    protected <T, R> MethodInterceptor<T> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final CacheContext cacheContext) {
+    protected <T, R> MethodInterceptor<T, R> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final CacheContext cacheContext) {
         return interceptorContext -> {
             try {
                 final Object o = interceptorContext.args()[0];
@@ -53,7 +53,7 @@ public class CacheUpdateMethodPostProcessor extends CacheServicePostProcessor<Up
                 return interceptorContext.invokeDefault();
             } catch (final ApplicationException e) {
                 context.handle(e);
-                return methodContext.method().returnType().defaultOrNull();
+                return interceptorContext.method().returnType().defaultOrNull();
             }
         };
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/CustomInvocation.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/CustomInvocation.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Callable;
  * @since 22.2
  */
 @FunctionalInterface
-public interface CustomInvocation {
+public interface CustomInvocation<T> {
     /**
      * Invoke the default method with the given arguments.
      *
@@ -35,7 +35,7 @@ public interface CustomInvocation {
      * @return the result of the invocation
      * @throws Exception if the invocation fails
      */
-    Object call(Object... args) throws Exception;
+    T call(Object... args) throws Exception;
 
     /**
      * Converts this invocation to a {@link Callable}. This is useful for the {@link MethodInterceptorContext}
@@ -45,7 +45,7 @@ public interface CustomInvocation {
      * @param args the default arguments to use
      * @return the invocation as a {@link Callable}
      */
-    default Callable<Object> toCallable(final Object... args) {
+    default Callable<T> toCallable(final Object... args) {
         return () -> this.call(args);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/LazyProxyManager.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/LazyProxyManager.java
@@ -63,7 +63,7 @@ public class LazyProxyManager<T> extends DefaultApplicationAwareContext implemen
 
     private final Map<Method, ?> delegates;
     private final ConcurrentClassMap<Object> typeDelegates;
-    private final Map<Method, MethodInterceptor<T>> interceptors;
+    private final Map<Method, MethodInterceptor<T, ?>> interceptors;
     private final MultiMap<Method, MethodWrapper<T>> wrappers;
     private T delegate;
 
@@ -72,7 +72,7 @@ public class LazyProxyManager<T> extends DefaultApplicationAwareContext implemen
     }
 
     public LazyProxyManager(final ApplicationContext applicationContext, final Class<T> proxyClass, final Class<T> targetClass, final T delegate, final Map<Method, ?> delegates, final ConcurrentClassMap<Object> typeDelegates,
-                            final Map<Method, MethodInterceptor<T>> interceptors, final MultiMap<Method, MethodWrapper<T>> wrappers) {
+                            final Map<Method, MethodInterceptor<T, ?>> interceptors, final MultiMap<Method, MethodWrapper<T>> wrappers) {
         super(applicationContext);
 
         if (applicationContext.environment().isProxy(targetClass)) {
@@ -142,7 +142,7 @@ public class LazyProxyManager<T> extends DefaultApplicationAwareContext implemen
     }
 
     @Override
-    public Result<MethodInterceptor<T>> interceptor(final Method method) {
+    public Result<MethodInterceptor<T, ?>> interceptor(final Method method) {
         return Result.of(this.interceptors).map(map -> map.get(method));
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/MethodInterceptor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/MethodInterceptor.java
@@ -35,7 +35,7 @@ import java.util.Objects;
  * @since 22.2
  */
 @FunctionalInterface
-public interface MethodInterceptor<T> {
+public interface MethodInterceptor<T, R> {
 
     /**
      * Intercepts a method call. This method is called in series with any other interceptors that have been added to
@@ -48,7 +48,7 @@ public interface MethodInterceptor<T> {
      * @throws Throwable if the interceptor fails to complete. This will cancel any further interceptors and the
      *                  method call and throw the exception to the caller.
      */
-    Object intercept(MethodInterceptorContext<T> context) throws Throwable;
+    R intercept(MethodInterceptorContext<T, R> context) throws Throwable;
 
     /**
      * A utility method to chain the given interceptor after the current interceptor. This method is typically used
@@ -57,10 +57,10 @@ public interface MethodInterceptor<T> {
      * @param after the interceptor to chain after the current interceptor.
      * @return the chained interceptor.
      */
-    default MethodInterceptor<T> andThen(final MethodInterceptor<T> after) {
+    default MethodInterceptor<T, R> andThen(final MethodInterceptor<T, R> after) {
         Objects.requireNonNull(after);
         return ctx -> {
-            final Object previous = this.intercept(ctx);
+            final R previous = this.intercept(ctx);
             return after.intercept(new MethodInterceptorContext<>(ctx, previous));
         };
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/MethodInterceptorContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/MethodInterceptorContext.java
@@ -29,16 +29,16 @@ import java.util.concurrent.Callable;
  * @author Guus Lieben
  * @since 22.2
  */
-public class MethodInterceptorContext<T> {
+public class MethodInterceptorContext<T, R> {
 
-    private final MethodView<T, ?> method;
+    private final MethodView<T, R> method;
     private final Object[] args;
     private final T instance;
-    private final Callable<Object> callable;
-    private final CustomInvocation customInvocation;
-    private final Object result;
+    private final Callable<R> callable;
+    private final CustomInvocation<R> customInvocation;
+    private final R result;
 
-    public MethodInterceptorContext(final MethodView<T, ?> method, final Object[] args, final T instance, final Callable<Object> callable, final CustomInvocation customInvocation, final Object result) {
+    public MethodInterceptorContext(final MethodView<T, R> method, final Object[] args, final T instance, final Callable<R> callable, final CustomInvocation<R> customInvocation, final R result) {
         this.method = method;
         this.args = args;
         this.instance = instance;
@@ -47,11 +47,11 @@ public class MethodInterceptorContext<T> {
         this.result = result;
     }
 
-    public MethodInterceptorContext(final MethodInterceptorContext<T> context, final Object result) {
+    public MethodInterceptorContext(final MethodInterceptorContext<T, R> context, final R result) {
         this(context.method, context.args, context.instance, context.callable, context.customInvocation, result);
     }
 
-    public MethodInterceptorContext(final MethodView<T, ?> method, final Object[] args, final T instance, final CustomInvocation customInvocation) {
+    public MethodInterceptorContext(final MethodView<T, R> method, final Object[] args, final T instance, final CustomInvocation<R> customInvocation) {
         this(method, args, instance, customInvocation.toCallable(args), customInvocation, method.returnType().defaultOrNull());
     }
 
@@ -59,7 +59,7 @@ public class MethodInterceptorContext<T> {
      * Returns the intercepted method, as it was defined on the original class.
      * @return the intercepted method
      */
-    public MethodView<T, ?> method() {
+    public MethodView<T, R> method() {
         return this.method;
     }
 
@@ -87,7 +87,7 @@ public class MethodInterceptorContext<T> {
      * @return the result of the underlying method
      * @throws Throwable if the underlying method throws an exception
      */
-    public Object invokeDefault() throws Throwable {
+    public R invokeDefault() throws Throwable {
         if (this.callable != null) {
             return this.callable.call();
         }
@@ -102,7 +102,7 @@ public class MethodInterceptorContext<T> {
      * @return the result of the underlying method
      * @throws Throwable if the underlying method throws an exception
      */
-    public Object invokeDefault(final Object... args) throws Throwable {
+    public R invokeDefault(final Object... args) throws Throwable {
         if (this.customInvocation != null) {
             return this.customInvocation.call(args);
         }
@@ -116,7 +116,12 @@ public class MethodInterceptorContext<T> {
      * @return the result of the previous interceptor, if any
      * @see org.dockbox.hartshorn.util.introspect.view.TypeView#defaultOrNull()
      */
-    public Object result() {
+    public R result() {
         return this.result;
+    }
+
+    public R checkedCast(final Object o) {
+        if (this.method.returnType().isVoid()) return null;
+        return this.method.returnType().cast(o);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ProxyFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ProxyFactory.java
@@ -251,7 +251,7 @@ public interface ProxyFactory<T, F extends ProxyFactory<T, F>> extends Modifiabl
      * @param interceptor The interceptor to use
      * @return This factory
      */
-    F intercept(MethodView<T, ?> method, MethodInterceptor<T> interceptor);
+    <R> F intercept(MethodView<T, R> method, MethodInterceptor<T, R> interceptor);
 
     /**
      * Intercepts the given method and replaces it with the given {@link MethodInterceptor}. If there is
@@ -261,7 +261,7 @@ public interface ProxyFactory<T, F extends ProxyFactory<T, F>> extends Modifiabl
      * @param interceptor The interceptor to use
      * @return This factory
      */
-    F intercept(Method method, MethodInterceptor<T> interceptor);
+    F intercept(Method method, MethodInterceptor<T, ?> interceptor);
 
     /**
      * Intercepts the given method and calls the given {@link MethodWrapper} for all known phases of the
@@ -357,7 +357,7 @@ public interface ProxyFactory<T, F extends ProxyFactory<T, F>> extends Modifiabl
      *
      * @return All known interceptors, or an empty map
      */
-    Map<Method, MethodInterceptor<T>> interceptors();
+    Map<Method, MethodInterceptor<T, ?>> interceptors();
 
     /**
      * Gets all known wrappers. This will return an empty map if no wrappers were set. If there are

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ProxyManager.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ProxyManager.java
@@ -93,7 +93,7 @@ public interface ProxyManager<T> extends ApplicationAwareContext {
      * @param method the method for which to obtain the interceptor
      * @return the interceptor for the given method
      */
-    Result<MethodInterceptor<T>> interceptor(Method method);
+    Result<MethodInterceptor<T, ?>> interceptor(Method method);
 
     /**
      * Gets all method wrappers for the given method. If the method is not intercepted, this method returns an empty set.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ContextMethodPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ContextMethodPostProcessor.java
@@ -25,14 +25,14 @@ import org.dockbox.hartshorn.proxy.Provided;
 public class ContextMethodPostProcessor extends ServiceAnnotatedMethodInterceptorPostProcessor<Provided> {
 
     @Override
-    public <T, R> MethodInterceptor<T> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final ComponentProcessingContext<T> processingContext) {
+    public <T, R> MethodInterceptor<T, R> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final ComponentProcessingContext<T> processingContext) {
         return interceptorContext -> {
             final Provided annotation = methodContext.annotation(Provided.class);
             final String name = annotation.value();
 
             Key<?> key = Key.of(methodContext.method().returnType());
             if (!name.isEmpty()) key = key.name(name);
-            return context.get(key);
+            return interceptorContext.checkedCast(context.get(key));
         };
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceMethodInterceptorPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceMethodInterceptorPostProcessor.java
@@ -42,7 +42,7 @@ public abstract class ServiceMethodInterceptorPostProcessor extends FunctionalCo
             final MethodProxyContext<T> ctx = new MethodProxyContextImpl<>(context, processingContext.type(), method);
 
             if (this.preconditions(context, ctx, processingContext)) {
-                final MethodInterceptor<T> function = this.process(context, ctx, processingContext);
+                final MethodInterceptor<T, ?> function = this.process(context, ctx, processingContext);
                 if (function != null) factory.intercept(method.method(), function);
             }
             else {
@@ -59,7 +59,7 @@ public abstract class ServiceMethodInterceptorPostProcessor extends FunctionalCo
 
     public abstract <T> boolean preconditions(ApplicationContext context, MethodProxyContext<T> methodContext, ComponentProcessingContext<T> processingContext);
 
-    public abstract <T, R> MethodInterceptor<T> process(ApplicationContext context, MethodProxyContext<T> methodContext, ComponentProcessingContext<T> processingContext);
+    public abstract <T, R> MethodInterceptor<T, R> process(ApplicationContext context, MethodProxyContext<T> methodContext, ComponentProcessingContext<T> processingContext);
 
     public boolean failOnPrecondition() {
         return true;

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
@@ -289,7 +289,7 @@ public class ProxyTests {
         final AgedProxy aged = () -> 12;
         factory.delegate(AgedProxy.class, aged);
 
-        final MethodInterceptor<NamedAgedProxy> named = context -> "NamedProxy";
+        final MethodInterceptor<NamedAgedProxy, ?> named = context -> "NamedProxy";
         factory.intercept(NamedProxy.class.getMethod("name"), named);
         final Result<NamedAgedProxy> proxy = factory.proxy();
         Assertions.assertTrue(proxy.present());

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/serialization/DeserializerMethodPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/serialization/DeserializerMethodPostProcessor.java
@@ -34,7 +34,7 @@ public class DeserializerMethodPostProcessor extends AbstractSerializerPostProce
     }
 
     @Override
-    public <T, R> MethodInterceptor<T> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final ComponentProcessingContext<T> processingContext) {
+    public <T, R> MethodInterceptor<T, R> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final ComponentProcessingContext<T> processingContext) {
         final SerializationSourceConverter converter = this.findConverter(context, methodContext, processingContext);
         final MethodView<T, ?> method = methodContext.method();
         final Deserialize serialize = method.annotations().get(Deserialize.class).get();
@@ -44,7 +44,7 @@ public class DeserializerMethodPostProcessor extends AbstractSerializerPostProce
         return interceptorContext -> {
             try (final InputStream inputStream = converter.inputStream(method, interceptorContext.args())) {
                 final Result<?> result = mapper.read(inputStream, returnType.type());
-                return this.wrapSerializationResult(method, result);
+                return interceptorContext.checkedCast(this.wrapSerializationResult(method, result));
             }
         };
     }

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/serialization/SerializerMethodPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/serialization/SerializerMethodPostProcessor.java
@@ -35,7 +35,7 @@ public class SerializerMethodPostProcessor extends AbstractSerializerPostProcess
     }
 
     @Override
-    public <T, R> MethodInterceptor<T> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final ComponentProcessingContext<T> processingContext) {
+    public <T, R> MethodInterceptor<T, R> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final ComponentProcessingContext<T> processingContext) {
         final SerializationSourceConverter converter = this.findConverter(context, methodContext, processingContext);
         final MethodView<T, ?> method = methodContext.method();
         final Serialize serialize = method.annotations().get(Serialize.class).get();
@@ -51,7 +51,7 @@ public class SerializerMethodPostProcessor extends AbstractSerializerPostProcess
                 if (outputStream == null && returnsStringOrWrapper) result = mapper.write(arguments[0]);
                 else result = mapper.write(outputStream, arguments[0]);
 
-                return this.wrapSerializationResult(method, result);
+                return interceptorContext.checkedCast(this.wrapSerializationResult(method, result));
             }
         };
     }
@@ -59,6 +59,6 @@ public class SerializerMethodPostProcessor extends AbstractSerializerPostProcess
     private boolean returnsStringOrWrapper(final MethodView<?, ?> method) {
         if (method.returnType().is(String.class)) return true;
         final TypeParametersIntrospector typeParameters = method.genericReturnType().typeParameters();
-        return typeParameters.count() == 1 && typeParameters.at(0).map(t -> t.is(String.class)).or(false);
+        return typeParameters.count() == 1 && Boolean.TRUE.equals(typeParameters.at(0).map(t -> t.is(String.class)).or(false));
     }
 }

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/QueryPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/QueryPostProcessor.java
@@ -51,7 +51,7 @@ public class QueryPostProcessor extends ServiceAnnotatedMethodInterceptorPostPro
     }
 
     @Override
-    public <T, R> MethodInterceptor<T> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final ComponentProcessingContext<T> processingContext) {
+    public <T, R> MethodInterceptor<T, R> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final ComponentProcessingContext<T> processingContext) {
         final MethodView<T, ?> method = methodContext.method();
         final QueryFunction function = context.get(QueryFunction.class);
 
@@ -67,7 +67,7 @@ public class QueryPostProcessor extends ServiceAnnotatedMethodInterceptorPostPro
 
             final QueryContext queryContext = new QueryContext(query, interceptorContext.args(), method, entityType, context, repository, modifying);
 
-            return function.execute(queryContext);
+            return interceptorContext.checkedCast(function.execute(queryContext));
         };
     }
 

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectPostProcessor.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectPostProcessor.java
@@ -34,7 +34,7 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
 public class TranslationInjectPostProcessor extends ServiceAnnotatedMethodInterceptorPostProcessor<InjectTranslation> {
 
     @Override
-    public <T, R> MethodInterceptor<T> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final ComponentProcessingContext<T> processingContext) {
+    public <T, R> MethodInterceptor<T, R> process(final ApplicationContext context, final MethodProxyContext<T> methodContext, final ComponentProcessingContext<T> processingContext) {
         final String key = this.key(context, methodContext.type(), methodContext.method());
         final InjectTranslation annotation = methodContext.method().annotations().get(InjectTranslation.class).get();
 
@@ -42,7 +42,7 @@ public class TranslationInjectPostProcessor extends ServiceAnnotatedMethodInterc
             // Prevents NPE when formatting cached resources without arguments
             final Object[] args = interceptorContext.args();
             final Object[] objects = null == args ? new Object[0] : args;
-            return (R) context.get(TranslationService.class).getOrCreate(key, annotation.value()).format(objects);
+            return interceptorContext.checkedCast(context.get(TranslationService.class).getOrCreate(key, annotation.value()).format(objects));
         };
     }
 


### PR DESCRIPTION
# Description
Method interceptors currently do not have a unified way of checking whether a value matches the expected return type. This risks cast exceptions, or otherwise unexpected behavior.

The suggested changes add type checking to interceptors, and mirror this behavior to proxy processors so the return type is appropriately enforced.

Fixes #834

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing (existing tests)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
