### PR TITLE
#879 Follow-up CVE-2021-37533, remove static analysis of CF qualifiers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import org.owasp.dependencycheck.gradle.DependencyCheckPlugin
 import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
 
 buildscript {
@@ -33,7 +32,6 @@ plugins {
     java
     `java-library`
     id("org.cadixdev.licenser") version "0.6.1"
-    id("org.checkerframework") version "0.6.19"
 }
 
 apply {
@@ -59,7 +57,6 @@ allprojects {
         plugin("java")
         plugin("java-library")
         plugin("maven-publish")
-        plugin("org.checkerframework")
         plugin("org.cadixdev.licenser")
     }
 
@@ -116,12 +113,14 @@ allprojects {
         // This is not required in child projects, only in this block.
         implementation(rootProject.libs.slf4j)
         implementation(rootProject.libs.bundles.jakarta)
+        // Only require qualifiers to be present, we don't use CF to actually run analysis on the code
+        // and we don't want to force users to use CF.
+        implementation(rootProject.libs.bundles.checkerQual)
 
         testImplementation(project(":hartshorn-test-suite"))
         testImplementation(rootProject.libs.bundles.test)
         testImplementation(rootProject.libs.bundles.testRuntime)
 
-        checkerFramework("org.checkerframework:checker:3.27.0")
     }
 
     tasks {

--- a/gradle/dependency-check-suppressions.xml
+++ b/gradle/dependency-check-suppressions.xml
@@ -1,17 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-
-    <!--
-    Risk accepted: CVE-2022-42920
-
-    Dependency check fails due to a transitive dependency on Apache BCEL with CVE-2022-42920.
-    This is present through annotation-tools-3.27.0 which in turn is present through Checker Framework 3.27.0 (shaded).
-    While we keep the CF annotations through org.checkerframework:checker-qual:3.27.0, we do not use the implementation
-    of CF3.27.0 at runtime, as we only use it for compile-time constraint validation (nullable validation).
-    -->
-    <suppress>
-        <notes><![CDATA[file name: checker-3.27.0.jar (shaded: org.apache.bcel:bcel:6.5.0)]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.bcel/bcel@.*$</packageUrl>
-        <vulnerabilityName>CVE-2022-42920</vulnerabilityName>
-    </suppress>
+    <!-- No active suppressions -->
 </suppressions>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@
 #
 caffeine = "3.1.1"
 cglib = "3.3.0"
+checker = "3.28.0"
 derby = "10.16.1.1"
 freemarker = "2.3.31"
 groovy = "4.0.2"
@@ -113,12 +114,16 @@ postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" 
 scala = { module = "org.scala-lang:scala-library", version.ref = "scala" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 woodstox = { module = "org.codehaus.woodstox:woodstox-core-asl", version.ref = "woodstox" }
+checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checker" }
 
 [bundles]
 #
 # Bundles in alphabetical order.
 # Dependencies per bundle should also be in alphabetical order.
 #
+checkerQual = [
+    "checker-qual",
+]
 databaseDrivers = [
     "derby",
     "derby-tools",


### PR DESCRIPTION
# Description
As Checker Framework has previously caused issues with transitive dependencies, it was decided to remove the static analysis it provides, while keeping the qualifier annotations.

This does not yet provide a replacement for the static analysis, though I plan on opening a PR to draft Errorprone integration. As this introduces additional functionality, I do not plan on merging this before open PRs are finalized to avoid conflicting with these changes.

Fixes #879

## Type of change
- [x] Chore (changes to the build process or auxiliary tools)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
