### PR TITLE
#844 Resolve CVE-2022-42889 through transitive dependency of Checker Framework

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ plugins {
     java
     `java-library`
     id("org.cadixdev.licenser") version "0.6.1"
-    id("org.checkerframework") version "0.6.5"
+    id("org.checkerframework") version "0.6.19"
 }
 
 apply {
@@ -118,6 +118,8 @@ allprojects {
         testImplementation(project(":hartshorn-test-suite"))
         testImplementation(rootProject.libs.bundles.test)
         testImplementation(rootProject.libs.bundles.testRuntime)
+
+        checkerFramework("org.checkerframework:checker:3.27.0")
     }
 
     tasks {


### PR DESCRIPTION
# Description
> CVE details: https://nvd.nist.gov/vuln/detail/CVE-2022-42889
> 
> Caused by transitive dependency on `org.apache.commons:commons-text:1.10.0` through `plume-util:options` in Checker Framework. As we only use the compile time plugin, and do not redistribute any of these dependencies this has been (safely) skipped in earlier pull requests (listed below).
> 
> - #835
> - #836
> - #838
> - #841

These changes resolve the use of the transitive dependency on `org.apache.commons:commons-text:1.10.0` through `plume-util:options` in Checker Framework. CF has recent releases which have updated the appropriate dependencies, which resolve the indirect use of `commons-text` in Hartshorn.

While not directly required to solve this CVE, these changes also lock the CF version to 3.27.0, instead of depending on automatic version selection through the CF plugin.

Fixes #844

## Type of change
- [x] Chore (changes to the build process or auxiliary tools)

# How Has This Been Tested?
- [x] Other: OWASP dependency check

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
