### PR TITLE
#837 Deprecate CGlib proxying

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/DefaultApplicationBuilder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/DefaultApplicationBuilder.java
@@ -42,7 +42,7 @@ import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 import org.dockbox.hartshorn.logging.ApplicationLogger;
 import org.dockbox.hartshorn.logging.logback.LogbackApplicationLogger;
 import org.dockbox.hartshorn.proxy.ApplicationProxier;
-import org.dockbox.hartshorn.proxy.cglib.CglibApplicationProxier;
+import org.dockbox.hartshorn.proxy.javassist.JavassistApplicationProxier;
 import org.dockbox.hartshorn.util.introspect.annotations.AnnotationLookup;
 import org.dockbox.hartshorn.util.introspect.annotations.VirtualHierarchyAnnotationLookup;
 
@@ -90,7 +90,7 @@ public abstract class DefaultApplicationBuilder<Self extends DefaultApplicationB
     protected final Set<ComponentPreProcessor> componentPreProcessors = ConcurrentHashMap.newKeySet();
 
     protected ComponentInitializer<ApplicationConfigurator> applicationConfigurator = ComponentInitializer.of(ctx -> new EnvironmentDrivenApplicationConfigurator());
-    protected ComponentInitializer<ApplicationProxier> applicationProxier = ComponentInitializer.of(ctx -> new CglibApplicationProxier());
+    protected ComponentInitializer<ApplicationProxier> applicationProxier = ComponentInitializer.of(ctx -> new JavassistApplicationProxier());
     protected ComponentInitializer<ApplicationFSProvider> applicationFSProvider = ComponentInitializer.of(ctx -> new ApplicationFSProviderImpl());
     protected ComponentInitializer<ExceptionHandler> exceptionHandler = ComponentInitializer.of(ctx -> new LoggingExceptionHandler());
     protected ComponentInitializer<ApplicationArgumentParser> argumentParser = ComponentInitializer.of(ctx -> new StandardApplicationArgumentParser());

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/MethodInvokable.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/MethodInvokable.java
@@ -33,6 +33,7 @@ public class MethodInvokable implements Invokable {
 
     @Override
     public Object invoke(final Object obj, final Object... args) throws Exception {
+        if (this.method == null) return null;
         return this.method.invoke(obj, args);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CGLibProxyMethodInvokable.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CGLibProxyMethodInvokable.java
@@ -20,11 +20,18 @@ import net.sf.cglib.proxy.MethodProxy;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.proxy.Invokable;
+import org.dockbox.hartshorn.proxy.javassist.JavassistProxyMethodHandler;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
 import java.lang.reflect.Method;
 
-public class ProxyMethodInvokable implements Invokable {
+/**
+ * @deprecated CGLib is not actively maintained, and commonly causes issues with Java 9+.
+ *             It is recommended to use Javassist instead, through the
+ *             {@link JavassistProxyMethodHandler}.
+ */
+@Deprecated(since = "22.5")
+public class CGLibProxyMethodInvokable implements Invokable {
 
     private final MethodProxy methodProxy;
     private final Object proxy;
@@ -32,7 +39,7 @@ public class ProxyMethodInvokable implements Invokable {
     private final Method method;
     private final TypeView<?> returnType;
 
-    public ProxyMethodInvokable(final ApplicationContext applicationContext, final MethodProxy methodProxy, final Object proxy, final Method method) {
+    public CGLibProxyMethodInvokable(final ApplicationContext applicationContext, final MethodProxy methodProxy, final Object proxy, final Method method) {
         this.methodProxy = methodProxy;
         this.proxy = proxy;
         this.parameterTypes = method.getParameterTypes();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibApplicationProxier.java
@@ -16,13 +16,25 @@
 
 package org.dockbox.hartshorn.proxy.cglib;
 
+import org.dockbox.hartshorn.logging.ApplicationLogger;
 import org.dockbox.hartshorn.proxy.AbstractApplicationProxier;
 import org.dockbox.hartshorn.proxy.StateAwareProxyFactory;
+import org.dockbox.hartshorn.proxy.javassist.JavassistApplicationProxier;
 
+/**
+ * @deprecated CGLib is not actively maintained, and commonly causes issues with Java 9+.
+ *             It is recommended to use Javassist instead, through the
+ *             {@link JavassistApplicationProxier}.
+ */
+@Deprecated(since = "22.5")
 public class CglibApplicationProxier extends AbstractApplicationProxier {
 
-    public CglibApplicationProxier() {
+    public CglibApplicationProxier(final ApplicationLogger logger) {
         this.registerProxyLookup(new CglibProxyLookup());
+        logger.log().warn("""
+                You are using CGLib, which is not actively maintained and may cause issues with Java 9+.
+                This may cause unexpected behavior or significant errors during the application runtime.
+                It is recommended to use the Javassist proxier instead.""");
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyConstructorFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyConstructorFunction.java
@@ -19,9 +19,16 @@ package org.dockbox.hartshorn.proxy.cglib;
 import net.sf.cglib.proxy.Enhancer;
 
 import org.dockbox.hartshorn.proxy.ProxyConstructorFunction;
+import org.dockbox.hartshorn.proxy.javassist.JavassistProxyConstructorFunction;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 
+/**
+ * @deprecated CGLib is not actively maintained, and commonly causes issues with Java 9+.
+ *             It is recommended to use Javassist instead, through the
+ *             {@link JavassistProxyConstructorFunction}.
+ */
+@Deprecated(since = "22.5")
 public class CglibProxyConstructorFunction<T> implements ProxyConstructorFunction<T> {
 
     private final Class<T> type;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyFactory.java
@@ -27,7 +27,14 @@ import org.dockbox.hartshorn.proxy.JDKInterfaceProxyFactory;
 import org.dockbox.hartshorn.proxy.MethodInvokable;
 import org.dockbox.hartshorn.proxy.ProxyConstructorFunction;
 import org.dockbox.hartshorn.proxy.StandardMethodInterceptor;
+import org.dockbox.hartshorn.proxy.javassist.JavassistProxyFactory;
 
+/**
+ * @deprecated CGLib is not actively maintained, and commonly causes issues with Java 9+.
+ *             It is recommended to use Javassist instead, through the
+ *             {@link JavassistProxyFactory}.
+ */
+@Deprecated(since = "22.5")
 public class CglibProxyFactory<T> extends JDKInterfaceProxyFactory<T> {
 
     private static final NamingPolicy NAMING_POLICY = (prefix, className, key, names) -> DefaultProxyFactory.NAME_GENERATOR.get(prefix);
@@ -46,7 +53,7 @@ public class CglibProxyFactory<T> extends JDKInterfaceProxyFactory<T> {
 
         enhancer.setCallback((MethodInterceptor) (obj, method, args, proxy) -> {
             final MethodInvokable realMethod = new MethodInvokable(method, this.applicationContext());
-            final Invokable proxyMethod = new ProxyMethodInvokable(this.applicationContext(), proxy, obj, method);
+            final Invokable proxyMethod = new CGLibProxyMethodInvokable(this.applicationContext(), proxy, obj, method);
             return interceptor.intercept(obj, realMethod, proxyMethod, args);
         });
         return new CglibProxyConstructorFunction<>(this.type(), enhancer);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyLookup.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyLookup.java
@@ -19,7 +19,14 @@ package org.dockbox.hartshorn.proxy.cglib;
 import net.sf.cglib.proxy.Enhancer;
 
 import org.dockbox.hartshorn.proxy.StandardProxyLookup;
+import org.dockbox.hartshorn.proxy.javassist.JavassistProxyLookup;
 
+/**
+ * @deprecated CGLib is not actively maintained, and commonly causes issues with Java 9+.
+ *             It is recommended to use Javassist instead, through the
+ *             {@link JavassistProxyLookup}.
+ */
+@Deprecated(since = "22.5")
 public class CglibProxyLookup implements StandardProxyLookup {
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionTypeView.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionTypeView.java
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.util.CollectionUtilities;
 import org.dockbox.hartshorn.util.Result;
 import org.dockbox.hartshorn.util.Tristate;
 import org.dockbox.hartshorn.util.Tuple;
+import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.TypeConstructorsIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeFieldsIntrospector;
@@ -330,18 +331,20 @@ public class ReflectionTypeView<T> extends ReflectionAnnotatedElementView implem
         // Do not use .cast here, getOrDefault causes boxing so we get e.g. Integer instead of int. Explicit cast
         // unboxes it correctly, but .cast will yield a ClassCastException.
         if (this.isPrimitive()) {
-            return (T) PRIMITIVE_DEFAULTS.getOrDefault(this.type(), null);
+            return TypeUtils.adjustWildcards(PRIMITIVE_DEFAULTS.getOrDefault(this.type(), null), Object.class);
         } else {
             final Class<?> primitive = WRAPPERS_TO_PRIMITIVE.get(this.type());
             if (primitive == null) return null;
-            else return (T) PRIMITIVE_DEFAULTS.getOrDefault(primitive, null);
+            else return TypeUtils.adjustWildcards(PRIMITIVE_DEFAULTS.getOrDefault(primitive, null), Object.class);
         }
     }
 
     @Override
     public T cast(final Object object) {
         if (object == null) return null;
-        if (this.isInstance(object)) return this.type.cast(object);
+        // Do not use .cast here, getOrDefault causes boxing so we get e.g. Integer instead of int. Explicit cast
+        // unboxes it correctly, but .cast will yield a ClassCastException.
+        if (this.isInstance(object)) return TypeUtils.adjustWildcards(object, Object.class);
         else throw new ClassCastException("Cannot cast '%s' to '%s'".formatted(object, this.type));
     }
 


### PR DESCRIPTION
# Description
CGlib is not officially supported in newer JDKs, and therefore risks instability issues when used in Hartshorn as we target Java 17+. This PR deprecates CGlib as the primary proxier, and uses Javassist as preferred option instead. CGlib support has not been marked for removal, though a warning will be given when it is used.
```
You are using CGLib, which is not actively maintained and may cause issues with Java 9+.
This may cause unexpected behavior or significant errors during the application runtime.
It is recommended to use the Javassist proxier instead.
```

Fixes #837

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)
- [x] Refactor (code changes that do not affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing (existing tests)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
