### PR TITLE
#849 Add missing `Class` overload for proxy delegate lookup

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ContextualApplicationEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ContextualApplicationEnvironment.java
@@ -340,6 +340,11 @@ public class ContextualApplicationEnvironment implements ObservableApplicationEn
     }
 
     @Override
+    public <D, T extends D> Option<D> delegate(final Class<D> type, final T instance) {
+        return this.applicationProxier.delegate(type, instance);
+    }
+
+    @Override
     public <T> StateAwareProxyFactory<T, ?> factory(final TypeView<T> type) {
         return this.applicationProxier.factory(type);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/AbstractApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/AbstractApplicationProxier.java
@@ -64,10 +64,15 @@ public abstract class AbstractApplicationProxier implements ApplicationProxier, 
 
     @Override
     public <D, T extends D> Option<D> delegate(final TypeView<D> type, final T instance) {
+        return this.delegate(type.type(), instance);
+    }
+
+    @Override
+    public <D, T extends D> Option<D> delegate(final Class<D> type, final T instance) {
         if (instance instanceof Proxy) {
             final Proxy<T> proxy = TypeUtils.adjustWildcards(instance, Proxy.class);
             final ProxyManager<?> manager = proxy.manager();
-            return manager.delegate(type.type());
+            return manager.delegate(type);
         }
         return Option.empty();
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ApplicationProxier.java
@@ -47,6 +47,8 @@ public interface ApplicationProxier extends ProxyLookup {
 
     <D, T extends D> Option<D> delegate(TypeView<D> type, T instance);
 
+    <D, T extends D> Option<D> delegate(Class<D> type, T instance);
+
     <T> StateAwareProxyFactory<T, ?> factory(TypeView<T> type);
 
     <T> StateAwareProxyFactory<T, ?> factory(Class<T> type);


### PR DESCRIPTION
# Description
Fixes #849

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
