### PR TITLE
#925 Use file reference instead of string representation for `copyArtifacts` source and target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,15 +153,15 @@ allprojects {
         // This is done to ensure that the output of all modules is placed in the same directory, and
         // can easily be accessed for further local development.
         register<Copy>("copyArtifacts") {
-            doLast {
-                val version = project.version
-                val destinationFolder = "$rootDir/hartshorn-assembly/distributions/$version"
-                val sourceFolder = "$buildDir/libs"
+            val version = rootProject.version
+            val destinationFolder = "$rootDir/hartshorn-assembly/distributions/$version"
+            val sourceFolder = "$buildDir/libs"
 
-                from(sourceFolder)
-                include("*$version*.jar")
-                into(destinationFolder)
-            }
+            if (!File(destinationFolder).exists()) mkdir(destinationFolder)
+
+            from(file(sourceFolder))
+            include("*$version*.jar")
+            into(file(destinationFolder))
         }
 
         // Configure existing tasks


### PR DESCRIPTION
# Description
Fixes #925

## Type of change
- [x] Chore (changes to the build process or auxiliary tools)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] Related issue number is linked in pull request title
