### PR TITLE
#917 Re-usable resource lookups with dynamically determined strategies

### DIFF
--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/annotations/Configuration.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/annotations/Configuration.java
@@ -19,8 +19,8 @@ package org.dockbox.hartshorn.config.annotations;
 import org.dockbox.hartshorn.config.ConfigurationServicePreProcessor;
 import org.dockbox.hartshorn.config.FileFormats;
 import org.dockbox.hartshorn.config.ObjectMapper;
-import org.dockbox.hartshorn.config.resource.ClassPathResourceLookupStrategy;
-import org.dockbox.hartshorn.config.resource.ResourceLookupStrategy;
+import org.dockbox.hartshorn.util.resources.ClassPathResourceLookupStrategy;
+import org.dockbox.hartshorn.util.resources.ResourceLookupStrategy;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ClassLoaderClasspathResourceLocator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ClassLoaderClasspathResourceLocator.java
@@ -17,7 +17,7 @@
 package org.dockbox.hartshorn.application.environment;
 
 import org.dockbox.hartshorn.application.Hartshorn;
-import org.dockbox.hartshorn.util.Resources;
+import org.dockbox.hartshorn.util.resources.Resources;
 import org.dockbox.hartshorn.util.option.Attempt;
 
 import java.io.File;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ClassPathResourceLookupStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ClassPathResourceLookupStrategy.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.dockbox.hartshorn.config.resource;
+package org.dockbox.hartshorn.util.resources;
 
 import org.dockbox.hartshorn.application.environment.ClasspathResourceLocator;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
