### PR TITLE
#911 Add isRecord to TypeView

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionTypeView.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionTypeView.java
@@ -155,6 +155,11 @@ public class ReflectionTypeView<T> extends ReflectionAnnotatedElementView implem
     }
 
     @Override
+    public boolean isRecord() {
+        return this.type.isRecord();
+    }
+
+    @Override
     public boolean isAbstract() {
         return this.isInterface() || Modifier.isAbstract(this.type.getModifiers());
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/view/TypeView.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/view/TypeView.java
@@ -40,6 +40,8 @@ public interface TypeView<T> extends AnnotatedElementView, ModifierCarrierView {
 
     boolean isInterface();
 
+    boolean isRecord();
+
     boolean isAbstract();
 
     boolean isFinal();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardTypeView.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardTypeView.java
@@ -73,6 +73,11 @@ public class WildcardTypeView implements TypeView<Object> {
     }
 
     @Override
+    public boolean isRecord() {
+        return false;
+    }
+
+    @Override
     public boolean isAbstract() {
         return false;
     }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ReflectTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ReflectTests.java
@@ -467,4 +467,72 @@ public class ReflectTests {
         Assertions.assertTrue(second.is(String.class));
         Assertions.assertFalse(second.isWildcard());
     }
+
+    @Test
+    void concreteClassIsCorrectlyIdentified() {
+        final TypeView<ConcreteClass> type = this.introspector.introspect(ConcreteClass.class);
+        Assertions.assertFalse(type.isAbstract());
+        Assertions.assertFalse(type.isInterface());
+        Assertions.assertFalse(type.isRecord());
+        Assertions.assertFalse(type.isEnum());
+        Assertions.assertFalse(type.isAnnotation());
+    }
+
+    @Test
+    void abstractClassIsCorrectlyIdentified() {
+        final TypeView<AbstractClass> type = this.introspector.introspect(AbstractClass.class);
+        Assertions.assertTrue(type.isAbstract());
+        Assertions.assertFalse(type.isInterface());
+        Assertions.assertFalse(type.isRecord());
+        Assertions.assertFalse(type.isEnum());
+        Assertions.assertFalse(type.isAnnotation());
+    }
+
+    @Test
+    void interfaceIsCorrectlyIdentified() {
+        final TypeView<Interface> type = this.introspector.introspect(Interface.class);
+        Assertions.assertTrue(type.isAbstract());
+        Assertions.assertTrue(type.isInterface());
+        Assertions.assertFalse(type.isRecord());
+        Assertions.assertFalse(type.isEnum());
+        Assertions.assertFalse(type.isAnnotation());
+    }
+
+    @Test
+    void recordIsCorrectlyIdentified() {
+        final TypeView<RecordType> type = this.introspector.introspect(RecordType.class);
+        Assertions.assertFalse(type.isAbstract());
+        Assertions.assertFalse(type.isInterface());
+        Assertions.assertTrue(type.isRecord());
+        Assertions.assertFalse(type.isEnum());
+        Assertions.assertFalse(type.isAnnotation());
+    }
+
+    @Test
+    void enumIsCorrectlyIdentified() {
+        final TypeView<EnumType> type = this.introspector.introspect(EnumType.class);
+        Assertions.assertFalse(type.isAbstract());
+        Assertions.assertFalse(type.isInterface());
+        Assertions.assertFalse(type.isRecord());
+        Assertions.assertTrue(type.isEnum());
+        Assertions.assertFalse(type.isAnnotation());
+    }
+
+    @Test
+    void annotationIsCorrectlyIdentified() {
+        final TypeView<AnnotationType> type = this.introspector.introspect(AnnotationType.class);
+        Assertions.assertTrue(type.isAbstract());
+        Assertions.assertTrue(type.isInterface());
+        Assertions.assertFalse(type.isRecord());
+        Assertions.assertFalse(type.isEnum());
+        Assertions.assertTrue(type.isAnnotation());
+    }
+
+    private static class ConcreteClass {}
+    private abstract static class AbstractClass {}
+    private interface Interface {}
+    private record RecordType() {}
+    private enum EnumType {}
+    private @interface AnnotationType {}
+
 }


### PR DESCRIPTION
# Description
TypeView has several methods to check if the introspected type is a specific type (e.g. enum, interface), but lacks a similar check for records. 

This PR fixes this by adding `isRecord`. In reflection introspectors this is delegated to the represented `Class`, for wildcards this will always return false.

Fixes #911

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
