### PR TITLE
#873 Add context configuring component processor

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ContextConfiguringComponentProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ContextConfiguringComponentProcessor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.component.processing;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.inject.Key;
+import org.dockbox.hartshorn.proxy.ProxyFactory;
+import org.dockbox.hartshorn.util.TypeUtils;
+
+public abstract class ContextConfiguringComponentProcessor<C extends Context> extends ComponentPostProcessor {
+
+    private final Class<C> contextType;
+
+    public ContextConfiguringComponentProcessor(final Class<C> contextType) {
+        this.contextType = contextType;
+    }
+
+    @Override
+    public <T> T process(final ApplicationContext context, @Nullable final T instance,
+                         final ComponentProcessingContext<T> processingContext) {
+        final C componentContext = processingContext.first(Key.of(this.contextType))
+                .orCompute(() -> this.createContext(context, processingContext)).orNull();
+
+        if (componentContext != null) {
+            this.configure(context, componentContext, processingContext);
+        }
+
+        if (instance instanceof Context contextInstance) {
+            contextInstance.add(componentContext);
+        }
+        else {
+            final Key<ProxyFactory<T, ?>> factoryKey = TypeUtils.adjustWildcards(Key.of(ProxyFactory.class), Key.class);
+            if (processingContext.containsKey(factoryKey)) {
+                final ProxyFactory<T, ?> proxyFactory = processingContext.get(factoryKey);
+                proxyFactory.contextContainer().add(componentContext);
+            }
+        }
+
+        return instance;
+    }
+
+    protected abstract <T> void configure(final ApplicationContext context, final C componentContext,
+                                          final ComponentProcessingContext<T> processingContext);
+
+    protected abstract C createContext(final ApplicationContext context,
+                                       final ComponentProcessingContext<?> processingContext);
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/DefaultProxyFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/DefaultProxyFactory.java
@@ -83,7 +83,7 @@ public abstract class DefaultProxyFactory<T> implements StateAwareProxyFactory<T
     private T typeDelegate;
 
     // Proxy data
-    private final ProxyContextContainer contextContainer = new ProxyContextContainer();
+    private final ProxyContextContainer contextContainer = new ProxyContextContainer(this::updateState);
     private final Class<T> type;
     private final ApplicationContext applicationContext;
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ProxyContextContainer.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/ProxyContextContainer.java
@@ -18,11 +18,18 @@ package org.dockbox.hartshorn.proxy;
 
 import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.context.DefaultContext;
+import org.dockbox.hartshorn.context.NamedContext;
 import org.dockbox.hartshorn.util.collections.MultiMap;
 
 import java.util.Set;
 
 public class ProxyContextContainer extends DefaultContext {
+
+    private final Runnable onModify;
+
+    public ProxyContextContainer(final Runnable onModify) {
+        this.onModify = onModify;
+    }
 
     public Set<Context> contexts() {
         return super.contexts;
@@ -30,5 +37,23 @@ public class ProxyContextContainer extends DefaultContext {
 
     public MultiMap<String, Context> namedContexts() {
         return super.namedContexts;
+    }
+
+    @Override
+    public <C extends Context> void add(final C context) {
+        super.add(context);
+        this.onModify.run();
+    }
+
+    @Override
+    public <N extends NamedContext> void add(final N context) {
+        super.add(context);
+        this.onModify.run();
+    }
+
+    @Override
+    public <C extends Context> void add(final String name, final C context) {
+        super.add(name, context);
+        this.onModify.run();
     }
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/ContextComponent.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/ContextComponent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.dockbox.hartshorn.processing;
+
+import org.dockbox.hartshorn.component.Component;
+import org.dockbox.hartshorn.context.DefaultContext;
+
+@Component
+public class ContextComponent extends DefaultContext {
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/ContextConfiguringComponentProcessorTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/ContextConfiguringComponentProcessorTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.dockbox.hartshorn.processing;
+
+import org.dockbox.hartshorn.application.ApplicationBuilder;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.inject.Key;
+import org.dockbox.hartshorn.proxy.Proxy;
+import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.testsuite.InjectTest;
+import org.dockbox.hartshorn.testsuite.ModifyApplication;
+import org.dockbox.hartshorn.testsuite.TestComponents;
+import org.dockbox.hartshorn.util.option.Option;
+import org.junit.jupiter.api.Assertions;
+
+@HartshornTest(includeBasePackages = false)
+public class ContextConfiguringComponentProcessorTests {
+
+    @ModifyApplication
+    public static ApplicationBuilder<?, ?> builder(final ApplicationBuilder<?, ?> builder) {
+        return builder.postProcessor(new SimpleContextConfiguringComponentProcessor());
+    }
+
+    @InjectTest
+    @TestComponents(EmptyComponent.class)
+    void testNonContextComponentIsProcessed(final ApplicationContext applicationContext) {
+        final EmptyComponent emptyComponent = applicationContext.get(EmptyComponent.class);
+
+        Assertions.assertNotNull(emptyComponent);
+        Assertions.assertTrue(applicationContext.environment().isProxy(emptyComponent));
+
+        final Proxy<EmptyComponent> component = (Proxy<EmptyComponent>) emptyComponent;
+        final Option<SimpleContext> context = component.manager().first(Key.of(SimpleContext.class));
+        Assertions.assertTrue(context.present());
+        Assertions.assertEquals("Foo", context.get().value());
+    }
+
+    @InjectTest
+    @TestComponents(ContextComponent.class)
+    void testContextComponentIsProcessed(final ApplicationContext applicationContext) {
+        final ContextComponent contextComponent = applicationContext.get(ContextComponent.class);
+
+        Assertions.assertNotNull(contextComponent);
+        Assertions.assertFalse(applicationContext.environment().isProxy(contextComponent));
+
+        final Option<SimpleContext> context = contextComponent.first(Key.of(SimpleContext.class));
+        Assertions.assertTrue(context.present());
+        Assertions.assertEquals("Foo", context.get().value());
+    }
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/EmptyComponent.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/EmptyComponent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.dockbox.hartshorn.processing;
+
+import org.dockbox.hartshorn.component.Component;
+
+@Component
+public class EmptyComponent {
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/SimpleContext.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/SimpleContext.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.dockbox.hartshorn.processing;
+
+import org.dockbox.hartshorn.context.DefaultContext;
+
+public class SimpleContext extends DefaultContext {
+
+    private String value;
+
+    public String value() {
+        return this.value;
+    }
+
+    public void value(final String value) {
+        this.value = value;
+    }
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/SimpleContextConfiguringComponentProcessor.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/SimpleContextConfiguringComponentProcessor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.dockbox.hartshorn.processing;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
+import org.dockbox.hartshorn.component.processing.ContextConfiguringComponentProcessor;
+
+public class SimpleContextConfiguringComponentProcessor extends ContextConfiguringComponentProcessor<SimpleContext> {
+
+    public SimpleContextConfiguringComponentProcessor() {
+        super(SimpleContext.class);
+    }
+
+    @Override
+    protected <T> void configure(final ApplicationContext context, final SimpleContext componentContext,
+                                 final ComponentProcessingContext<T> processingContext) {
+        componentContext.value("Foo");
+    }
+
+    @Override
+    protected SimpleContext createContext(final ApplicationContext context,
+                                          final ComponentProcessingContext<?> processingContext) {
+        return new SimpleContext();
+    }
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scan/TypeCollectorTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scan/TypeCollectorTests.java
@@ -39,7 +39,7 @@ import test.org.dockbox.hartshorn.scan.types.ScanEnum;
 import test.org.dockbox.hartshorn.scan.types.ScanInterface;
 import test.org.dockbox.hartshorn.scan.types.ScanRecord;
 
-@HartshornTest
+@HartshornTest(includeBasePackages = false)
 public class TypeCollectorTests {
 
     @InjectTest


### PR DESCRIPTION
# Description
Add a standard abstract ComponentProcessor implementation which can be used to prepare a given context type for components. This will first attempt to get the context from the processing context, and will otherwise create the context, and provide it to implementations of the processor reliably so they can pre-configure the context of the component.

Afterwards, the context is added to the component . This should be done by first checking if the type is an implementation of `Context`, and otherwise preparing a proxy for the type. To support this, we now also treat modifying the context container of a proxy factory as a modification action.

Fixes #873

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