@@ -31,8 +31,10 @@ import java.util.stream.Collectors;
  */
 public class ClassPathResourceLookupStrategy implements ResourceLookupStrategy {
 
+    public static final String NAME = "classpath";
+
     public String name() {
-        return "classpath";
+        return NAME;
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/FallbackResourceLookup.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/FallbackResourceLookup.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.util.resources;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class FallbackResourceLookup implements ResourceLookup {
+
+    private static final Pattern STRATEGY_PATTERN = Pattern.compile("(.+):(.+)");
+
+    private final Map<String, ResourceLookupStrategy> strategies = new ConcurrentHashMap<>();
+    private final ApplicationContext applicationContext;
+    private final ResourceLookupStrategy fallbackStrategy;
+
+    public FallbackResourceLookup(final ApplicationContext applicationContext, final ResourceLookupStrategy fallbackStrategy) {
+        this.applicationContext = applicationContext;
+        this.fallbackStrategy = fallbackStrategy;
+
+        applicationContext.first(ResourceLookupStrategyContext.class)
+                .peek(strategyContext -> strategyContext.strategies().forEach(this::addLookupStrategy));
+    }
+
+    @Override
+    public Set<URI> lookup(final String path) {
+        String matchedSource = path;
+        final Matcher matcher = STRATEGY_PATTERN.matcher(matchedSource);
+
+        ResourceLookupStrategy strategy = this.fallbackStrategy;
+        if (matcher.find()) {
+            strategy = this.strategies.getOrDefault(matcher.group(1), strategy);
+            matchedSource = matcher.group(2);
+        }
+
+        return strategy.lookup(this.applicationContext, matchedSource);
+    }
+
+    @Override
+    public void addLookupStrategy(final ResourceLookupStrategy strategy) {
+        if (this.strategies.containsKey(strategy.name())) {
+            throw new IllegalArgumentException("A strategy for source " + strategy.name() + " already exists");
+        }
+        this.strategies.put(strategy.name(), strategy);
+    }
+
+    @Override
+    public void removeLookupStrategy(final ResourceLookupStrategy strategy) {
+        this.strategies.remove(strategy.name());
+    }
+
+    @Override
+    public Set<ResourceLookupStrategy> strategies() {
+        return Set.copyOf(this.strategies.values());
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/FileSystemLookupStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/FileSystemLookupStrategy.java
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package org.dockbox.hartshorn.config;
+package org.dockbox.hartshorn.util.resources;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.config.resource.ResourceLookupStrategy;
 
 import java.io.File;
 import java.net.URI;
@@ -31,13 +30,15 @@ import java.util.stream.Collectors;
  * the path representation, typically this will be similar to {@code /config/{owner-id}/}.
  *
  * <p>This strategy does not require the name to be present, as it is the default strategy used in
- * {@link ConfigurationServicePreProcessor}.
+ * {@link Resources#getResourceURIs(ApplicationContext, String, ResourceLookupStrategy...)}.
  */
 public class FileSystemLookupStrategy implements ResourceLookupStrategy {
 
+    public static final String NAME = "fs";
+
     @Override
     public String name() {
-        return "fs";
+        return NAME;
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/MissingSourceException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/MissingSourceException.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.dockbox.hartshorn.config.resource;
+package org.dockbox.hartshorn.util.resources;
 
 import org.dockbox.hartshorn.util.ApplicationRuntimeException;
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ResourceLookup.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ResourceLookup.java
@@ -14,22 +14,19 @@
  * limitations under the License.
  */
 
-package org.dockbox.hartshorn.config.resource;
-
-import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.config.annotations.Configuration;
+package org.dockbox.hartshorn.util.resources;
 
 import java.net.URI;
 import java.util.Set;
 
-/**
- * Defines how a {@link Configuration#value() resource} is looked up while processing types annotated with
- * {@link Configuration}.
- */
-public interface ResourceLookupStrategy {
-    String name();
+public interface ResourceLookup {
 
-    Set<URI> lookup(ApplicationContext context, String path);
+    Set<URI> lookup(String path);
 
-    URI baseUrl(ApplicationContext context);
+    void addLookupStrategy(ResourceLookupStrategy strategy);
+
+    void removeLookupStrategy(ResourceLookupStrategy strategy);
+
+    Set<ResourceLookupStrategy> strategies();
+
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ResourceLookupStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ResourceLookupStrategy.java
@@ -14,33 +14,21 @@
  * limitations under the License.
  */
 
-package org.dockbox.hartshorn.config;
+package org.dockbox.hartshorn.util.resources;
 
-import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
 
 import java.net.URI;
+import java.util.Set;
 
-public class ConfigurationURIContext {
+/**
+ * Defines how a resource is looked up when using
+ */
+public interface ResourceLookupStrategy {
 
-    private final URI uri;
-    private final ComponentKey<?> key;
-    private final String source;
+    String name();
 
-    public ConfigurationURIContext(final URI uri, final ComponentKey<?> key, final String source) {
-        this.uri = uri;
-        this.key = key;
-        this.source = source;
-    }
+    Set<URI> lookup(ApplicationContext context, String path);
 
-    public URI uri() {
-        return this.uri;
-    }
-
-    public ComponentKey<?> key() {
-        return this.key;
-    }
-
-    public String source() {
-        return this.source;
-    }
+    URI baseUrl(ApplicationContext context);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ResourceLookupStrategyBeanObserver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ResourceLookupStrategyBeanObserver.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.util.resources;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.beans.BeanContext;
+import org.dockbox.hartshorn.beans.BeanObserver;
+import org.dockbox.hartshorn.component.Service;
+import org.dockbox.hartshorn.context.ContextKey;
+
+import java.util.List;
+
+@Service
+public class ResourceLookupStrategyBeanObserver implements BeanObserver {
+
+    @Override
+    public void onBeansCollected(final ApplicationContext applicationContext, final BeanContext beanContext) {
+        final List<ResourceLookupStrategy> strategies = beanContext.provider().all(ResourceLookupStrategy.class);
+        final ContextKey<ResourceLookupStrategyContext> contextKey = ContextKey.builder(ResourceLookupStrategyContext.class)
+                .fallback(ResourceLookupStrategyContext::new)
+                .build();
+        final ResourceLookupStrategyContext strategyContext = applicationContext.first(contextKey).get();
+        strategies.forEach(strategyContext::addLookupStrategy);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ResourceLookupStrategyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ResourceLookupStrategyContext.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.util.resources;
+
+import org.dockbox.hartshorn.context.DefaultContext;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ResourceLookupStrategyContext extends DefaultContext {
+
+    private final Set<ResourceLookupStrategy> strategies = ConcurrentHashMap.newKeySet();
+
+    public void addLookupStrategy(final ResourceLookupStrategy strategy) {
+        this.strategies.add(strategy);
+    }
+
+    public void removeLookupStrategy(final ResourceLookupStrategy strategy) {
+        this.strategies.remove(strategy);
+    }
+
+    public Set<ResourceLookupStrategy> strategies() {
+        return Collections.unmodifiableSet(this.strategies);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ResourceProviders.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ResourceProviders.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.util.resources;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.beans.Bean;
+import org.dockbox.hartshorn.component.Service;
+import org.dockbox.hartshorn.component.processing.Binds;
+
+@Service
+public class ResourceProviders {
+
+    @Bean
+    public static ResourceLookupStrategy classPathResourceLookupStrategy() {
+        return new ClassPathResourceLookupStrategy();
+    }
+
+    @Bean
+    public static ResourceLookupStrategy fileSystemResourceLookupStrategy() {
+        return new FileSystemLookupStrategy();
+    }
+
+    @Binds
+    public ResourceLookup resourceLookup(final ApplicationContext applicationContext) {
+        return new FallbackResourceLookup(applicationContext, new FileSystemLookupStrategy());
+    }
+
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/Resources.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/Resources.java
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package org.dockbox.hartshorn.util;
+package org.dockbox.hartshorn.util.resources;
 
 import org.dockbox.hartshorn.application.Hartshorn;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -72,15 +74,21 @@ public final class Resources {
     }
 
     public static Set<File> getResourcesAsFiles(final String resource) throws IOException {
-        return getResourceURLs(resource).stream()
-                .map(url -> new File(url.getFile()))
-                .collect(Collectors.toUnmodifiableSet());
+        return getResourcesAsFiles(getClassLoader(), resource);
     }
 
     public static Set<File> getResourcesAsFiles(final ClassLoader loader, final String resource) throws IOException {
         return getResourceURLs(loader, resource).stream()
                 .map(url -> new File(url.getFile()))
                 .collect(Collectors.toUnmodifiableSet());
+    }
+
+    public static Set<URI> getResourceURIs(final ApplicationContext applicationContext, final String resource, final ResourceLookupStrategy... strategies) {
+        final Set<URI> uris = new HashSet<>();
+        for (final ResourceLookupStrategy strategy : strategies) {
+            uris.addAll(strategy.lookup(applicationContext, resource));
+        }
+        return Collections.unmodifiableSet(uris);
     }
 
     private static ClassLoader getClassLoader() {

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ResourceLookupTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ResourceLookupTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.dockbox.hartshorn;
+
+import org.dockbox.hartshorn.application.environment.ApplicationFSProvider;
+import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.util.resources.ResourceLookup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+
+@HartshornTest
+public class ResourceLookupTests {
+
+    @Inject
+    private ResourceLookup resourceLookup;
+
+    @Inject
+    private ApplicationFSProvider fileSystemProvider;
+
+    @Test
+    void testClasspathLookup() {
+        this.testResourceLookup("classpath:sample.txt");
+    }
+
+    @Test
+    void testFilesystemLookup() throws IOException {
+        this.createLocalFile();
+        this.testResourceLookup("fs:sample.txt");
+    }
+
+    @Test
+    void testUnnamedResourceLookup() throws IOException {
+        this.createLocalFile();
+        this.testResourceLookup("sample.txt");
+    }
+
+    private void testResourceLookup(final String path) {
+        final Set<URI> lookup = this.resourceLookup.lookup(path);
+        Assertions.assertFalse(lookup.isEmpty());
+        Assertions.assertEquals(1, lookup.size());
+
+        final URI uri = lookup.iterator().next();
+        final File file = new File(uri);
+
+        Assertions.assertEquals("sample.txt", file.getName());
+        Assertions.assertTrue(file.exists());
+    }
+
+    private void createLocalFile() throws IOException {
+        final Path path = this.fileSystemProvider.applicationPath();
+        Files.createFile(path.resolve("sample.txt"));
+    }
+}

--- a/hartshorn-core/src/test/resources/sample.txt
+++ b/hartshorn-core/src/test/resources/sample.txt
@@ -1,0 +1,1 @@
+Hello world!


### PR DESCRIPTION
# Description
In Config there are various strategies to look up resources (e.g. from filesystem or classpath). This is however not easily accessible for use with dynamic lookups. Currently this is only supported in the component processor for configuration components.

These changes move the lookup strategies to core, and add a common `ResourceLookup` which can dynamically determine which strategy to use for resource lookups.

Fixes #917

## Type of change
- [x] New feature (non-breaking change that does affect the code)
- [x] Refactor (code changes that do not affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
