### PR TITLE
#830 Allow getting beans by `Key` value

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/BeanProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/BeanProvider.java
@@ -16,6 +16,8 @@
 
 package org.dockbox.hartshorn.beans;
 
+import org.dockbox.hartshorn.inject.Key;
+
 import java.util.List;
 
 public interface BeanProvider {
@@ -23,7 +25,11 @@ public interface BeanProvider {
 
     <T> T first(Class<T> type, String id);
 
+    <T> T first(Key<T> key);
+
     <T> List<T> all(Class<T> type);
 
     <T> List<T> all(Class<T> type, String id);
+
+    <T> List<T> all(Key<T> key);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/ContextBeanProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/ContextBeanProvider.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.beans;
 
 import org.dockbox.hartshorn.inject.Key;
+import org.dockbox.hartshorn.util.StringUtilities;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -35,6 +36,7 @@ public class ContextBeanProvider implements BeanProvider {
     }
 
     private Predicate<BeanReference<?>> idFilter(final String id) {
+        if (StringUtilities.empty(id)) return ref -> true;
         return ref -> ref.id().equals(id);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/ContextBeanProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/ContextBeanProvider.java
@@ -16,6 +16,8 @@
 
 package org.dockbox.hartshorn.beans;
 
+import org.dockbox.hartshorn.inject.Key;
+
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -50,6 +52,12 @@ public class ContextBeanProvider implements BeanProvider {
         return this.first(type, this.typeAndIdFilter(type, id));
     }
 
+    @Override
+    public <T> T first(final Key<T> key) {
+        if (key.name() != null) return this.first(key.type(), key.name().value());
+        else return this.first(key.type());
+    }
+
     private <T> T first(final Class<T> type, final Predicate<BeanReference<?>> predicate) {
         return this.stream(type, predicate)
                 .findFirst()
@@ -66,6 +74,12 @@ public class ContextBeanProvider implements BeanProvider {
     public <T> List<T> all(final Class<T> type, final String id) {
         return this.stream(type, this.typeAndIdFilter(type, id))
                 .toList();
+    }
+
+    @Override
+    public <T> List<T> all(final Key<T> key) {
+        if (key.name() != null) return this.all(key.type(), key.name().value());
+        else return this.all(key.type());
     }
 
     private <T>Stream<T> stream(final Class<T> type, final Predicate<BeanReference<?>> predicate) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ContextParameterLoaderRule.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ContextParameterLoaderRule.java
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.component.ComponentRequiredException;
 import org.dockbox.hartshorn.inject.Context;
 import org.dockbox.hartshorn.inject.Required;
 import org.dockbox.hartshorn.util.Result;
+import org.dockbox.hartshorn.util.StringUtilities;
 import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.view.ParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
@@ -31,7 +32,6 @@ public class ContextParameterLoaderRule implements ParameterLoaderRule<Parameter
 
     @Override
     public boolean accepts(final ParameterView<?> parameter, final int index, final ParameterLoaderContext context, final Object... args) {
-
         return parameter.annotations().has(Context.class) && parameter.type().isChildOf(org.dockbox.hartshorn.context.Context.class);
     }
 
@@ -41,7 +41,7 @@ public class ContextParameterLoaderRule implements ParameterLoaderRule<Parameter
         final String name = parameter.annotations().get(Context.class).map(Context::value).orNull();
 
         TypeView<? extends org.dockbox.hartshorn.context.Context> type = TypeUtils.adjustWildcards(parameter.type(), TypeView.class);
-        final Result<? extends org.dockbox.hartshorn.context.Context> out = name == null
+        final Result<? extends org.dockbox.hartshorn.context.Context> out = StringUtilities.empty(name)
                 ? applicationContext.first(type.type())
                 : applicationContext.first(type.type(), name);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/parameter/ParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/parameter/ParameterLoader.java
@@ -21,5 +21,8 @@ import org.dockbox.hartshorn.application.context.ParameterLoaderContext;
 import java.util.List;
 
 public abstract class ParameterLoader<C extends ParameterLoaderContext> {
+
+    public abstract Object loadArgument(C context, int index, Object... args);
+
     public abstract List<Object> loadArguments(C context, Object... args);
 }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanObject.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanObject.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.core.beans;
+
+public record BeanObject(String name) {
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanService.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.core.beans;
+
+import org.dockbox.hartshorn.beans.Bean;
+import org.dockbox.hartshorn.component.Service;
+
+@Service
+public class BeanService {
+
+    @Bean(id = "user")
+    public static BeanObject userBean() {
+        return new BeanObject("user");
+    }
+
+    @Bean(id = "admin")
+    public static BeanObject adminBean() {
+        return new BeanObject("admin");
+    }
+
+    @Bean(id = "guest")
+    public static BeanObject guestBean() {
+        return new BeanObject("guest");
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/BeanTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.core.beans;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.beans.BeanContext;
+import org.dockbox.hartshorn.beans.BeanProvider;
+import org.dockbox.hartshorn.inject.Context;
+import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.testsuite.InjectTest;
+import org.dockbox.hartshorn.util.Result;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
+
+@HartshornTest
+public class BeanTests {
+
+    @InjectTest
+    void testApplicationHasBeanContext(final ApplicationContext applicationContext) {
+        final Result<BeanContext> beanContext = applicationContext.first(BeanContext.class);
+        Assertions.assertTrue(beanContext.present());
+
+        final BeanProvider provider = beanContext.get().provider();
+        Assertions.assertNotNull(provider);
+    }
+
+    @InjectTest
+    void testBeansAreCollected(@Context final BeanContext beanContext) {
+        final BeanProvider beanProvider = beanContext.provider();
+        final List<BeanObject> beanObjects = beanProvider.all(BeanObject.class);
+        Assertions.assertEquals(3, beanObjects.size());
+
+        final BeanObject user = beanProvider.first(BeanObject.class, "user");
+        Assertions.assertNotNull(user);
+
+        final BeanObject admin = beanProvider.first(BeanObject.class, "admin");
+        Assertions.assertNotNull(admin);
+
+        final BeanObject guest = beanProvider.first(BeanObject.class, "guest");
+        Assertions.assertNotNull(guest);
+    }
+
+    @InjectTest
+    void testBeansAreObserved(final TestBeanObserver observer) {
+        final List<BeanObject> beans = observer.beans();
+        Assertions.assertEquals(3, beans.size());
+
+        final BeanObject user = findBeanInList(beans, "user");
+        Assertions.assertNotNull(user);
+
+        final BeanObject admin = findBeanInList(beans, "admin");
+        Assertions.assertNotNull(admin);
+
+        final BeanObject guest = findBeanInList(beans, "guest");
+        Assertions.assertNotNull(guest);
+    }
+
+    @Nullable
+    private static BeanObject findBeanInList(final List<BeanObject> beans, final String user) {
+        return beans.stream()
+                .filter(bean -> user.equals(bean.name()))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/TestBeanObserver.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/beans/TestBeanObserver.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.core.beans;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.beans.BeanContext;
+import org.dockbox.hartshorn.beans.BeanObserver;
+import org.dockbox.hartshorn.component.Service;
+
+import java.util.List;
+
+@Service
+public class TestBeanObserver implements BeanObserver {
+
+    private List<BeanObject> beans;
+
+    @Override
+    public void onBeansCollected(final ApplicationContext applicationContext, final BeanContext beanContext) {
+        this.beans = beanContext.provider().all(BeanObject.class);
+    }
+
+    public List<BeanObject> beans() {
+        return this.beans;
+    }
+}

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.application.InitializingContext;
 import org.dockbox.hartshorn.application.ServiceImpl;
 import org.dockbox.hartshorn.application.StandardApplicationBuilder;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.application.context.ParameterLoaderContext;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.ComponentLocatorImpl;
 import org.dockbox.hartshorn.component.ComponentPopulator;
@@ -29,7 +30,9 @@ import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentProcessor;
 import org.dockbox.hartshorn.component.processing.ServiceActivator;
 import org.dockbox.hartshorn.util.Result;
+import org.dockbox.hartshorn.util.introspect.reflect.view.ExecutableElementContextParameterLoader;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.parameter.ParameterLoader;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -140,7 +143,11 @@ public class HartshornLifecycleExtension implements
         final Optional<Method> testMethod = extensionContext.getTestMethod();
         if (testMethod.isEmpty()) throw new ParameterResolutionException("Test method was not provided to runner");
 
-        return this.applicationContext.get(parameterContext.getParameter().getType());
+        final ParameterLoader<ParameterLoaderContext> parameterLoader = new ExecutableElementContextParameterLoader();
+        final MethodView<?, ?> executable = this.applicationContext.environment().introspect(testMethod.get());
+        final ParameterLoaderContext parameterLoaderContext = new ParameterLoaderContext(executable, executable.declaredBy(), extensionContext.getTestInstance().orElse(null), this.applicationContext);
+
+        return parameterLoader.loadArgument(parameterLoaderContext, parameterContext.getIndex());
     }
 
     protected void populateTestInstance(final Object instance, final ApplicationContext applicationContext) {


### PR DESCRIPTION
# Description
Currently it's only possible to get beans using a `Class` type and `String` ID. This is commonly abstracted to a `Key` instance, but this is not supported by the `BeanProvider` interface. This PR resolves this and appropriately handles the key lookup.

Additionally, this resolves #826 to ensure empty keys are handled correctly in parameter loaders.

Fixes #830

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
