### PR TITLE
#923 Update project introduction and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,26 +29,60 @@ Or if you are using Gradle:
 implementation "org.dockbox.hartshorn:hartshorn-core:$version"
 ```
 
-Depending on which module you're using, you may also need to import a specific implementation. For example, Hartshorn JPA comes with a Hibernate implementation, which you can import using `hartshorn-jpa-hibernate`. Implementations will always transitively import their API counterpart(s).
-
 ### Starting your first application
 
 Getting started with Hartshorn is easy, the example below will introduce you to the basics of setting up and running your first application.
 
-**TODO: Write content here**
+Hartshorn applications are built using the `HartshornApplication` class. This class is the entry point of your application, and is responsible for bootstrapping the application. The bootstrap process will initialize a standalone `ApplicationContext` which will be used to manage the application's lifecycle.
+
+```java
+public static void main(String[] args) {
+    ApplicationContext applicationContext = HartshornApplication.create();
+    // ...
+}
+```
+
+The `ApplicationContext` is the core of Hartshorn, and is responsible for managing the application's lifecycle. The `ApplicationContext` is also responsible for managing the application's dependency injection container, which is used to inject dependencies into your application. Dependencies can be declared through the use of the `@Binds` annotation, which will bind a type to an implementation. The `@Inject` annotation can be used to inject dependencies into your application.
+
+```java
+@Binds
+public String helloWorld() {
+    return "Hello World!";
+}
+```
+
+Injection is performed on managed components. A component is considered managed if it is annotated with the `@Component` annotation, or a stereotype annotation that is annotated with `@Component`, such as `@Service`.
+
+```java
+@Service
+public class SampleService {
+    
+    @Inject
+    private String helloWorld;
+    
+    public void sayHelloWorld() {
+        System.out.println(helloWorld);
+    }
+}
+```
+
+Bringing it all together, we can now use our `SampleService` to print "Hello World!" to the console.
+
+```java
+public static void main(String[] args) {
+    ApplicationContext applicationContext = HartshornApplication.create();
+    SampleService sampleService = applicationContext.get(SampleService.class);
+    sampleService.sayHelloWorld();
+}
+```
+
+### Next steps
+
+Once you've gotten started with Hartshorn, you'll want to learn more about the framework. The [documentation](https://hartshorn.dockbox.org/) is a great place to start, and will help you get familiar with the framework. You can also check out the [examples](https://github.com/Dockbox-OSS/Hartshorn-Examples) repository for more in-depth examples.
 
 ## Building Hartshorn
 
 If you wish to build Hartshorn yourself, either to get access to pre-release versions, or to add customizations, the guide below explains how to build usable JAR artifacts.  All platforms require a Java installation, with JDK 17 or more recent version.
-
-Before building, ensure you set the JAVA\_HOME environment variable. For example:
-
-
-| Platform | Command                                              |
-| :------: | ---------------------------------------------------- |
-|   Unix   | ``export JAVA_HOME=/usr/lib/jvm/openjdk-17-jdk``     |
-|   OSX   | ``export JAVA_HOME=`/usr/libexec/java_home -v 17` `` |
-| Windows | ``set JAVA_HOME="C:\Program Files\Java\jdk-17.0.3"`` |
 
 Hartshorn uses Gradle to automate builds, performing several steps before and after a build has completed.
 Depending on your IDE the Gradle wrapper may be automatically used. If you encounter any issues, use `./gradlew` for Unix systems or  `gradlew.bat` for Windows systems in place of any `gradle` command.

--- a/README.md
+++ b/README.md
@@ -3,36 +3,18 @@
 <p align="center"><img src="https://github.com/GuusLieben/Hartshorn/actions/workflows/hartshorn.yml/badge.svg"></p>
 <p align="center"><img src="https://img.shields.io/badge/JDK%20source-17-white"> <img src="https://img.shields.io/badge/JDK%20target-19-white"></p>
 
-[Hartshorn](https://hartshorn.dockbox.org/) is a modern JVM-based full stack Java framework. It is capable of aiding developers while building modular, testable, and scalable applications with support for Java and other JVM languages.  
-
-Hartshorn is an umbrella term for the Hartshorn Framework and all official [modules](https://hartshorn.dockbox.org/modules/modules/). Hartshorn Framework itself is a service- and dependency management framework which complements [JSR 330](https://www.jcp.org/en/jsr/detail?id=330), but does not embrace the Java EE specification. You can read more about Hartshorn's core technologies and principles in the [core technologies](https://hartshorn.dockbox.org/core/cdi/) topic.  
-
-Hartshorn aims to ease the creation and management of complex JVM applications, this is done by providing tools necessary to build these applications. These tools include:
-- Context and Dependency Injection (CDI) and Inversion of Control (IoC)
-- Automatic application configuration
-- Component lifecycle management
-
-### Philosophy
-Hartshorn follows a range of technical [core principles](https://hartshorn.dockbox.org/core/cdi/), as well as a specific design philosophy. Here are the guiding principles of the Hartshorn Framework:
-- Extensibility and flexibility. Hartshorn puts an emphasis on enabling developers to extend and switch between implementations at every level, without requiring changes to your code.
-- Allow for diverse usages. Hartshorn allows for a large amount of flexibility, by providing a template for you to develop your application in.
-- High standards for code quality. Hartshorn aims to use modern language features in combination with a meaningful and future-proof API to allow developers to intuitively use the framework.
-
-### Why use Hartshorn?
-Hartshorn is capable of being as complex or simplistic as you need it to be, remaining largely unbiased to allow you to build applications in the way you see fit. It aims to avoid some of the downsides of frameworks like Spring, Ktor, and Quarkus:
-- Fast startup time
-- Reduced memory footprint
-- Full component customization
-- Easy unit testing
-
-<br>  
+[Hartshorn](https://hartshorn.dockbox.org/) is a modern JVM-based full stack Java framework. It is capable of aiding developers while building modular, testable, and scalable applications with support for Java and other JVM languages. Hartshorn aims to ease the creation and management of complex JVM applications, this is done by providing tools necessary to build these applications. You can read more about Hartshorn's core technologies and principles in the [core technologies](https://hartshorn.dockbox.org/core/cdi/) topic.
 
 ## Getting started
+
 If you are just getting started with hartshorn, you'll want to view the [Getting Started](https://hartshorn.dockbox.org/getting-started/setup/) guides on the official documentation website. The provided guides use Hartshorn's application starter which enables you to get started quickly. If you are just looking for the Maven dependencies, these are listed below.
 
 ### Maven configuration
-Each module has its own dedicated dependency, so you have the freedom to use only the modules you actually need.  
+
+Each module has its own dedicated dependency, so you have the freedom to use only the modules you actually need. You can find all modules and their respective releases on [Maven Central](https://central.sonatype.dev/namespace/org.dockbox.hartshorn).
+
 To get started, add the Maven dependency:
+
 ```xml
 <dependency>
   <groupId>org.dockbox.hartshorn</groupId>
