### PR TITLE
#853 Allow specifying lockmode on JPA repository queries

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ContextualApplicationEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ContextualApplicationEnvironment.java
@@ -33,11 +33,11 @@ import org.dockbox.hartshorn.context.ModifiableContextCarrier;
 import org.dockbox.hartshorn.logging.ApplicationLogger;
 import org.dockbox.hartshorn.logging.LogExclude;
 import org.dockbox.hartshorn.proxy.ApplicationProxier;
-import org.dockbox.hartshorn.proxy.Proxy;
 import org.dockbox.hartshorn.proxy.ProxyManager;
 import org.dockbox.hartshorn.proxy.StateAwareProxyFactory;
 import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.ElementAnnotationsIntrospector;
+import org.dockbox.hartshorn.util.introspect.IntrospectionEnvironment;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.annotations.AnnotationLookup;
 import org.dockbox.hartshorn.util.introspect.annotations.DuplicateAnnotationCompositeException;
@@ -52,7 +52,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
-import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -272,6 +271,11 @@ public class ContextualApplicationEnvironment implements ObservableApplicationEn
     @Override
     public ApplicationContext applicationContext() {
         return this.applicationContext;
+    }
+
+    @Override
+    public IntrospectionEnvironment environment() {
+        return this.introspector().environment();
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/IntrospectionEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/IntrospectionEnvironment.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.util.introspect;
 
 public interface IntrospectionEnvironment {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/IntrospectionEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/IntrospectionEnvironment.java
@@ -1,0 +1,7 @@
+package org.dockbox.hartshorn.util.introspect;
+
+public interface IntrospectionEnvironment {
+
+    boolean parameterNamesAvailable();
+
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/Introspector.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/Introspector.java
@@ -56,4 +56,6 @@ public interface Introspector {
     ElementAnnotationsIntrospector introspect(AnnotatedElement annotatedElement);
 
     ApplicationContext applicationContext();
+
+    IntrospectionEnvironment environment();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionIntrospectionEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionIntrospectionEnvironment.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.util.introspect.reflect;
 
 import org.dockbox.hartshorn.util.Tristate;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionIntrospectionEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionIntrospectionEnvironment.java
@@ -1,0 +1,23 @@
+package org.dockbox.hartshorn.util.introspect.reflect;
+
+import org.dockbox.hartshorn.util.Tristate;
+import org.dockbox.hartshorn.util.introspect.IntrospectionEnvironment;
+
+public class ReflectionIntrospectionEnvironment implements IntrospectionEnvironment {
+
+    private Tristate parameterNamesAvailable = Tristate.UNDEFINED;
+
+    @Override
+    public boolean parameterNamesAvailable() {
+        if (this.parameterNamesAvailable == Tristate.UNDEFINED) {
+            try {
+                IntrospectionEnvironment.class.getDeclaredMethod("parameterNamesAvailable");
+                this.parameterNamesAvailable = Tristate.TRUE;
+            }
+            catch (final NoSuchMethodException e) {
+                this.parameterNamesAvailable = Tristate.FALSE;
+            }
+        }
+        return this.parameterNamesAvailable.booleanValue();
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionIntrospector.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionIntrospector.java
@@ -18,6 +18,7 @@ package org.dockbox.hartshorn.util.introspect.reflect;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.util.introspect.ElementAnnotationsIntrospector;
+import org.dockbox.hartshorn.util.introspect.IntrospectionEnvironment;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.reflect.view.ReflectionConstructorView;
 import org.dockbox.hartshorn.util.introspect.reflect.view.ReflectionFieldView;
@@ -50,6 +51,7 @@ public class ReflectionIntrospector implements Introspector {
     private final Map<Field, FieldView<?, ?>> fieldViewCache = new ConcurrentHashMap<>();
     private final Map<Parameter, ParameterView<?>> parameterViewCache = new ConcurrentHashMap<>();
     private final Map<Constructor<?>, ConstructorView<?>> constructorViewCache = new ConcurrentHashMap<>();
+    private final IntrospectionEnvironment environment = new ReflectionIntrospectionEnvironment();
 
     private final ApplicationContext applicationContext;
 
@@ -139,5 +141,10 @@ public class ReflectionIntrospector implements Introspector {
     @Override
     public ApplicationContext applicationContext() {
         return this.applicationContext;
+    }
+
+    @Override
+    public IntrospectionEnvironment environment() {
+        return this.environment;
     }
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/SimpleContextConfiguringComponentProcessor.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/SimpleContextConfiguringComponentProcessor.java
@@ -27,6 +27,11 @@ public class SimpleContextConfiguringComponentProcessor extends ContextConfiguri
     }
 
     @Override
+    protected boolean supports(final ComponentProcessingContext<?> processingContext) {
+        return true;
+    }
+
+    @Override
     protected <T> void configure(final ApplicationContext context, final SimpleContext componentContext,
                                  final ComponentProcessingContext<T> processingContext) {
         componentContext.value("Foo");

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaParameterLoader.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaParameterLoader.java
@@ -28,7 +28,12 @@ public class JpaParameterLoader extends RuleBasedParameterLoader<JpaParameterLoa
     @Override
     protected <T> T loadDefault(final ParameterView<T> parameter, final int index, final JpaParameterLoaderContext context, final Object... args) {
         final Object value = args[index];
-        context.query().setParameter(parameter.name(), value);
+        if (context.applicationContext().environment().environment().parameterNamesAvailable()) {
+            context.query().setParameter(parameter.name(), value);
+        }
+        else {
+            context.query().setParameter(index + 1, value);
+        }
         return super.loadDefault(parameter, index, context, args);
     }
 }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/annotations/UsePersistence.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/annotations/UsePersistence.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.jpa.annotations;
 import org.dockbox.hartshorn.component.processing.ServiceActivator;
 import org.dockbox.hartshorn.config.annotations.UseSerialization;
 import org.dockbox.hartshorn.jpa.JpaRepositoryDelegationPostProcessor;
+import org.dockbox.hartshorn.jpa.query.QueryExecutionContextPostProcessor;
 import org.dockbox.hartshorn.proxy.UseProxying;
 
 import java.lang.annotation.Retention;
@@ -29,6 +30,9 @@ import java.lang.annotation.RetentionPolicy;
 @UseTransactionManagement
 @UseQuerying
 @Retention(RetentionPolicy.RUNTIME)
-@ServiceActivator(processors = JpaRepositoryDelegationPostProcessor.class)
+@ServiceActivator(processors = {
+        JpaRepositoryDelegationPostProcessor.class,
+        QueryExecutionContextPostProcessor.class,
+})
 public @interface UsePersistence {
 }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/annotations/UsePersistence.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/annotations/UsePersistence.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.jpa.annotations;
 
 import org.dockbox.hartshorn.component.processing.ServiceActivator;
+import org.dockbox.hartshorn.config.annotations.UseConfigurations;
 import org.dockbox.hartshorn.config.annotations.UseSerialization;
 import org.dockbox.hartshorn.jpa.JpaRepositoryDelegationPostProcessor;
 import org.dockbox.hartshorn.jpa.query.QueryExecutionContextPostProcessor;
@@ -29,6 +30,7 @@ import java.lang.annotation.RetentionPolicy;
 @UseSerialization
 @UseTransactionManagement
 @UseQuerying
+@UseConfigurations
 @Retention(RetentionPolicy.RUNTIME)
 @ServiceActivator(processors = {
         JpaRepositoryDelegationPostProcessor.class,

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/FlushMode.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/FlushMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.jpa.query;
 
 import java.lang.annotation.ElementType;

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/FlushMode.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/FlushMode.java
@@ -1,0 +1,15 @@
+package org.dockbox.hartshorn.jpa.query;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.persistence.FlushModeType;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface FlushMode {
+
+    FlushModeType value();
+}

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/LockMode.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/LockMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.jpa.query;
 
 import java.lang.annotation.ElementType;

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/LockMode.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/LockMode.java
@@ -1,0 +1,15 @@
+package org.dockbox.hartshorn.jpa.query;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.persistence.LockModeType;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface LockMode {
+
+    LockModeType value();
+}

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/Pagination.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/Pagination.java
@@ -23,7 +23,7 @@ public final class Pagination {
     private Pagination() {
     }
 
-    public static Pagination Nacreate() {
+    public static Pagination create() {
         return new Pagination();
     }
 

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryExecutionContext.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryExecutionContext.java
@@ -1,0 +1,40 @@
+package org.dockbox.hartshorn.jpa.query;
+
+import org.dockbox.hartshorn.context.DefaultContext;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.LockModeType;
+
+public class QueryExecutionContext extends DefaultContext {
+
+    private Map<MethodView<?, ?>, LockModeType> lockModes = new ConcurrentHashMap<>();
+    private Map<MethodView<?, ?>, FlushModeType> flushModes = new ConcurrentHashMap<>();
+
+    public LockModeType lockMode(final MethodView<?, ?> method) {
+        return this.lockModes.get(method);
+    }
+
+    public FlushModeType flushMode(final MethodView<?, ?> method) {
+        return this.flushModes.get(method);
+    }
+
+    public void lockMode(final MethodView<?, ?> method, final LockModeType lockMode) {
+        this.lockModes.put(method, lockMode);
+    }
+
+    public void flushMode(final MethodView<?, ?> method, final FlushModeType flushMode) {
+        this.flushModes.put(method, flushMode);
+    }
+
+    public boolean hasLockMode(final MethodView<?, ?> method) {
+        return this.lockModes.containsKey(method);
+    }
+
+    public boolean hasFlushMode(final MethodView<?, ?> method) {
+        return this.flushModes.containsKey(method);
+    }
+}

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryExecutionContext.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryExecutionContext.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.jpa.query;
 
 import org.dockbox.hartshorn.context.DefaultContext;

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryExecutionContextPostProcessor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryExecutionContextPostProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.jpa.query;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryExecutionContextPostProcessor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryExecutionContextPostProcessor.java
@@ -33,6 +33,15 @@ public class QueryExecutionContextPostProcessor extends ContextConfiguringCompon
     }
 
     @Override
+    protected boolean supports(final ComponentProcessingContext<?> processingContext) {
+        final TypeMethodsIntrospector<?> introspector = processingContext.type().methods();
+        if (introspector.annotatedWith(LockMode.class).isEmpty()) {
+            return false;
+        }
+        return !introspector.annotatedWith(FlushMode.class).isEmpty();
+    }
+
+    @Override
     protected <T> void configure(final ApplicationContext context, final QueryExecutionContext componentContext,
                                  final ComponentProcessingContext<T> processingContext) {
 

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryExecutionContextPostProcessor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryExecutionContextPostProcessor.java
@@ -1,0 +1,40 @@
+package org.dockbox.hartshorn.jpa.query;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
+import org.dockbox.hartshorn.component.processing.ContextConfiguringComponentProcessor;
+import org.dockbox.hartshorn.util.introspect.TypeMethodsIntrospector;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+
+import java.lang.annotation.Annotation;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+public class QueryExecutionContextPostProcessor extends ContextConfiguringComponentProcessor<QueryExecutionContext> {
+
+    public QueryExecutionContextPostProcessor() {
+        super(QueryExecutionContext.class);
+    }
+
+    @Override
+    protected <T> void configure(final ApplicationContext context, final QueryExecutionContext componentContext,
+                                 final ComponentProcessingContext<T> processingContext) {
+
+        final TypeMethodsIntrospector<T> methods = processingContext.type().methods();
+        this.configure(methods, LockMode.class, LockMode::value, componentContext::lockMode);
+        this.configure(methods, FlushMode.class, FlushMode::value, componentContext::flushMode);
+    }
+
+    private <A extends Annotation, E> void configure(final TypeMethodsIntrospector<?> methods, final Class<A> annotation,
+                                                     final Function<A, E> mapper, final BiConsumer<MethodView<?, ?>, E> setter) {
+        for (final MethodView<?, ?> view : methods.annotatedWith(annotation)) {
+            final A a = view.annotations().get(annotation).get();
+            setter.accept(view, mapper.apply(a));
+        }
+    }
+
+    @Override
+    protected QueryExecutionContext createContext(final ApplicationContext context, final ComponentProcessingContext<?> processingContext) {
+        return new QueryExecutionContext();
+    }
+}

--- a/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/LockFlushModeTests.java
+++ b/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/LockFlushModeTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.dockbox.hartshorn.jpa;
+
+import com.mysql.cj.jdbc.Driver;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.jpa.annotations.UsePersistence;
+import org.dockbox.hartshorn.jpa.query.QueryExecutionContext;
+import org.dockbox.hartshorn.jpa.query.context.JpaQueryContext;
+import org.dockbox.hartshorn.jpa.query.context.unnamed.UnnamedJpaQueryContextCreator;
+import org.dockbox.hartshorn.jpa.remote.DataSourceConfiguration;
+import org.dockbox.hartshorn.jpa.remote.DataSourceList;
+import org.dockbox.hartshorn.proxy.MethodInterceptorContext;
+import org.dockbox.hartshorn.proxy.ProxyManager;
+import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.testsuite.TestComponents;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.option.Option;
+import org.hibernate.dialect.MySQLDialect;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.Query;
+
+@HartshornTest(includeBasePackages = false)
+@TestComponents({
+        PersistentTestComponentsService.class,
+        LockFlushModeUserJpaRepository.class,
+})
+@UsePersistence
+@Testcontainers(disabledWithoutDocker = true)
+public class LockFlushModeTests {
+
+    @Container
+    private static final MySQLContainer<?> mySql = new MySQLContainer<>(MySQLContainer.NAME).withDatabaseName(SqlServiceTest.DEFAULT_DATABASE);
+
+    @Inject
+    private UnnamedJpaQueryContextCreator contextCreator;
+
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @BeforeEach
+    void prepareDataSource() {
+        final DataSourceConfiguration configuration = SqlServiceTest.jdbc("mysql", Driver.class, mySql, MySQLDialect.class, MySQLContainer.MYSQL_PORT);
+        this.applicationContext.get(DataSourceList.class).add("users", configuration);
+    }
+
+    @Test
+    void testQueryExecutionContextIsConfigured() {
+        final LockFlushModeUserJpaRepository repository = this.applicationContext.get(LockFlushModeUserJpaRepository.class);
+        final ProxyManager<LockFlushModeUserJpaRepository> manager = this.applicationContext.environment().manager(repository).get();
+        final Option<QueryExecutionContext> executionContextOption = manager.first(QueryExecutionContext.class);
+
+        Assertions.assertTrue(executionContextOption.present());
+
+        final QueryExecutionContext executionContext = executionContextOption.get();
+        final TypeView<LockFlushModeUserJpaRepository> repositoryView = this.applicationContext.environment().introspect(repository);
+
+        final MethodView<LockFlushModeUserJpaRepository, ?> findWaldoWithLockMode = repositoryView.methods().named("findWaldoWithLockMode").get();
+        Assertions.assertEquals(LockModeType.PESSIMISTIC_WRITE, executionContext.lockMode(findWaldoWithLockMode));
+
+        final MethodView<LockFlushModeUserJpaRepository, ?> findWaldoWithFlushMode = repositoryView.methods().named("findWaldoWithFlushMode").get();
+        Assertions.assertEquals(FlushModeType.COMMIT, executionContext.flushMode(findWaldoWithFlushMode));
+    }
+
+    @Test
+    void testLockModeIsPresentInPersistenceCapable() {
+        final Query query = this.createNonExecutedQuery("findWaldoWithLockMode");
+        final LockModeType lockMode = query.getLockMode();
+
+        Assertions.assertEquals(LockModeType.PESSIMISTIC_WRITE, lockMode);
+    }
+
+    @Test
+    void testFlushModeIsPresentInPersistenceCapable() {
+        final Query query = this.createNonExecutedQuery("findWaldoWithFlushMode");
+        final FlushModeType flushMode = query.getFlushMode();
+
+        Assertions.assertEquals(FlushModeType.COMMIT, flushMode);
+    }
+
+    private Query createNonExecutedQuery(final String methodName) {
+        final LockFlushModeUserJpaRepository repository = this.applicationContext.get(LockFlushModeUserJpaRepository.class);
+        final TypeView<LockFlushModeUserJpaRepository> repositoryView = this.applicationContext.environment().introspect(repository);
+        final MethodView<LockFlushModeUserJpaRepository, ?> methodView = repositoryView.methods().named(methodName).get();
+        final MethodInterceptorContext<LockFlushModeUserJpaRepository, ?> interceptorContext = new MethodInterceptorContext<>(methodView, new Object[0], repository, null, null, null);
+
+        final TypeView<User> entityType = this.applicationContext.environment().introspect(User.class);
+        final JpaQueryContext queryContext = this.contextCreator.create(this.applicationContext, interceptorContext, entityType, repository).get();
+
+        return queryContext.query();
+    }
+}

--- a/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/LockFlushModeUserJpaRepository.java
+++ b/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/LockFlushModeUserJpaRepository.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.dockbox.hartshorn.jpa;
+
+import org.dockbox.hartshorn.component.Service;
+import org.dockbox.hartshorn.jpa.JpaRepository;
+import org.dockbox.hartshorn.jpa.annotations.DataSource;
+import org.dockbox.hartshorn.jpa.annotations.Query;
+import org.dockbox.hartshorn.jpa.query.FlushMode;
+import org.dockbox.hartshorn.jpa.query.LockMode;
+
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.LockModeType;
+
+@Service(lazy = true)
+@DataSource("users")
+public interface LockFlushModeUserJpaRepository extends JpaRepository<User, Long> {
+
+    @LockMode(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM users u WHERE u.name = 'Waldo'")
+    default void findWaldoWithLockMode() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @FlushMode(FlushModeType.COMMIT)
+    @Query("SELECT u FROM users u WHERE u.name = 'Waldo'")
+    default void findWaldoWithFlushMode() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+}

--- a/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/NamedQueryRepositoryTests.java
+++ b/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/NamedQueryRepositoryTests.java
@@ -19,7 +19,6 @@ package test.org.dockbox.hartshorn.jpa;
 import com.mysql.cj.jdbc.Driver;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.config.annotations.UseConfigurations;
 import org.dockbox.hartshorn.jpa.annotations.UsePersistence;
 import org.dockbox.hartshorn.jpa.remote.DataSourceConfiguration;
 import org.dockbox.hartshorn.jpa.remote.DataSourceList;
@@ -36,7 +35,6 @@ import jakarta.inject.Inject;
 
 @Testcontainers(disabledWithoutDocker = true)
 @UsePersistence
-@UseConfigurations
 @HartshornTest(includeBasePackages = false)
 @TestComponents({ UserNamedQueryRepository.class, PersistentTestComponentsService.class})
 public class NamedQueryRepositoryTests {

--- a/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/QueryRepositoryTests.java
+++ b/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/QueryRepositoryTests.java
@@ -19,7 +19,6 @@ package test.org.dockbox.hartshorn.jpa;
 import com.mysql.cj.jdbc.Driver;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.config.annotations.UseConfigurations;
 import org.dockbox.hartshorn.jpa.annotations.UsePersistence;
 import org.dockbox.hartshorn.jpa.remote.DataSourceConfiguration;
 import org.dockbox.hartshorn.jpa.remote.DataSourceList;
@@ -41,7 +40,6 @@ import jakarta.persistence.TransactionRequiredException;
 
 @Testcontainers(disabledWithoutDocker = true)
 @UsePersistence
-@UseConfigurations
 @HartshornTest(includeBasePackages = false)
 @TestComponents({UserQueryRepository.class, PersistentTestComponentsService.class})
 public class QueryRepositoryTests {

--- a/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/SqlServiceTest.java
+++ b/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/SqlServiceTest.java
@@ -22,7 +22,6 @@ import com.mysql.cj.jdbc.Driver;
 import org.apache.derby.jdbc.EmbeddedDriver;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentPostConstructor;
-import org.dockbox.hartshorn.config.annotations.UseConfigurations;
 import org.dockbox.hartshorn.config.properties.PropertyHolder;
 import org.dockbox.hartshorn.jpa.JpaRepository;
 import org.dockbox.hartshorn.jpa.JpaRepositoryFactory;
@@ -72,7 +71,6 @@ import jakarta.persistence.EntityManager;
 @HartshornTest(includeBasePackages = false)
 @Testcontainers(disabledWithoutDocker = true)
 @UsePersistence
-@UseConfigurations
 @TestComponents({UserJpaRepository.class, PersistentTestComponentsService.class})
 class SqlServiceTest {
 

--- a/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/TransactionalServiceTests.java
+++ b/hartshorn-jpa/src/test/java/test/org/dockbox/hartshorn/jpa/TransactionalServiceTests.java
@@ -42,7 +42,8 @@ import jakarta.persistence.EntityManager;
 @Testcontainers(disabledWithoutDocker = true)
 public class TransactionalServiceTests {
 
-    @Container private static final MySQLContainer<?> mySql = new MySQLContainer<>(MySQLContainer.NAME).withDatabaseName(SqlServiceTest.DEFAULT_DATABASE);
+    @Container
+    private static final MySQLContainer<?> mySql = new MySQLContainer<>(MySQLContainer.NAME).withDatabaseName(SqlServiceTest.DEFAULT_DATABASE);
 
     @InjectTest
     @TestComponents(TransactionalService.class)


### PR DESCRIPTION
# Description
Currently it is not possible to configure the lock mode of an action which will be performed through JPA repositories, whether these are custom or predefined query actions.

These changes add support for lockmode specifications, so this can be prepared for the entity manager action. The lockmodes are provided by Jakarta's LockModeType.

```java
@Service
public interface UserRepository extends JpaRepository<User, Long> {
    @LockMode(LockModeType.OPTIMISTIC)
    @Query(...)
    List<User> lockAllById(Long id);
}
```

Fixes #853

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
