### PR TITLE
#890 Delete `lombok.config`

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,1 +1,0 @@
-lombok.accessors.fluent=true


### PR DESCRIPTION
# Description
Lombok was removed from the build configuration in March 2022 (https://github.com/Dockbox-OSS/Hartshorn/commit/1414d99630dffe4ddafd25d159493dafe650d992), but the configuration was not correctly cleaned up

This PR removes the last remaining artifact of Lombok, which is the configuration file for it (`lombok.config`)

Fixes #890

## Type of change
- [x] Chore (changes to the build process or auxiliary tools)

# Checklist:
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
