### PR TITLE
#780 Handle ambiguous method definitions and calls

### DIFF
--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/HslExpression.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/HslExpression.java
@@ -18,6 +18,7 @@ package org.dockbox.hartshorn.hsl;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.hsl.customizer.ScriptContext;
+import org.dockbox.hartshorn.hsl.interpreter.ResultCollector;
 import org.dockbox.hartshorn.hsl.runtime.ScriptRuntime;
 import org.dockbox.hartshorn.hsl.runtime.ValidateExpressionRuntime;
 
@@ -45,7 +46,11 @@ public class HslExpression extends HslScript {
 
     public boolean valid() {
         final ScriptContext context = this.evaluate();
-        return ValidateExpressionRuntime.valid(context);
+        return this.valid(context);
+    }
+
+    public boolean valid(final ResultCollector collector) {
+        return ValidateExpressionRuntime.valid(collector);
     }
 
     @Override

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/HslLanguageFactory.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/HslLanguageFactory.java
@@ -20,6 +20,7 @@ import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.factory.Factory;
 import org.dockbox.hartshorn.hsl.interpreter.Interpreter;
+import org.dockbox.hartshorn.hsl.runtime.ExecutionOptions;
 import org.dockbox.hartshorn.hsl.interpreter.ResultCollector;
 import org.dockbox.hartshorn.hsl.lexer.Lexer;
 import org.dockbox.hartshorn.hsl.modules.NativeModule;
@@ -45,5 +46,8 @@ public interface HslLanguageFactory {
 
     @Factory
     Interpreter interpreter(ResultCollector resultCollector, Map<String, NativeModule> modules);
+
+    @Factory
+    Interpreter interpreter(ResultCollector resultCollector, Map<String, NativeModule> modules, ExecutionOptions options);
 
 }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ConditionContext.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ConditionContext.java
@@ -18,6 +18,7 @@ package org.dockbox.hartshorn.hsl.condition;
 
 import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.hsl.customizer.CodeCustomizer;
+import org.dockbox.hartshorn.hsl.runtime.ExecutionOptions;
 import org.dockbox.hartshorn.hsl.modules.NativeModule;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
@@ -125,4 +126,8 @@ public interface ConditionContext extends Context {
      * @return The modules.
      */
     Map<String, NativeModule> externalModules();
+
+    void interpreterOptions(ExecutionOptions executionOptions);
+
+    ExecutionOptions interpreterOptions();
 }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ExpressionConditionContext.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ExpressionConditionContext.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.hsl.condition;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.context.DefaultContext;
 import org.dockbox.hartshorn.hsl.customizer.CodeCustomizer;
+import org.dockbox.hartshorn.hsl.runtime.ExecutionOptions;
 import org.dockbox.hartshorn.hsl.modules.NativeModule;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
@@ -43,6 +44,7 @@ public class ExpressionConditionContext extends DefaultContext implements Condit
     private final Map<String, NativeModule> externalModules = new ConcurrentHashMap<>();
     private final ApplicationContext applicationContext;
 
+    private ExecutionOptions executionOptions = new ExecutionOptions();
     private boolean includeApplicationContext;
 
     public ExpressionConditionContext(final ApplicationContext applicationContext) {
@@ -198,5 +200,23 @@ public class ExpressionConditionContext extends DefaultContext implements Condit
     @Override
     public Map<String, NativeModule> externalModules() {
         return this.externalModules;
+    }
+
+    /**
+     * Gets the interpreter options for this context, overriding any existing settings.
+     * @param executionOptions The interpreter options.
+     */
+    @Override
+    public void interpreterOptions(final ExecutionOptions executionOptions) {
+        this.executionOptions = executionOptions;
+    }
+
+    /**
+     * Gets the interpreter options for this context.
+     * @return The interpreter options.
+     */
+    @Override
+    public ExecutionOptions interpreterOptions() {
+        return this.executionOptions;
     }
 }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Array.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Array.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.hsl.interpreter;
 
 import org.dockbox.hartshorn.hsl.objects.PropertyContainer;
+import org.dockbox.hartshorn.hsl.runtime.ExecutionOptions;
 import org.dockbox.hartshorn.hsl.token.Token;
 
 import java.util.Arrays;
@@ -88,12 +89,12 @@ public class Array implements Iterable<Object>, PropertyContainer {
     }
 
     @Override
-    public void set(final Token name, final Object value, final VariableScope fromScope) {
+    public void set(final Token name, final Object value, final VariableScope fromScope, final ExecutionOptions options) {
         throw new UnsupportedOperationException("Cannot set properties on arrays.");
     }
 
     @Override
-    public Object get(final Token name, final VariableScope fromScope) {
+    public Object get(final Token name, final VariableScope fromScope, final ExecutionOptions interpreter) {
         if ("length".equals(name.lexeme())) {
             return this.values.length;
         } else {

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AbstractNativeModule.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AbstractNativeModule.java
@@ -109,6 +109,8 @@ public abstract class AbstractNativeModule implements NativeModule {
             final TypeView<?> typeView = this.applicationContext().environment().introspect(this.moduleClass());
             for (final MethodView<?, ?> method : typeView.methods().all()) {
                 if (!method.isPublic()) continue;
+                if (method.declaredBy().is(Object.class)) continue;
+
                 final Token token = new Token(TokenType.IDENTIFIER, method.name(), -1, -1);
 
                 final List<Parameter> parameters = new ArrayList<>();

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AmbiguousLibraryFunction.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AmbiguousLibraryFunction.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.hsl.modules;
 
 import org.dockbox.hartshorn.hsl.interpreter.Interpreter;

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AmbiguousLibraryFunction.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AmbiguousLibraryFunction.java
@@ -1,0 +1,59 @@
+package org.dockbox.hartshorn.hsl.modules;
+
+import org.dockbox.hartshorn.hsl.interpreter.Interpreter;
+import org.dockbox.hartshorn.hsl.objects.CallableNode;
+import org.dockbox.hartshorn.hsl.objects.InstanceReference;
+import org.dockbox.hartshorn.hsl.runtime.RuntimeError;
+import org.dockbox.hartshorn.hsl.token.Token;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+
+import java.util.List;
+import java.util.Set;
+
+public class AmbiguousLibraryFunction implements CallableNode {
+
+    private final Set<HslLibrary> libraries;
+
+    public AmbiguousLibraryFunction(final Set<HslLibrary> libraries) {
+        this.libraries = libraries;
+    }
+
+    public Set<HslLibrary> libraries() {
+        return this.libraries;
+    }
+
+    @Override
+    public Object call(final Token at, final Interpreter interpreter, final InstanceReference instance, final List<Object> arguments) throws ApplicationException {
+        final List<HslLibrary> applicableLibraries = this.libraries.stream()
+                .filter(library -> library.declaration().params().size() == arguments.size())
+                .toList();
+
+        if (applicableLibraries.isEmpty()) {
+            throw new RuntimeError(at, "No applicable library found for " + arguments.size() + " arguments");
+        }
+        else if (applicableLibraries.size() > 1) {
+            throw new RuntimeError(at, "Multiple applicable libraries found for " + arguments.size() + " arguments");
+        }
+        else {
+            final HslLibrary library = applicableLibraries.get(0);
+            return library.call(at, interpreter, instance, arguments);
+        }
+    }
+
+    private boolean isApplicableFor(final HslLibrary library, final List<Object> arguments) {
+        if (library.declaration().params().size() != arguments.size()) {
+            return false;
+        }
+        final MethodView<?, ?> method = library.declaration().method();
+        final List<TypeView<?>> parameters = method.parameters().types();
+        for (int i = 0; i < parameters.size(); i++) {
+            final TypeView<?> parameter = parameters.get(i);
+            final Object argument = arguments.get(i);
+            if (argument == null && !parameter.isPrimitive()) continue;
+            if (!parameter.isParentOf(argument.getClass())) return false;
+        }
+        return true;
+    }
+}

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/HslLibrary.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/HslLibrary.java
@@ -46,6 +46,10 @@ public class HslLibrary implements CallableNode {
         this.externalModules = externalModules;
     }
 
+    public HslLibrary(final NativeFunctionStatement declaration, final String moduleName, final NativeModule externalModule) {
+        this(declaration, Map.of(moduleName, externalModule));
+    }
+
     @Override
     public Object call(final Token at, final Interpreter interpreter, final InstanceReference instance, final List<Object> arguments) throws ApplicationException {
         final String moduleName = this.declaration.moduleName().lexeme();

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/HslLibrary.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/HslLibrary.java
@@ -50,6 +50,10 @@ public class HslLibrary implements CallableNode {
         this(declaration, Map.of(moduleName, externalModule));
     }
 
+    public NativeFunctionStatement declaration() {
+        return this.declaration;
+    }
+
     @Override
     public Object call(final Token at, final Interpreter interpreter, final InstanceReference instance, final List<Object> arguments) throws ApplicationException {
         final String moduleName = this.declaration.moduleName().lexeme();

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/PropertyContainer.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/PropertyContainer.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.hsl.objects;
 
+import org.dockbox.hartshorn.hsl.runtime.ExecutionOptions;
 import org.dockbox.hartshorn.hsl.interpreter.VariableScope;
 import org.dockbox.hartshorn.hsl.runtime.RuntimeError;
 import org.dockbox.hartshorn.hsl.token.Token;
@@ -37,9 +38,11 @@ public interface PropertyContainer {
      *
      * @param name The name of the property.
      * @param value The value of the property.
+     * @param options The execution options.
+     *
      * @throws RuntimeError If the property is not supported or not accessible.
      */
-    void set(Token name, Object value, VariableScope fromScope);
+    void set(Token name, Object value, VariableScope fromScope, ExecutionOptions options);
 
     /**
      * Gets a property from the instance. This may either return a {@link CallableNode}
@@ -48,8 +51,10 @@ public interface PropertyContainer {
      * is thrown.
      *
      * @param name The name of the property.
+     * @param options The execution options.
+     *
      * @return The value of the property.
      * @throws RuntimeError If the property is not supported or accessible.
      */
-    Object get(Token name, VariableScope fromScope);
+    Object get(Token name, VariableScope fromScope, ExecutionOptions options);
 }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/CompositeInstance.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/CompositeInstance.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.hsl.objects.external;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.hsl.ast.statement.FieldStatement;
 import org.dockbox.hartshorn.hsl.interpreter.Interpreter;
+import org.dockbox.hartshorn.hsl.runtime.ExecutionOptions;
 import org.dockbox.hartshorn.hsl.interpreter.VariableScope;
 import org.dockbox.hartshorn.hsl.objects.ClassReference;
 import org.dockbox.hartshorn.hsl.objects.ExternalObjectReference;
@@ -68,11 +69,11 @@ public class CompositeInstance<T> extends VirtualInstance implements ExternalObj
     }
 
     @Override
-    public void set(final Token name, final Object value, final VariableScope fromScope) {
+    public void set(final Token name, final Object value, final VariableScope fromScope, final ExecutionOptions options) {
         this.checkInstance();
         final FieldStatement virtualField = super.type().field(name.lexeme());
         if (virtualField != null) {
-            super.set(name, value, fromScope);
+            super.set(name, value, fromScope, options);
         }
         else {
             final Option<FieldView<T, ?>> field = this.firstExternalClass.fields().named(name.lexeme());
@@ -86,11 +87,11 @@ public class CompositeInstance<T> extends VirtualInstance implements ExternalObj
     }
 
     @Override
-    public Object get(final Token name, final VariableScope fromScope) {
+    public Object get(final Token name, final VariableScope fromScope, final ExecutionOptions options) {
         this.checkInstance();
         final FieldStatement virtualField = super.type().field(name.lexeme());
         if (virtualField != null) {
-            return super.get(name, fromScope);
+            return super.get(name, fromScope, options);
         }
         else {
             final Option<FieldView<T, ?>> field = this.firstExternalClass.fields().named(name.lexeme());

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExternalFunction.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExternalFunction.java
@@ -50,7 +50,7 @@ public class ExternalFunction extends AbstractFinalizable implements MethodRefer
         this(type, methodName, null);
     }
 
-    public ExternalFunction(final TypeView<?> type, final String methodName, final InstanceReference instance) {
+    private ExternalFunction(final TypeView<?> type, final String methodName, final InstanceReference instance) {
         super(false);
         this.methodName = methodName;
         this.type = (TypeView<Object>) type;

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExternalInstance.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExternalInstance.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.hsl.objects.external;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.dockbox.hartshorn.hsl.runtime.ExecutionOptions;
 import org.dockbox.hartshorn.hsl.interpreter.VariableScope;
 import org.dockbox.hartshorn.hsl.objects.ClassReference;
 import org.dockbox.hartshorn.hsl.objects.ExternalObjectReference;
@@ -61,7 +62,7 @@ public class ExternalInstance implements InstanceReference, ExternalObjectRefere
     }
 
     @Override
-    public void set(final Token name, final Object value, final VariableScope fromScope) {
+    public void set(final Token name, final Object value, final VariableScope fromScope, final ExecutionOptions options) {
         this.type.fields().named(name.lexeme())
                 .map(field -> (FieldView<Object, Object>) field)
                 .peek(field -> field.set(this.instance(), value))
@@ -69,9 +70,9 @@ public class ExternalInstance implements InstanceReference, ExternalObjectRefere
     }
 
     @Override
-    public Object get(final Token name, final VariableScope fromScope) {
         final boolean isMethod = this.type.methods().all().stream()
                 .anyMatch(method -> method.name().equals(name.lexeme()));
+    public Object get(final Token name, final VariableScope fromScope, final ExecutionOptions options) {
 
         if (isMethod) return new ExternalFunction(this.type, name.lexeme());
 

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/virtual/VirtualInstance.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/virtual/VirtualInstance.java
@@ -18,6 +18,7 @@ package org.dockbox.hartshorn.hsl.objects.virtual;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.hsl.ast.statement.FieldStatement;
+import org.dockbox.hartshorn.hsl.runtime.ExecutionOptions;
 import org.dockbox.hartshorn.hsl.interpreter.VariableScope;
 import org.dockbox.hartshorn.hsl.objects.InstanceReference;
 import org.dockbox.hartshorn.hsl.objects.MethodReference;
@@ -47,7 +48,7 @@ public class VirtualInstance implements InstanceReference {
     }
 
     @Override
-    public void set(final Token name, final Object value, final VariableScope fromScope) {
+    public void set(final Token name, final Object value, final VariableScope fromScope, final ExecutionOptions options) {
         final FieldStatement field = this.virtualClass.field(name.lexeme());
         if (field == null && !this.virtualClass.isDynamic()) {
             throw new RuntimeError(name, "Undefined property '" + name.lexeme() + "'.");
@@ -60,7 +61,7 @@ public class VirtualInstance implements InstanceReference {
     }
 
     @Override
-    public Object get(final Token name, final VariableScope fromScope) {
+    public Object get(final Token name, final VariableScope fromScope, final ExecutionOptions options) {
         final FieldStatement field = this.virtualClass.field(name.lexeme());
         if (this.virtualClass.isDynamic() || (field != null && this.fields.containsKey(name.lexeme()))) {
             if (field != null) this.checkScopeCanAccess(name, field, fromScope);

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/runtime/AbstractScriptRuntime.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/runtime/AbstractScriptRuntime.java
@@ -108,6 +108,7 @@ public class AbstractScriptRuntime extends ExpressionConditionContext implements
     protected Interpreter createInterpreter(final ResultCollector resultCollector) {
         final Interpreter interpreter = this.factory.interpreter(resultCollector, this.standardLibraries());
         interpreter.externalModules(this.externalModules());
+        interpreter.executionOptions(this.interpreterOptions());
         return interpreter;
     }
 

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/runtime/ExecutionOptions.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/runtime/ExecutionOptions.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.hsl.runtime;
+
+public class ExecutionOptions {
+
+    private boolean permitAmbiguousExternalFunctions = true;
+
+    public boolean permitAmbiguousExternalFunctions() {
+        return this.permitAmbiguousExternalFunctions;
+    }
+
+    public ExecutionOptions permitAmbiguousExternalFunctions(final boolean permitAmbiguousModuleFunctions) {
+        this.permitAmbiguousExternalFunctions = permitAmbiguousModuleFunctions;
+        return this;
+    }
+}

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/runtime/ExecutionOptions.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/runtime/ExecutionOptions.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.hsl.runtime;
 public class ExecutionOptions {
 
     private boolean permitAmbiguousExternalFunctions = true;
+    private boolean permitDuplicateModules = true;
 
     public boolean permitAmbiguousExternalFunctions() {
         return this.permitAmbiguousExternalFunctions;
@@ -26,6 +27,15 @@ public class ExecutionOptions {
 
     public ExecutionOptions permitAmbiguousExternalFunctions(final boolean permitAmbiguousModuleFunctions) {
         this.permitAmbiguousExternalFunctions = permitAmbiguousModuleFunctions;
+        return this;
+    }
+
+    public boolean permitDuplicateModules() {
+        return this.permitDuplicateModules;
+    }
+
+    public ExecutionOptions permitDuplicateModules(final boolean permitDuplicateModules) {
+        this.permitDuplicateModules = permitDuplicateModules;
         return this;
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/InterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/InterpreterTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.dockbox.hartshorn.hsl;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.hsl.HslScript;
+import org.dockbox.hartshorn.hsl.ScriptEvaluationError;
+import org.dockbox.hartshorn.hsl.modules.InstanceNativeModule;
+import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import jakarta.inject.Inject;
+
+@HartshornTest
+public class InterpreterTests {
+
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @Test
+    void testAmbiguousExternalFunctionsAreAllowedByDefault() {
+        final HslScript script = HslScript.of(this.applicationContext, "ambiguousCall()");
+        script.runtime().module("ambiguous", new InstanceNativeModule(this.applicationContext, new AmbiguousExternalModule()));
+        Assertions.assertDoesNotThrow(script::evaluate);
+    }
+
+    @Test
+    void testAmbiguousExternalFunctionsAreAllowedWhenEnabled() {
+        final HslScript script = HslScript.of(this.applicationContext, "ambiguousCall()");
+        script.runtime().module("ambiguous", new InstanceNativeModule(this.applicationContext, new AmbiguousExternalModule()));
+        script.runtime().interpreterOptions().permitAmbiguousExternalFunctions(true);
+        Assertions.assertDoesNotThrow(script::evaluate);
+    }
+
+    @Test
+    void testAmbiguousExternalFunctionsAreNotAllowedWhenDisabled() {
+        final HslScript script = HslScript.of(this.applicationContext, "ambiguousCall()");
+        script.runtime().module("ambiguous", new InstanceNativeModule(this.applicationContext, new AmbiguousExternalModule()));
+        script.runtime().interpreterOptions().permitAmbiguousExternalFunctions(false);
+        Assertions.assertThrows(ScriptEvaluationError.class, script::evaluate);
+    }
+
+    public static class AmbiguousExternalModule {
+        public boolean ambiguousCall() {
+            return true;
+        }
+
+        public boolean ambiguousCall(final boolean value) {
+            return value;
+        }
+    }
+}

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ScriptRuntimeTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ScriptRuntimeTests.java
@@ -20,11 +20,11 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.hsl.HslExpression;
 import org.dockbox.hartshorn.hsl.HslScript;
 import org.dockbox.hartshorn.hsl.UseExpressionValidation;
-import org.dockbox.hartshorn.hsl.modules.InstanceNativeModule;
 import org.dockbox.hartshorn.hsl.customizer.AbstractCodeCustomizer;
 import org.dockbox.hartshorn.hsl.customizer.CodeCustomizer;
 import org.dockbox.hartshorn.hsl.customizer.ScriptContext;
 import org.dockbox.hartshorn.hsl.lexer.Comment;
+import org.dockbox.hartshorn.hsl.modules.InstanceNativeModule;
 import org.dockbox.hartshorn.hsl.runtime.Phase;
 import org.dockbox.hartshorn.hsl.token.TokenType;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
@@ -216,7 +216,7 @@ public class ScriptRuntimeTests {
 
     ScriptContext assertValid(final HslExpression expression) {
         final ScriptContext context = Assertions.assertDoesNotThrow(expression::evaluate);
-        Assertions.assertTrue(expression.valid());
+        Assertions.assertTrue(expression.valid(context));
         return context;
     }
 


### PR DESCRIPTION
# Description
There are various approaches to how we could support ambiguous method definitions, either because of overloading or because of conflicting modules. Previously, there was no concrete decision on whether or not this should be supported.

These changes set the scope to: "**only** external functions are supported, **if** this is enabled". This means that overloading of functions in HSL natively will not be supported. This decision is based on the fact that HSL is a scripting language, and not a full fledged OO language. Because of this fact, the additional complexity is not considered worth the developer time to support ambiguous method handling outside of reasonable external scenarios.

The reason external methods are still allowed is because this can otherwise be blocking for existing external modules, and limit future implementations. This is however configurable, so if preferred this behavior can be turned off through the runtime execution options.

Fixes #780

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
