### PR TITLE
#882 Rename `@Provider` to `@Binds`, clean up class-bindings

### DIFF
--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheProviders.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheProviders.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.cache;
 import org.dockbox.hartshorn.cache.annotations.UseCaching;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 
 /**
  * Default providers for cache components. This implementation is active by
@@ -37,17 +37,15 @@ public class CacheProviders {
      * active by default when {@link UseCaching} is used.
      * @return {@link CacheManagerImpl}
      */
-    @Provider
-    public Class<? extends CacheManager> cacheManager() {
-        return CacheManagerImpl.class;
-    }
+    @Binds
+    public Class<? extends CacheManager> cacheManager = CacheManagerImpl.class;
 
     /**
      * The default binding for {@link KeyGenerator}. This implementation is
      * active by default when {@link UseCaching} is used.
      * @return {@link HashCodeKeyGenerator}
      */
-    @Provider
+    @Binds
     public KeyGenerator keyGenerator() {
         return new HashCodeKeyGenerator();
     }

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/caffeine/CaffeineProviders.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/caffeine/CaffeineProviders.java
@@ -21,7 +21,7 @@ import org.dockbox.hartshorn.cache.annotations.UseCaching;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.condition.RequiresClass;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 
 /**
  * The provider configuration for Caffeine caches.
@@ -38,8 +38,6 @@ public class CaffeineProviders {
      * to support both injected and bound provision.
      * @return {@link CaffeineCache}
      */
-    @Provider
-    public Class<? extends Cache> cache() {
-        return CaffeineCache.class;
-    }
+    @Binds
+    public Class<? extends Cache> cache = CaffeineCache.class;
 }

--- a/hartshorn-cache/src/test/java/test/org/dockbox/hartshorn/cache/TestCacheProviders.java
+++ b/hartshorn-cache/src/test/java/test/org/dockbox/hartshorn/cache/TestCacheProviders.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.cache.CacheManager;
 import org.dockbox.hartshorn.cache.annotations.UseCaching;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 
 import jakarta.inject.Singleton;
 
