### PR TITLE
#839 Preliminary Java 18 support

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/BeanProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/BeanProvider.java
@@ -16,6 +16,8 @@
 
 package org.dockbox.hartshorn.beans;
 
+import org.dockbox.hartshorn.inject.Key;
+
 import java.util.List;
 
 public interface BeanProvider {
@@ -23,7 +25,11 @@ public interface BeanProvider {
 
     <T> T first(Class<T> type, String id);
 
+    <T> T first(Key<T> key);
+
     <T> List<T> all(Class<T> type);
 
     <T> List<T> all(Class<T> type, String id);
+
+    <T> List<T> all(Key<T> key);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/ContextBeanProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/ContextBeanProvider.java
@@ -16,6 +16,8 @@
 
 package org.dockbox.hartshorn.beans;
 
+import org.dockbox.hartshorn.inject.Key;
+
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -50,6 +52,12 @@ public class ContextBeanProvider implements BeanProvider {
         return this.first(type, this.typeAndIdFilter(type, id));
     }
 
+    @Override
+    public <T> T first(final Key<T> key) {
+        if (key.name() != null) return this.first(key.type(), key.name().value());
+        else return this.first(key.type());
+    }
+
     private <T> T first(final Class<T> type, final Predicate<BeanReference<?>> predicate) {
         return this.stream(type, predicate)
                 .findFirst()
@@ -66,6 +74,12 @@ public class ContextBeanProvider implements BeanProvider {
     public <T> List<T> all(final Class<T> type, final String id) {
         return this.stream(type, this.typeAndIdFilter(type, id))
                 .toList();
+    }
+
+    @Override
+    public <T> List<T> all(final Key<T> key) {
+        if (key.name() != null) return this.all(key.type(), key.name().value());
+        else return this.all(key.type());
     }
 
     private <T>Stream<T> stream(final Class<T> type, final Predicate<BeanReference<?>> predicate) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ContextParameterLoaderRule.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ContextParameterLoaderRule.java
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.component.ComponentRequiredException;
 import org.dockbox.hartshorn.inject.Context;
 import org.dockbox.hartshorn.inject.Required;
 import org.dockbox.hartshorn.util.Result;
+import org.dockbox.hartshorn.util.StringUtilities;
 import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.view.ParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
@@ -31,7 +32,6 @@ public class ContextParameterLoaderRule implements ParameterLoaderRule<Parameter
 
     @Override
     public boolean accepts(final ParameterView<?> parameter, final int index, final ParameterLoaderContext context, final Object... args) {
-
         return parameter.annotations().has(Context.class) && parameter.type().isChildOf(org.dockbox.hartshorn.context.Context.class);
     }
 
@@ -41,7 +41,7 @@ public class ContextParameterLoaderRule implements ParameterLoaderRule<Parameter
         final String name = parameter.annotations().get(Context.class).map(Context::value).orNull();
 
         TypeView<? extends org.dockbox.hartshorn.context.Context> type = TypeUtils.adjustWildcards(parameter.type(), TypeView.class);
-        final Result<? extends org.dockbox.hartshorn.context.Context> out = name == null
+        final Result<? extends org.dockbox.hartshorn.context.Context> out = StringUtilities.empty(name)
                 ? applicationContext.first(type.type())
                 : applicationContext.first(type.type(), name);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/parameter/ParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/parameter/ParameterLoader.java
@@ -21,5 +21,8 @@ import org.dockbox.hartshorn.application.context.ParameterLoaderContext;
 import java.util.List;
 
 public abstract class ParameterLoader<C extends ParameterLoaderContext> {
+
+    public abstract Object loadArgument(C context, int index, Object... args);
+
     public abstract List<Object> loadArguments(C context, Object... args);
 }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanObject.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanObject.java
@@ -1,0 +1,4 @@
+package org.dockbox.hartshorn.core.beans;
+
+public record BeanObject(String name) {
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanService.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanService.java
@@ -1,0 +1,23 @@
+package org.dockbox.hartshorn.core.beans;
+
+import org.dockbox.hartshorn.beans.Bean;
+import org.dockbox.hartshorn.component.Service;
+
+@Service
+public class BeanService {
+
+    @Bean(id = "user")
+    public static BeanObject userBean() {
+        return new BeanObject("user");
+    }
+
+    @Bean(id = "admin")
+    public static BeanObject adminBean() {
+        return new BeanObject("admin");
+    }
+
+    @Bean(id = "guest")
+    public static BeanObject guestBean() {
+        return new BeanObject("guest");
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanTests.java
@@ -1,0 +1,65 @@
+package org.dockbox.hartshorn.core.beans;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.beans.BeanContext;
+import org.dockbox.hartshorn.beans.BeanProvider;
+import org.dockbox.hartshorn.inject.Context;
+import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.testsuite.InjectTest;
+import org.dockbox.hartshorn.util.Result;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
+
+@HartshornTest
+public class BeanTests {
+
+    @InjectTest
+    void testApplicationHasBeanContext(final ApplicationContext applicationContext) {
+        final Result<BeanContext> beanContext = applicationContext.first(BeanContext.class);
+        Assertions.assertTrue(beanContext.present());
+
+        final BeanProvider provider = beanContext.get().provider();
+        Assertions.assertNotNull(provider);
+    }
+
+    @InjectTest
+    void testBeansAreCollected(@Context final BeanContext beanContext) {
+        final BeanProvider beanProvider = beanContext.provider();
+        final List<BeanObject> beanObjects = beanProvider.all(BeanObject.class);
+        Assertions.assertEquals(3, beanObjects.size());
+
+        final BeanObject user = beanProvider.first(BeanObject.class, "user");
+        Assertions.assertNotNull(user);
+
+        final BeanObject admin = beanProvider.first(BeanObject.class, "admin");
+        Assertions.assertNotNull(admin);
+
+        final BeanObject guest = beanProvider.first(BeanObject.class, "guest");
+        Assertions.assertNotNull(guest);
+    }
+
+    @InjectTest
+    void testBeansAreObserved(final TestBeanObserver observer) {
+        final List<BeanObject> beans = observer.beans();
+        Assertions.assertEquals(3, beans.size());
+
+        final BeanObject user = findBeanInList(beans, "user");
+        Assertions.assertNotNull(user);
+
+        final BeanObject admin = findBeanInList(beans, "admin");
+        Assertions.assertNotNull(admin);
+
+        final BeanObject guest = findBeanInList(beans, "guest");
+        Assertions.assertNotNull(guest);
+    }
+
+    @Nullable
+    private static BeanObject findBeanInList(final List<BeanObject> beans, final String user) {
+        return beans.stream()
+                .filter(bean -> user.equals(bean.name()))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/TestBeanObserver.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/TestBeanObserver.java
@@ -1,0 +1,23 @@
+package org.dockbox.hartshorn.core.beans;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.beans.BeanContext;
+import org.dockbox.hartshorn.beans.BeanObserver;
+import org.dockbox.hartshorn.component.Service;
+
+import java.util.List;
+
+@Service
+public class TestBeanObserver implements BeanObserver {
+
+    private List<BeanObject> beans;
+
+    @Override
+    public void onBeansCollected(final ApplicationContext applicationContext, final BeanContext beanContext) {
+        this.beans = beanContext.provider().all(BeanObject.class);
+    }
+
+    public List<BeanObject> beans() {
+        return this.beans;
+    }
+}

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.application.InitializingContext;
 import org.dockbox.hartshorn.application.ServiceImpl;
 import org.dockbox.hartshorn.application.StandardApplicationBuilder;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.application.context.ParameterLoaderContext;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.ComponentLocatorImpl;
 import org.dockbox.hartshorn.component.ComponentPopulator;
@@ -29,7 +30,9 @@ import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentProcessor;
 import org.dockbox.hartshorn.component.processing.ServiceActivator;
 import org.dockbox.hartshorn.util.Result;
+import org.dockbox.hartshorn.util.introspect.reflect.view.ExecutableElementContextParameterLoader;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.parameter.ParameterLoader;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -140,7 +143,11 @@ public class HartshornLifecycleExtension implements
         final Optional<Method> testMethod = extensionContext.getTestMethod();
         if (testMethod.isEmpty()) throw new ParameterResolutionException("Test method was not provided to runner");
 
-        return this.applicationContext.get(parameterContext.getParameter().getType());
+        final ParameterLoader<ParameterLoaderContext> parameterLoader = new ExecutableElementContextParameterLoader();
+        final MethodView<?, ?> executable = this.applicationContext.environment().introspect(testMethod.get());
+        final ParameterLoaderContext parameterLoaderContext = new ParameterLoaderContext(executable, executable.declaredBy(), extensionContext.getTestInstance().orElse(null), this.applicationContext);
+
+        return parameterLoader.loadArgument(parameterLoaderContext, parameterContext.getIndex());
     }
 
     protected void populateTestInstance(final Object instance, final ApplicationContext applicationContext) {


### PR DESCRIPTION
# Description
Hartshorn currently targets Java 17, and will continue to do so until (at least) after 22.5 is released. However, support for Java 18 can and should be introduced in the first release after 22.5. This PR upgrades the Gradle wrapper to Gradle 7.5.1, and adds CI targets for Java 18. The toolchain has also been updated to support this.

This targets 22.6/23.1 due to the requirement to update the toolchain's Java version. Updating this in the current development stage would require the Java 18 update to be pushed in 22.5.

Fixes #839

## Type of change
- [x] Chore (changes to the build process or auxiliary tools)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
