### PR TITLE
#940 Separate translation key generation from component processor

### DIFF
--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationProviders.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationProviders.java
@@ -16,10 +16,13 @@
 
 package org.dockbox.hartshorn.i18n;
 
+import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.i18n.annotations.UseTranslations;
+import org.dockbox.hartshorn.i18n.services.SimpleTranslationKeyGenerator;
+import org.dockbox.hartshorn.i18n.services.TranslationKeyGenerator;
 
 @Service
 @RequiresActivator(UseTranslations.class)
@@ -33,5 +36,10 @@ public class TranslationProviders {
     @Binds
     public TranslationBundle translationBundle() {
         return new DefaultTranslationBundle();
+    }
+
+    @Binds
+    public TranslationKeyGenerator translationKeyGenerator(final ComponentLocator componentLocator) {
+        return new SimpleTranslationKeyGenerator(componentLocator);
     }
 }

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/SimpleTranslationKeyGenerator.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/SimpleTranslationKeyGenerator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.i18n.services;
+
+import org.dockbox.hartshorn.component.Component;
+import org.dockbox.hartshorn.component.ComponentContainer;
+import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.i18n.annotations.InjectTranslation;
+import org.dockbox.hartshorn.util.StringUtilities;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.option.Option;
+
+import jakarta.inject.Inject;
+
+@Component
+public class SimpleTranslationKeyGenerator implements TranslationKeyGenerator {
+
+    private final ComponentLocator componentLocator;
+
+    @Inject
+    public SimpleTranslationKeyGenerator(final ComponentLocator componentLocator) {
+        this.componentLocator = componentLocator;
+    }
+
+    @Override
+    public String key(final TypeView<?> type, final MethodView<?, ?> method) {
+        final Option<InjectTranslation> resource = method.annotations().get(InjectTranslation.class);
+
+        // If the method has an explicit key, use that without further processing
+        if (resource.present()) {
+            final String resourceKey = resource.get().key();
+            if (StringUtilities.notEmpty(resourceKey)) {
+                return resourceKey;
+            }
+        }
+
+        String methodName = method.name();
+        if (methodName.startsWith("get")) methodName = methodName.substring(3);
+        String methodKey = String.join(".", StringUtilities.splitCapitals(methodName)).toLowerCase();
+
+        final TypeView<?> declaringType = method.declaredBy();
+        final Option<ComponentContainer> container = this.componentLocator.container(declaringType.type());
+        if (container.present()) {
+            final String containerKey = container.get().id();
+            if (containerKey != null) methodKey = containerKey + "." + methodKey;
+        }
+
+        return methodKey;
+    }
+}

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationKeyGenerator.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationKeyGenerator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.i18n.services;
+
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+
+public interface TranslationKeyGenerator {
+
+    String key(final TypeView<?> type, final MethodView<?, ?> method);
+}


### PR DESCRIPTION
# Description
The `TranslationInjectPostProcessor` defines the key generation behavior for i18n keys represented by method views. This limits the re-usability of the key generation, and risks multiple implementations being created to achieve the same goal.
https://github.com/Dockbox-OSS/Hartshorn/blob/6b96e855f854451b49056b53509a021443549c73/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectPostProcessor.java#L65-L87

These changes extract the key generation to a dedicated interface `TranslationKeyGenerator`, and provide a default implementation based on the previous implementation in `TranslationInjectPostProcessor`.

Fixes #940

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