@@ -28,7 +28,7 @@ import jakarta.inject.Singleton;
 @RequiresActivator(UseCaching.class)
 public class TestCacheProviders {
 
-    @Provider(priority = 0)
+    @Binds(priority = 0)
     @Singleton
     public Class<? extends CacheManager> cacheManager = JUnitCacheManager.class;
 

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandProviders.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandProviders.java
@@ -21,7 +21,7 @@ import org.dockbox.hartshorn.commands.annotations.UseCommands;
 import org.dockbox.hartshorn.commands.arguments.CommandParameterLoader;
 import org.dockbox.hartshorn.commands.extension.CooldownExtension;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.util.parameter.ParameterLoader;
 
@@ -31,34 +31,26 @@ import jakarta.inject.Singleton;
 @RequiresActivator(UseCommands.class)
 public class CommandProviders {
 
+    @Binds
+    public Class<? extends CommandListener> listener = CommandListenerImpl.class;
+
+    @Binds
+    @Singleton
+    public Class<? extends SystemSubject> systemSubject = ApplicationSystemSubject.class;
+
+    @Binds
+    @Singleton
+    public Class<? extends CommandGateway> commandGateway = CommandGatewayImpl.class;
+
+    @Binds
+    public Class<? extends CommandParser> commandParser = CommandParserImpl.class;
+
     @Bean
     public static CooldownExtension cooldownExtension() {
         return new CooldownExtension();
     }
 
-    @Provider
-    public Class<? extends CommandListener> listener() {
-        return CommandListenerImpl.class;
-    }
-
-    @Provider
-    @Singleton
-    public Class<? extends SystemSubject> systemSubject() {
-        return ApplicationSystemSubject.class;
-    }
-
-    @Provider
-    @Singleton
-    public Class<? extends CommandGateway> commandGateway() {
-        return CommandGatewayImpl.class;
-    }
-
-    @Provider
-    public Class<? extends CommandParser> commandParser() {
-        return CommandParserImpl.class;
-    }
-
-    @Provider("command_loader")
+    @Binds("command_loader")
     public ParameterLoader<?> parameterLoader() {
         return new CommandParameterLoader();
     }

--- a/hartshorn-commands/src/test/java/test/org/dockbox/hartshorn/commands/TestCommandProviders.java
+++ b/hartshorn-commands/src/test/java/test/org/dockbox/hartshorn/commands/TestCommandProviders.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.commands.SystemSubject;
 import org.dockbox.hartshorn.commands.annotations.UseCommands;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 
 import jakarta.inject.Singleton;
 
@@ -28,7 +28,7 @@ import jakarta.inject.Singleton;
 @RequiresActivator(UseCommands.class)
 public class TestCommandProviders {
 
-    @Provider(priority = 0)
+    @Binds(priority = 0)
     @Singleton
     public Class<? extends SystemSubject> systemSubject = JUnitSystemSubject.class;
 

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationProviders.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationProviders.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.config;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.processing.ProcessingOrder;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.config.annotations.Configuration;
 import org.dockbox.hartshorn.config.annotations.UseConfigurations;
 import org.dockbox.hartshorn.config.properties.ConfigurationObjectPostProcessor;
@@ -41,12 +41,12 @@ public class ConfigurationProviders {
      *
      * @return {@link StandardPropertyHolder}
      */
-    @Provider(phase = ProcessingOrder.EARLY)
+    @Binds(phase = ProcessingOrder.EARLY)
     public Class<? extends PropertyHolder> propertyHolder() {
         return StandardPropertyHolder.class;
     }
 
-    @Provider(phase = ProcessingOrder.EARLY)
+    @Binds(phase = ProcessingOrder.EARLY)
     public URIConfigProcessor uriConfigProcessor() {
         return new StandardURIConfigProcessor();
     }

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/jackson/JacksonProviders.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/jackson/JacksonProviders.java
@@ -31,7 +31,7 @@ import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.condition.RequiresClass;
 import org.dockbox.hartshorn.component.processing.ProcessingOrder;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.config.JsonInclusionRule;
 import org.dockbox.hartshorn.config.ObjectMapper;
 import org.dockbox.hartshorn.config.annotations.UseConfigurations;
@@ -46,42 +46,42 @@ public class JacksonProviders {
 
     private static final int DATA_MAPPER_PHASE = ProcessingOrder.EARLY - 64;
 
-    @Provider(value = "properties", phase = DATA_MAPPER_PHASE)
+    @Binds(value = "properties", phase = DATA_MAPPER_PHASE)
     @RequiresClass("com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper")
     public JacksonDataMapper properties() {
         return new JavaPropsDataMapper();
     }
 
-    @Provider(value = "json", phase = DATA_MAPPER_PHASE)
+    @Binds(value = "json", phase = DATA_MAPPER_PHASE)
     @RequiresClass("com.fasterxml.jackson.databind.json.JsonMapper")
     public JacksonDataMapper json() {
         return new JsonDataMapper();
     }
 
-    @Provider(value = "toml", phase = DATA_MAPPER_PHASE)
+    @Binds(value = "toml", phase = DATA_MAPPER_PHASE)
     @RequiresClass("com.fasterxml.jackson.dataformat.toml.TomlMapper")
     public JacksonDataMapper toml() {
         return new TomlDataMapper();
     }
 
-    @Provider(value = "xml", phase = DATA_MAPPER_PHASE)
+    @Binds(value = "xml", phase = DATA_MAPPER_PHASE)
     @RequiresClass("com.fasterxml.jackson.dataformat.xml.XmlMapper")
     public JacksonDataMapper xml() {
         return new XmlDataMapper();
     }
 
-    @Provider(value = "yml", phase = DATA_MAPPER_PHASE)
+    @Binds(value = "yml", phase = DATA_MAPPER_PHASE)
     @RequiresClass("com.fasterxml.jackson.dataformat.yaml.YAMLMapper")
     public JacksonDataMapper yml() {
         return new YamlDataMapper();
     }
 
-    @Provider(phase = DATA_MAPPER_PHASE + 32)
+    @Binds(phase = DATA_MAPPER_PHASE + 32)
     public ObjectMapper objectMapper() {
         return new JacksonObjectMapper();
     }
 
-    @Provider(phase = DATA_MAPPER_PHASE + 16) // Before ObjectMapper
+    @Binds(phase = DATA_MAPPER_PHASE + 16) // Before ObjectMapper
     public JacksonObjectMapperConfigurator mapperConfigurator(final Introspector introspector) {
         final Function<JsonInclusionRule, Include> rules = (rule) -> switch (rule) {
             case SKIP_EMPTY -> Include.NON_EMPTY;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/BeanProviders.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/BeanProviders.java
@@ -18,14 +18,12 @@ package org.dockbox.hartshorn.beans;
 
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 
 @Service
 @RequiresActivator(UseBeanScanning.class)
 public class BeanProviders {
 
-    @Provider
-    public Class<? extends BeanProvider> beanProvider() {
-        return ContextBeanProvider.class;
-    }
+    @Binds
+    public Class<? extends BeanProvider> beanProvider = ContextBeanProvider.class;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ApplicationProviders.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ApplicationProviders.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.application.UseBootstrap;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.logging.LogExclude;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.slf4j.Logger;
 
 /**
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 @LogExclude
 public class ApplicationProviders {
 
-    @Provider
+    @Binds
     public Logger logger(final ApplicationContext context) {
         return context.log();
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/Binds.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/Binds.java
@@ -44,7 +44,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.FIELD })
-public @interface Provider {
+public @interface Binds {
     String value() default "";
 
     int priority() default -1;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/DefaultProviders.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/DefaultProviders.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.inject;
 import org.dockbox.hartshorn.application.UseBootstrap;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.inject.processing.UseServiceProvision;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.context.ConcreteContextCarrier;
 import org.dockbox.hartshorn.context.ContextCarrier;
@@ -30,7 +30,7 @@ import jakarta.inject.Singleton;
 @RequiresActivator({ UseBootstrap.class, UseServiceProvision.class })
 public class DefaultProviders {
 
-    @Provider
+    @Binds
     @Singleton
     public Class<? extends ContextCarrier> contextCarrier() {
         return ConcreteContextCarrier.class;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/BindingProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/BindingProcessor.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentContainer;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.condition.ConditionMatcher;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.inject.ComponentInitializationException;
 import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
@@ -70,7 +70,7 @@ public class BindingProcessor {
     private <R, E extends AnnotatedElementView & ObtainableView<?> & GenericTypeView<?>> void process(final Key<R> key, final E element,
                                                                                                       final ApplicationContext applicationContext) throws ApplicationException {
         final ConditionMatcher conditionMatcher = applicationContext.get(ConditionMatcher.class);
-        final Provider annotation = element.annotations().get(Provider.class).get();
+        final Binds annotation = element.annotations().get(Binds.class).get();
 
         final boolean singleton = applicationContext.environment().singleton(key.type()) || element.annotations().has(Singleton.class);
 
@@ -86,7 +86,7 @@ public class BindingProcessor {
     }
 
     private <R> void processInstanceBinding(
-            final ApplicationContext context, final ObtainableView<R> element, final Key<R> key, final boolean singleton, final Provider annotation
+            final ApplicationContext context, final ObtainableView<R> element, final Key<R> key, final boolean singleton, final Binds annotation
     ) {
         final BindingFunction<R> function = context.bind(key).priority(annotation.priority());
         final Supplier<R> supplier = () -> element.getWithContext().rethrowUnchecked().orNull();
@@ -99,7 +99,7 @@ public class BindingProcessor {
     }
 
     private <R, C extends Class<R>> void processClassBinding(final ApplicationContext context, final ObtainableView<C> element,
-                                                             final Key<R> key, boolean singleton, final Provider annotation) throws ApplicationException {
+                                                             final Key<R> key, boolean singleton, final Binds annotation) throws ApplicationException {
         final C targetType = element.getWithContext()
                 .rethrowUnchecked()
                 .orElseThrow(() -> new ComponentInitializationException("Failed to obtain class type for " + element.qualifiedName()));

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContext.java
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.inject.processing;
 
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 
@@ -24,12 +24,12 @@ public class ProviderContext {
 
     private final Key<?> key;
     private final AnnotatedElementView element;
-    private final Provider provider;
+    private final Binds binding;
 
-    public ProviderContext(final Key<?> key, final AnnotatedElementView element, final Provider provider) {
+    public ProviderContext(final Key<?> key, final AnnotatedElementView element, final Binds binding) {
         this.key = key;
         this.element = element;
-        this.provider = provider;
+        this.binding = binding;
     }
 
     public Key<?> key() {
@@ -40,7 +40,7 @@ public class ProviderContext {
         return this.element;
     }
 
-    public Provider provider() {
-        return this.provider;
+    public Binds provider() {
+        return this.binding;
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderServicePreProcessor.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.component.processing.ExitingComponentProcessor;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
@@ -36,8 +36,8 @@ public final class ProviderServicePreProcessor extends ComponentPreProcessor imp
 
     @Override
     public <T> void process(final ApplicationContext context, final ComponentProcessingContext<T> processingContext) {
-        final List<MethodView<T, ?>> methods = processingContext.type().methods().annotatedWith(Provider.class);
-        final List<FieldView<T, ?>> fields = processingContext.type().fields().annotatedWith(Provider.class);
+        final List<MethodView<T, ?>> methods = processingContext.type().methods().annotatedWith(Binds.class);
+        final List<FieldView<T, ?>> fields = processingContext.type().fields().annotatedWith(Binds.class);
 
         if (methods.isEmpty() && fields.isEmpty()) return;
 
@@ -54,8 +54,8 @@ public final class ProviderServicePreProcessor extends ComponentPreProcessor imp
 
     private <E extends AnnotatedElementView & ObtainableView<?> & GenericTypeView<?>> void register(final ProviderContextList context, final E element) {
         final Key<?> key = this.key(element);
-        final Provider provider = element.annotations().get(Provider.class).get();
-        final ProviderContext providerContext = new ProviderContext(key, element, provider);
+        final Binds binding = element.annotations().get(Binds.class).get();
+        final ProviderContext providerContext = new ProviderContext(key, element, binding);
         context.add(providerContext);
     }
 
@@ -73,7 +73,7 @@ public final class ProviderServicePreProcessor extends ComponentPreProcessor imp
     }
 
     private <E extends AnnotatedElementView & ObtainableView<?> & GenericTypeView<?>> Key<?> key(final E element) {
-        final Provider annotation = element.annotations().get(Provider.class).get();
+        final Binds annotation = element.annotations().get(Binds.class).get();
         if (element.type().is(Class.class) || element.type().is(TypeView.class)) {
             final TypeView<?> view = element.genericType().typeParameters().at(0).get();
             return Key.of(view.type(), annotation.value());

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/FieldProviderService.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/FieldProviderService.java
@@ -16,7 +16,7 @@
 
 package test.org.dockbox.hartshorn.components;
 
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.component.Service;
 
 import jakarta.inject.Singleton;
@@ -24,10 +24,10 @@ import jakarta.inject.Singleton;
 @Service
 public class FieldProviderService {
 
-    @Provider("field")
+    @Binds("field")
     private final ProvidedInterface field = () -> "Field";
 
     @Singleton
-    @Provider("singletonField")
+    @Binds("singletonField")
     private final ProvidedInterface singletonField = () -> "Field";
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/PersonProviders.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/PersonProviders.java
@@ -17,14 +17,14 @@
 package test.org.dockbox.hartshorn.components;
 
 import org.dockbox.hartshorn.component.Service;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 
 @Service
 public class PersonProviders {
 
-    @Provider
+    @Binds
     public Class<? extends Person> person = PersonImpl.class;
 
-    @Provider
+    @Binds
     public Class<? extends User> user = BoundUserImpl.class;
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/SampleProviderService.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/SampleProviderService.java
@@ -16,7 +16,7 @@
 
 package test.org.dockbox.hartshorn.components;
 
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.component.Service;
 
 import jakarta.inject.Named;
@@ -25,28 +25,28 @@ import jakarta.inject.Singleton;
 @Service
 public class SampleProviderService {
 
-    @Provider
+    @Binds
     public ProvidedInterface get() {
         return () -> "Provision";
     }
 
-    @Provider("named")
+    @Binds("named")
     public ProvidedInterface named() {
         return () -> "NamedProvision";
     }
 
-    @Provider("parameter")
+    @Binds("parameter")
     public ProvidedInterface withParameter(final SampleField field) {
         return () -> "ParameterProvision";
     }
 
-    @Provider("namedParameter")
+    @Binds("namedParameter")
     public ProvidedInterface withNamedField(@Named("named") final SampleField field) {
         return () -> "NamedParameterProvision";
     }
 
     @Singleton
-    @Provider("singleton")
+    @Binds("singleton")
     public ProvidedInterface singleton() {
         return () -> "SingletonProvision";
     }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/SampleProviders.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/SampleProviders.java
@@ -17,12 +17,12 @@
 package test.org.dockbox.hartshorn.components;
 
 import org.dockbox.hartshorn.component.Service;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 
 @Service
 public class SampleProviders {
 
-    @Provider("meta")
+    @Binds("meta")
     public SampleInterface sampleInterface = new SampleMetaAnnotatedImplementation();
 
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/conditions/ConditionalProviders.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/conditions/ConditionalProviders.java
@@ -19,7 +19,7 @@ package test.org.dockbox.hartshorn.conditions;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresClass;
 import org.dockbox.hartshorn.component.condition.RequiresProperty;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 
 @Service
 public class ConditionalProviders {
@@ -28,7 +28,7 @@ public class ConditionalProviders {
      * Passes as long as {@code java.lang.String} is on the classpath. As this is
      * part of the standard library, it should always be available.
      */
-    @Provider("a")
+    @Binds("a")
     @RequiresClass("java.lang.String")
     public String a() {
         return "a";
@@ -38,7 +38,7 @@ public class ConditionalProviders {
      * Fails when {@code java.gnal.String} is not on the classpath. As this is
      * an intentional typo, it should never be available.
      */
-    @Provider("b")
+    @Binds("b")
     @RequiresClass("java.gnal.String")
     public String b() {
         return "b";
@@ -48,7 +48,7 @@ public class ConditionalProviders {
      * Passes as long as {@code property.c} is present as a property, no matter
      * what its value is.
      */
-    @Provider("c")
+    @Binds("c")
     @RequiresProperty(name = "property.c")
     public String c() {
         return "c";
@@ -59,7 +59,7 @@ public class ConditionalProviders {
      * value is equal to {@code d}. This is handled by {@link ConditionTests},
      * so the property is <b>present</b>.
      */
-    @Provider("d")
+    @Binds("d")
     @RequiresProperty(name = "property.d", withValue = "d")
     public String d() {
         return "d";
@@ -70,7 +70,7 @@ public class ConditionalProviders {
      * value is equal to {@code e}. This is handled by {@link ConditionTests},
      * so the property is <b>absent</b>.
      */
-    @Provider("e")
+    @Binds("e")
     @RequiresProperty(name = "property.e", withValue = "e")
     public String e() {
         return "e";
@@ -80,7 +80,7 @@ public class ConditionalProviders {
      * Passes if there is no property named {@code property.l}. This is handled
      * by {@link ConditionTests}, so the property is <b>absent</b>.
      */
-    @Provider("f")
+    @Binds("f")
     @RequiresProperty(name = "property.f", matchIfMissing = true)
     public String f() {
         return "f";

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/factory/FactoryProviders.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/factory/FactoryProviders.java
@@ -17,15 +17,15 @@
 package test.org.dockbox.hartshorn.factory;
 
 import org.dockbox.hartshorn.component.Service;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 
 @Service
 public class FactoryProviders {
 
-    @Provider(priority = 1)
+    @Binds(priority = 1)
     public Class<? extends FactoryProvided> highPriority = HighPriorityFactoryBound.class;
 
-    @Provider
+    @Binds
     public Class<? extends FactoryProvided> lowPriority = LowPriorityFactoryBound.class;
 
 

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/proxy/ProxyProviders.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/proxy/ProxyProviders.java
@@ -17,12 +17,12 @@
 package test.org.dockbox.hartshorn.proxy;
 
 import org.dockbox.hartshorn.component.Service;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 
 @Service
 public class ProxyProviders {
 
-    @Provider
+    @Binds
     public InterfaceProxy proxy() {
         return new ConcreteProxy();
     }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scan/DemoProvider.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scan/DemoProvider.java
@@ -18,13 +18,13 @@ package test.org.dockbox.hartshorn.scan;
 
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 
 @Service
 @RequiresActivator(UseDemo.class)
 public class DemoProvider {
 
-    @Provider
+    @Binds
     public Demo demo() {
         return new DemoImpl();
     }

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventProviders.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventProviders.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.events;
 
 import org.dockbox.hartshorn.beans.Bean;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.events.handle.ConditionMatcherEventExecutionFilter;
 import org.dockbox.hartshorn.events.handle.EventExecutionFilter;
@@ -33,12 +33,10 @@ import jakarta.inject.Singleton;
 public class EventProviders {
 
     @Singleton
-    @Provider
-    public Class<? extends EventBus> eventBus() {
-        return EventBusImpl.class;
-    }
+    @Binds
+    public Class<? extends EventBus> eventBus = EventBusImpl.class;
 
-    @Provider("event_loader")
+    @Binds("event_loader")
     public ParameterLoader<?> eventParameterLoader() {
         return new EventParameterLoader();
     }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/HslLanguageProviders.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/HslLanguageProviders.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.hsl;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.hsl.interpreter.Interpreter;
 import org.dockbox.hartshorn.hsl.lexer.Lexer;
 import org.dockbox.hartshorn.hsl.parser.expression.ComplexExpressionParserAdapter;
@@ -34,22 +34,22 @@ import org.dockbox.hartshorn.hsl.semantic.Resolver;
 @RequiresActivator(UseExpressionValidation.class)
 public class HslLanguageProviders {
 
-    @Provider
+    @Binds
     private final Class<? extends Lexer> lexer = Lexer.class;
 
-    @Provider
+    @Binds
     private final Class<? extends TokenParser> tokenParser = StandardTokenParser.class;
 
-    @Provider
+    @Binds
     private final Class<? extends Resolver> resolver = Resolver.class;
 
-    @Provider
+    @Binds
     private final Class<? extends Interpreter> interpreter = Interpreter.class;
 
-    @Provider
+    @Binds
     private final Class<? extends ExpressionParser> expressionParser = ComplexExpressionParserAdapter.class;
 
-    @Provider
+    @Binds
     public ScriptRuntime runtime(final ApplicationContext applicationContext, final HslLanguageFactory factory) {
         return new StandardRuntime(applicationContext, factory);
     }

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationProviders.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationProviders.java
@@ -18,19 +18,19 @@ package org.dockbox.hartshorn.i18n;
 
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.i18n.annotations.UseTranslations;
 
 @Service
 @RequiresActivator(UseTranslations.class)
 public class TranslationProviders {
 
-    @Provider
+    @Binds
     public TranslationService translationService() {
         return new BundledTranslationService();
     }
 
-    @Provider
+    @Binds
     public TranslationBundle translationBundle() {
         return new DefaultTranslationBundle();
     }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/DataSourceProviders.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/DataSourceProviders.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.jpa;
 
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.jpa.annotations.UsePersistence;
 import org.dockbox.hartshorn.jpa.remote.DataSourceConfiguration;
 import org.dockbox.hartshorn.jpa.remote.DataSourceList;
@@ -37,10 +37,8 @@ public class DataSourceProviders {
      * The default data source list. This is typically overridden by an ORM-specific
      * implementation.
      */
-    @Provider
-    public Class<? extends DataSourceList> dataSourceList() {
-        return StandardDataSourceList.class;
-    }
+    @Binds
+    public Class<? extends DataSourceList> dataSourceList = StandardDataSourceList.class;
 
     /**
      * The default data source configuration. This is automatically selected when no
@@ -49,7 +47,7 @@ public class DataSourceProviders {
      * @param sourceList The data source list implementation
      * @return The default data source configuration
      */
-    @Provider
+    @Binds
     public DataSourceConfiguration defaultConnection(final DataSourceList sourceList) {
         return sourceList.defaultConnection();
     }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/PersistenceProviders.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/PersistenceProviders.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.jpa;
 
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.jpa.annotations.UsePersistence;
 import org.dockbox.hartshorn.jpa.entitymanager.EntityManagerLookup;
 import org.dockbox.hartshorn.jpa.entitymanager.EntityTypeLookup;
@@ -39,22 +39,22 @@ import jakarta.inject.Singleton;
 @RequiresActivator(UsePersistence.class)
 public class PersistenceProviders {
 
-    @Provider("jpa_query")
+    @Binds("jpa_query")
     public ParameterLoader<?> jpaParameterLoader() {
         return new JpaParameterLoader();
     }
 
-    @Provider
+    @Binds
     public EntityManagerLookup entityManagerLookup() {
         return new ProxyAttachedEntityManagerLookup();
     }
 
-    @Provider(phase = -128)
+    @Binds(phase = -128)
     public EntityTypeLookup entityTypeLookup() {
         return new JpaEntityTypeLookup();
     }
 
-    @Provider
+    @Binds
     @Singleton
     public JpaQueryContextCreator queryContextFactory(final EntityTypeLookup entityTypeLookup) {
         final AggregateJpaQueryContextCreator contextFactory = new AggregateJpaQueryContextCreator();
@@ -64,7 +64,7 @@ public class PersistenceProviders {
         return contextFactory;
     }
 
-    @Provider
+    @Binds
     public Class<? extends QueryConstructor> queryConstructor() {
         return EntityManagerQueryConstructor.class;
     }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateProviders.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateProviders.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.jpa.hibernate;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.condition.RequiresClass;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.jpa.JpaRepository;
 import org.dockbox.hartshorn.jpa.annotations.UsePersistence;
 import org.dockbox.hartshorn.jpa.entitymanager.EntityManagerCarrier;
@@ -39,43 +39,43 @@ import jakarta.inject.Singleton;
 @RequiresClass("org.hibernate.Hibernate")
 public class HibernateProviders {
 
-    @Provider(priority = 0)
+    @Binds(priority = 0)
     public Class<? extends DataSourceList> dataSourceList() {
         return HibernateDataSourceList.class;
     }
 
-    @Provider
+    @Binds
     public Class<? extends JpaRepository<?, ?>> jpaRepository() {
         return TypeUtils.adjustWildcards(HibernateJpaRepository.class, Class.class);
     }
 
-    @Provider
+    @Binds
     public Class<? extends EntityManagerCarrier> entityManagerCarrier() {
         return HibernateEntityManagerCarrier.class;
     }
 
-    @Provider
+    @Binds
     public Class<? extends TransactionManager> transactionManager() {
         return HibernateTransactionManager.class;
     }
 
-    @Provider
+    @Binds
     public Class<? extends NamedQueryRegistry> namedQueryRegistry() {
         return HibernateNamedQueryRegistry.class;
     }
 
-    @Provider
+    @Binds
     public QueryExecutor queryFunction(final QueryResultTransformer queryResultTransformer) {
         return new EntityQueryExecutor(queryResultTransformer);
     }
 
-    @Provider
+    @Binds
     @Singleton
     public QueryExecuteTypeLookup queryTypeLookup() {
         return new HibernateQueryExecuteTypeLookup();
     }
 
-    @Provider
+    @Binds
     @Singleton
     public QueryResultTransformer queryResultTransformer() {
         return new HibernateQueryResultTransformer();

--- a/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/ReportingProviders.java
+++ b/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/ReportingProviders.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.reporting;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.reporting.aggregate.AggregateDiagnosticsReporter;
 import org.dockbox.hartshorn.reporting.aggregate.AggregateReporterConfiguration;
 import org.dockbox.hartshorn.reporting.application.ApplicationDiagnosticsReporter;
@@ -32,7 +32,7 @@ import org.dockbox.hartshorn.reporting.system.SystemDiagnosticsReporter;
 @RequiresActivator(UseReporting.class)
 public class ReportingProviders {
 
-    @Provider
+    @Binds
     public Reportable applicationReportable(final ApplicationContext applicationContext) {
         final ConfigurableDiagnosticsReporter<AggregateReporterConfiguration> reporter = new AggregateDiagnosticsReporter();
         reporter.configuration().add(new SystemDiagnosticsReporter());
@@ -43,12 +43,12 @@ public class ReportingProviders {
         return reporter;
     }
 
-    @Provider
+    @Binds
     public DiagnosticsPropertyCollector diagnosticsPropertyCollector() {
         return new StandardDiagnosticsReportCollector();
     }
 
-    @Provider
+    @Binds
     public DiagnosticsReportCollector diagnosticsReportCollector() {
         return new StandardDiagnosticsReportCollector();
     }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpServerProviders.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpServerProviders.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.web;
 
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.util.parameter.ParameterLoader;
 import org.dockbox.hartshorn.web.annotations.UseHttpServer;
 import org.dockbox.hartshorn.web.processing.HttpServletParameterLoader;
@@ -30,27 +30,21 @@ import org.dockbox.hartshorn.web.servlet.WebServletImpl;
 @RequiresActivator(UseHttpServer.class)
 public abstract class HttpServerProviders {
 
-    @Provider
+    @Binds
     public ErrorServlet errorServlet() {
         return new ErrorServletImpl();
     }
 
-    @Provider
-    public Class<? extends WebServlet> webServlet() {
-        return WebServletImpl.class;
-    }
+    @Binds
+    public Class<? extends WebServlet> webServlet = WebServletImpl.class;
 
-    @Provider
-    public Class<WebServletImpl> webServletImpl() {
-        return WebServletImpl.class;
-    }
+    @Binds
+    public Class<WebServletImpl> webServletImpl = WebServletImpl.class;
 
-    @Provider
-    public Class<ServletHandler> servletHandler() {
-        return ServletHandler.class;
-    }
+    @Binds
+    public Class<ServletHandler> servletHandler = ServletHandler.class;
 
-    @Provider("http_webserver")
+    @Binds("http_webserver")
     public ParameterLoader<?> parameterLoader() {
         return new HttpServletParameterLoader();
     }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyProviders.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyProviders.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.web.jetty;
 
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.condition.RequiresClass;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.web.HttpWebServer;
 import org.dockbox.hartshorn.web.annotations.UseHttpServer;
@@ -29,12 +29,12 @@ import org.dockbox.hartshorn.web.servlet.DirectoryServlet;
 @RequiresClass("org.eclipse.jetty.server.Server")
 public class JettyProviders {
 
-    @Provider
+    @Binds
     public DirectoryServlet directoryServlet() {
         return new JettyDirectoryServlet();
     }
 
-    @Provider
+    @Binds
     public HttpWebServer httpWebServer(final JettyResourceService resourceService) {
         return new JettyHttpWebServer(resourceService);
     }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/MVCProviders.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/MVCProviders.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.web.mvc;
 
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.util.parameter.ParameterLoader;
 import org.dockbox.hartshorn.web.annotations.UseMvcServer;
 import org.dockbox.hartshorn.web.processing.MvcParameterLoader;
@@ -28,12 +28,12 @@ import org.dockbox.hartshorn.web.servlet.MvcServlet;
 @RequiresActivator(UseMvcServer.class)
 public class MVCProviders {
 
-    @Provider("mvc_webserver")
+    @Binds("mvc_webserver")
     public ParameterLoader<?> mvcParameterLoader() {
         return new MvcParameterLoader();
     }
 
-    @Provider
+    @Binds
     public Class<MvcServlet> mvcServlet() {
         return MvcServlet.class;
     }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerProviders.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerProviders.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.web.mvc.freemarker;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.condition.RequiresClass;
-import org.dockbox.hartshorn.component.processing.Provider;
+import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.web.annotations.UseMvcServer;
 import org.dockbox.hartshorn.web.mvc.MVCInitializer;
 
@@ -30,7 +30,7 @@ import jakarta.inject.Singleton;
 @RequiresClass("freemarker.template.Template")
 public class FreeMarkerProviders {
 
-    @Provider
+    @Binds
     @Singleton
     public MVCInitializer mvcInitializer() {
         return new FreeMarkerMVCInitializer();


### PR DESCRIPTION
# Description
`@Provider` and `@Provided` are far from similar in functionality, yet their names are almost identical. QA has indicated that this leads to common confusion, where `@Provided` is accidentally used for service-based bindings.

This PR renames `@Provider` to `@Binds`, without making further functional changes.

Fixes #882

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (code changes that do not affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing (existing tests were updated)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have ~~added~~ updated tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