@@ -40,102 +22,42 @@ To get started, add the Maven dependency:
   <version>${version}</version>
 </dependency>
 ```
+
 Or if you are using Gradle:
+
 ```groovy
 implementation "org.dockbox.hartshorn:hartshorn-core:$version"
 ```
 
+Depending on which module you're using, you may also need to import a specific implementation. For example, Hartshorn JPA comes with a Hibernate implementation, which you can import using `hartshorn-jpa-hibernate`. Implementations will always transitively import their API counterpart(s).
+
 ### Starting your first application
-Getting started with Hartshorn is easy, the example below will introduce you to the application starter as well as showing you how to create a simple REST controller. You can find a full guide on this topic on the [Getting started section](https://hartshorn.dockbox.org/getting-started/first-application/) of the documentation website.  
 
-Before creating a REST controller, we'll first need a domain object representing our response. In this example we will use a simple `Greeting` object, which contains a single message. This will result in the following response from the REST API:
-```json
-{
-    "content": "Hello, World!"
-}
-```
-To model the greeting, you can use a Plain Old Java Object (POJO), no annotations required.
+Getting started with Hartshorn is easy, the example below will introduce you to the basics of setting up and running your first application.
 
-```java
-public class Greeting {
+**TODO: Write content here**
 
-    private final String content;
-
-    public Greeting(final String content) {
-        this.content = content;
-    }
-
-    public String getContent() {
-        return this.content;
-    }
-}
-```
-Next we'll create a REST controller capable of handling HTTP requests. In Hartshorn, REST controllers are a component stereotype, meaning they are automatically managed by the application. This allows you to simply mark the controller with `@RestController`, without needing to register the component manually.
-
-```java
-
-@RestController
-public class GreetingController {
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, %s!".formatted(name)); // If no value is provided for 'name', the default value 'World' will be used
-
-    }
-}
-```
-Finally, we start the application from our main application class. Here we can use the `HartshornApplication` starter, which will automatically perform all steps required to bootstrap your application and start the RESTful web service.
-
-```java
-
-@Activator
-// Indicates this class is allowed to be used as an application starter. You can also define additional metadata here
-@UseHttpServer // Indicates we should start a web server and process controllers
-public class GreetingApplication {
-
-    public static void main(final String[] args) {
-        HartshornApplication.create(GreetingApplication.class, args);
-    }
-}
-```
-That's it! You can now navigate to http://localhost:8080/greeting, which will result in the following response:
-```json
-{
-    "content": "Hello, World!"
-}
-```
-Additionally, if you go to http://localhost:8080/greeting?name=YourName, the response will greet you instead of the entire world! For example, adding `?name=Hartshorn` will result in:
-```json
-{
-    "content": "Hello, Hartshorn!"
-}
-```
-  
-<br>  
-  
 ## Building Hartshorn
-If you wish to build Hartshorn yourself, either to get access to pre-release versions, or to add customizations, the guide below explains how to set up your Gradle environment.  All platforms require a Java installation, with JDK 17 or more recent version.
 
-Set the JAVA\_HOME environment variable. For example:
+If you wish to build Hartshorn yourself, either to get access to pre-release versions, or to add customizations, the guide below explains how to build usable JAR artifacts.  All platforms require a Java installation, with JDK 17 or more recent version.
+
+Before building, ensure you set the JAVA\_HOME environment variable. For example:
+
 
 | Platform | Command                                              |
-| :---: |------------------------------------------------------|
-|  Unix    | ``export JAVA_HOME=/usr/lib/jvm/openjdk-17-jdk``     |
-|  OSX     | ``export JAVA_HOME=`/usr/libexec/java_home -v 17` `` |
-|  Windows | ``set JAVA_HOME="C:\Program Files\Java\jdk-17.0.3"`` |
+| :------: | ---------------------------------------------------- |
+|   Unix   | ``export JAVA_HOME=/usr/lib/jvm/openjdk-17-jdk``     |
+|   OSX   | ``export JAVA_HOME=`/usr/libexec/java_home -v 17` `` |
+| Windows | ``set JAVA_HOME="C:\Program Files\Java\jdk-17.0.3"`` |
 
-Hartshorn uses a custom Gradle wrapper to automate builds, performing several steps before and after a build has completed.  
-Depending on your IDE the Gradle wrapper may be automatically used. If you encounter any issues, use `./gradlew` for Unix systems or Git Bash and `gradlew.bat` for Windows systems in place of any 'gradle' command.  
+Hartshorn uses Gradle to automate builds, performing several steps before and after a build has completed.
+Depending on your IDE the Gradle wrapper may be automatically used. If you encounter any issues, use `./gradlew` for Unix systems or  `gradlew.bat` for Windows systems in place of any `gradle` command.
 
-Within the directory containing the unpacked source code, run the gradle build:
-```bash
-./gradlew build
-```
+To build all Hartshorn modules at once, run `gradle build`. To build specific modules, run `gradle :hartshorn-$module:build`.
 
-Once the build completes, the project distribution archives will be installed at `/hartshorn-assembly/distributions` in the base directory. 
-Builds are versioned by date and by commit hash, with the artifact following the format `$archivesBaseName-$commitHash-$date.jar`.
+Once the build completes, the project distribution archives will be installed at `/hartshorn-assembly/distributions` in the base directory.
+Builds are versioned by release versions, with the artifact following the format `hartshorn-$module-$version.jar`. This will also generate appropriate `javadoc` and `sources` artifacts.
 
-<br>  
-  
 ## Contributing
+
 Interested in contributing to Hartshorn, want to report a bug, or have a question? Before you do, please read the [contribution guidelines](https://hartshorn.dockbox.org/contributing/)


### PR DESCRIPTION
# Description
The README contains examples which are out of date since the latest release, for example:
https://github.com/Dockbox-OSS/Hartshorn/blob/28db9bae2cd11e4eb82014f6fe40781e9b594fa9/README.md?plain=1#L91-L100

It also contains examples which are subject to change ( #746 ):
https://github.com/Dockbox-OSS/Hartshorn/blob/28db9bae2cd11e4eb82014f6fe40781e9b594fa9/README.md?plain=1#L77-L85

These changes update the readme to be correct for the latest release, and focus on the DI aspects of the framework in the 'getting started' section. The readme now also refers to the [examples repository](https://github.com/Dockbox-OSS/Hartshorn-Examples), which we can use to add examples of simple use-cases of the framework.

Fixes #923

## Type of change
- [x] Documentation (documentation changes)

# Checklist:
- [x] I have performed a self-review of my content
- [x] Related issue number is linked in pull request title
