### PR TITLE
#931 Rename shortened keywords, add markers for reserved token types

### DIFF
--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/lexer/Lexer.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/lexer/Lexer.java
@@ -22,6 +22,8 @@ import org.dockbox.hartshorn.hsl.token.Token;
 import org.dockbox.hartshorn.hsl.token.TokenConstants;
 import org.dockbox.hartshorn.hsl.token.TokenType;
 import org.dockbox.hartshorn.inject.binding.Bound;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +39,8 @@ import java.util.Map;
  */
 public class Lexer {
 
-    private static final Map<String, TokenType> keywords = TokenType.keywords();
+    private static final Logger LOG = LoggerFactory.getLogger(Lexer.class);
+    private static final Map<String, TokenType> KEYWORDS = TokenType.keywords();
 
     private final List<Token> tokens = new ArrayList<>();
     private final List<Comment> comments = new ArrayList<>();
@@ -328,7 +331,7 @@ public class Lexer {
         // See if the scanIdentifier is a reserved word.
         final String text = this.source.substring(this.start, this.current);
 
-        TokenType type = keywords.get(text);
+        TokenType type = KEYWORDS.get(text);
 
         if (type == null) type = TokenType.IDENTIFIER;
         this.addToken(type);
@@ -341,6 +344,11 @@ public class Lexer {
     }
 
     private void addToken(final TokenType type) {
+        if (type.reserved()) {
+            LOG.warn("Reserved token type used: " + type + " at line " + this.line + ", column " + this.column + ". " +
+                    "Reserved tokens are not supported and may not be implemented yet. " +
+                    "This may cause unexpected behavior.");
+        }
         this.addToken(type, null);
     }
 

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/ClassStatementParser.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/ClassStatementParser.java
@@ -94,7 +94,7 @@ public class ClassStatementParser implements ASTNodeParser<ClassStatement> {
         if (parser.check(TokenType.CONSTRUCTOR)) {
             return this.handleDelegate(parser, validator, parser.firstCompatibleParser(ConstructorStatement.class));
         }
-        else if (parser.check(TokenType.FUN)) {
+        else if (parser.check(TokenType.FUNCTION)) {
             return this.handleDelegate(parser, validator, parser.firstCompatibleParser(FunctionStatement.class));
         }
         else {

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/FinalDeclarationStatementParser.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/FinalDeclarationStatementParser.java
@@ -42,14 +42,14 @@ public class FinalDeclarationStatementParser implements ASTNodeParser<Finalizabl
             final FinalizableStatement finalizable = switch (current.type()) {
                 case PREFIX, INFIX -> {
                     parser.advance();
-                    if (parser.check(TokenType.FUN)) {
+                    if (parser.check(TokenType.FUNCTION)) {
                         yield lookupFinalizableFunction(parser, validator, parser.peek());
                     }
                     else {
                         throw new ScriptEvaluationError("Unexpected token '" + current.lexeme() + "' at line " + current.line() + ", column " + current.column(), Phase.PARSING, current);
                     }
                 }
-                case FUN -> lookupFinalizableFunction(parser, validator, current);
+                case FUNCTION -> lookupFinalizableFunction(parser, validator, current);
                 case VAR -> delegateParseStatement(parser, validator, VariableStatement.class, "variable", current);
                 case CLASS -> delegateParseStatement(parser, validator, ClassStatement.class, "class", current);
                 case NATIVE -> delegateParseStatement(parser, validator, NativeFunctionStatement.class, "native function", current);

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/FunctionStatementParser.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/FunctionStatementParser.java
@@ -38,9 +38,9 @@ public class FunctionStatementParser extends AbstractBodyStatementParser<Functio
 
     @Override
     public Option<Function> parse(final TokenParser parser, final TokenStepValidator validator) {
-        if (parser.check(TokenType.PREFIX, TokenType.INFIX, TokenType.FUN)) {
+        if (parser.check(TokenType.PREFIX, TokenType.INFIX, TokenType.FUNCTION)) {
             final Token functionType = parser.advance();
-            final Token functionToken = functionType.type() == TokenType.FUN ? functionType : parser.advance();
+            final Token functionToken = functionType.type() == TokenType.FUNCTION ? functionType : parser.advance();
             final Token name = validator.expect(TokenType.IDENTIFIER, "function name");
 
             int expectedNumberOrArguments = Integer.MAX_VALUE;

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/ModuleStatementParser.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/ModuleStatementParser.java
@@ -30,9 +30,9 @@ public class ModuleStatementParser implements ASTNodeParser<ModuleStatement> {
 
     @Override
     public Option<ModuleStatement> parse(final TokenParser parser, final TokenStepValidator validator) {
-        if (parser.match(TokenType.USING)) {
+        if (parser.match(TokenType.IMPORT)) {
             final Token name = validator.expect(TokenType.IDENTIFIER, "module name");
-            validator.expectAfter(TokenType.SEMICOLON, TokenType.USING);
+            validator.expectAfter(TokenType.SEMICOLON, TokenType.IMPORT);
             return Option.of(new ModuleStatement(name));
         }
         return Option.empty();

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/NativeFunctionStatementParser.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/NativeFunctionStatementParser.java
@@ -31,7 +31,7 @@ public class NativeFunctionStatementParser extends AbstractBodyStatementParser<N
 
     @Override
     public Option<NativeFunctionStatement> parse(final TokenParser parser, final TokenStepValidator validator) {
-        if (parser.match(TokenType.NATIVE) && parser.match(TokenType.FUN)) {
+        if (parser.match(TokenType.NATIVE) && parser.match(TokenType.FUNCTION)) {
             final Token moduleName = validator.expect(TokenType.IDENTIFIER, "module name");
 
             while (parser.match(TokenType.COLON)) {

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenMetaData.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenMetaData.java
@@ -29,6 +29,7 @@ public class TokenMetaData {
     private final String representation;
     private final boolean keyword;
     private final boolean standaloneStatement;
+    private final boolean reserved;
     private final TokenType assignsWith;
 
     TokenMetaData(final TokenMetaDataBuilder builder) {
@@ -36,6 +37,7 @@ public class TokenMetaData {
         this.representation = builder.representation;
         this.keyword = builder.keyword;
         this.standaloneStatement = builder.standaloneStatement;
+        this.reserved = builder.reserved;
         this.assignsWith = builder.assignsWith;
     }
 
@@ -71,6 +73,15 @@ public class TokenMetaData {
      */
     public boolean standaloneStatement() {
         return this.standaloneStatement;
+    }
+
+    /**
+     * Gets whether the use of this {@link TokenType} is reserved. This is typically used
+     * to indicate a token that is not yet supported, but is reserved for future use.
+     * @return {@code true} if the token is reserved.
+     */
+    public boolean reserved() {
+        return this.reserved;
     }
 
     /**

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenMetaDataBuilder.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenMetaDataBuilder.java
@@ -30,6 +30,7 @@ public class TokenMetaDataBuilder {
     String representation;
     boolean keyword;
     boolean standaloneStatement;
+    boolean reserved;
     TokenType assignsWith;
 
     TokenMetaDataBuilder(final TokenType type) {
@@ -62,6 +63,11 @@ public class TokenMetaDataBuilder {
 
     public TokenMetaDataBuilder standaloneStatement(final boolean standaloneStatement) {
         this.standaloneStatement = standaloneStatement;
+        return this;
+    }
+
+    public TokenMetaDataBuilder reserved(final boolean reserved) {
+        this.reserved = reserved;
         return this;
     }
 

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenType.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenType.java
@@ -116,20 +116,20 @@ public enum TokenType {
     IMPORT(builder -> builder.keyword(true).standaloneStatement(true).ok()),
     SWITCH(builder -> builder.keyword(true).standaloneStatement(true).ok()),
 
+    PUBLIC(builder -> builder.keyword(true).ok()),
+    PRIVATE(builder -> builder.keyword(true).ok()),
+    FINAL(builder -> builder.keyword(true).reserved(true).ok()),
+
     // Reserved words/characters
     OPERATOR(builder -> builder.keyword(true).reserved(true).ok()),
 
     STATIC(builder -> builder.keyword(true).reserved(true).ok()),
-    FINAL(builder -> builder.keyword(true).reserved(true).ok()),
 
     ABSTRACT(builder -> builder.keyword(true).reserved(true).ok()),
     OVERRIDE(builder -> builder.keyword(true).reserved(true).ok()),
     INTERFACE(builder -> builder.keyword(true).reserved(true).ok()),
     IMPLEMENTS(builder -> builder.keyword(true).reserved(true).ok()),
     ENUM(builder -> builder.keyword(true).reserved(true).ok()),
-
-    PUBLIC(builder -> builder.keyword(true).reserved(true).ok()),
-    PRIVATE(builder -> builder.keyword(true).reserved(true).ok()),
 
     ASSERT(builder -> builder.keyword(true).reserved(true).ok()),
 

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenType.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenType.java
@@ -88,7 +88,7 @@ public enum TokenType {
     PREFIX(builder -> builder.keyword(true).ok()),
     INFIX(builder -> builder.keyword(true).ok()),
     CLASS(builder -> builder.keyword(true).ok()),
-    FUN(builder -> builder.keyword(true).ok()),
+    FUNCTION(builder -> builder.keyword(true).ok()),
     EXTENDS(builder -> builder.keyword(true).ok()),
     ELSE(builder -> builder.keyword(true).ok()),
     TRUE(builder -> builder.keyword(true).ok()),
@@ -113,7 +113,7 @@ public enum TokenType {
     CONTINUE(builder -> builder.keyword(true).standaloneStatement(true).ok()),
     RETURN(builder -> builder.keyword(true).standaloneStatement(true).ok()),
     TEST(builder -> builder.keyword(true).standaloneStatement(true).ok()),
-    USING(builder -> builder.keyword(true).standaloneStatement(true).ok()),
+    IMPORT(builder -> builder.keyword(true).standaloneStatement(true).ok()),
     SWITCH(builder -> builder.keyword(true).standaloneStatement(true).ok()),
 
     // Reserved words/characters

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenType.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/token/TokenType.java
@@ -117,19 +117,40 @@ public enum TokenType {
     SWITCH(builder -> builder.keyword(true).standaloneStatement(true).ok()),
 
     // Reserved words/characters
-    OPERATOR(builder -> builder.keyword(true).ok()),
+    OPERATOR(builder -> builder.keyword(true).reserved(true).ok()),
 
-    STATIC(builder -> builder.keyword(true).ok()),
-    FINAL(builder -> builder.keyword(true).ok()),
+    STATIC(builder -> builder.keyword(true).reserved(true).ok()),
+    FINAL(builder -> builder.keyword(true).reserved(true).ok()),
 
-    ABSTRACT(builder -> builder.keyword(true).ok()),
-    OVERRIDE(builder -> builder.keyword(true).ok()),
-    INTERFACE(builder -> builder.keyword(true).ok()),
-    IMPLEMENTS(builder -> builder.keyword(true).ok()),
+    ABSTRACT(builder -> builder.keyword(true).reserved(true).ok()),
+    OVERRIDE(builder -> builder.keyword(true).reserved(true).ok()),
+    INTERFACE(builder -> builder.keyword(true).reserved(true).ok()),
+    IMPLEMENTS(builder -> builder.keyword(true).reserved(true).ok()),
+    ENUM(builder -> builder.keyword(true).reserved(true).ok()),
 
-    PUBLIC(builder -> builder.keyword(true).ok()),
-    PRIVATE(builder -> builder.keyword(true).ok()),
+    PUBLIC(builder -> builder.keyword(true).reserved(true).ok()),
+    PRIVATE(builder -> builder.keyword(true).reserved(true).ok()),
 
+    ASSERT(builder -> builder.keyword(true).reserved(true).ok()),
+
+    THROW(builder -> builder.keyword(true).reserved(true).ok()),
+    TRY(builder -> builder.keyword(true).reserved(true).ok()),
+    CATCH(builder -> builder.keyword(true).reserved(true).ok()),
+    FINALLY(builder -> builder.keyword(true).reserved(true).ok()),
+
+    AS(builder -> builder.keyword(true).reserved(true).ok()),
+    IS(builder -> builder.keyword(true).reserved(true).ok()),
+    NEW(builder -> builder.keyword(true).reserved(true).ok()),
+    TYPEOF(builder -> builder.keyword(true).reserved(true).ok()),
+    INSTANCEOF(builder -> builder.keyword(true).reserved(true).ok()),
+
+    DELETE(builder -> builder.keyword(true).reserved(true).ok()),
+
+    WITH(builder -> builder.keyword(true).reserved(true).ok()),
+    YIELD(builder -> builder.keyword(true).reserved(true).ok()),
+
+    AWAIT(builder -> builder.keyword(true).reserved(true).ok()),
+    ASYNC(builder -> builder.keyword(true).reserved(true).ok()),
     ;
 
     private final TokenMetaData metaData;
@@ -143,7 +164,7 @@ public enum TokenType {
     }
 
     TokenType(final char representation) {
-        this(representation + "");
+        this(String.valueOf(representation));
     }
 
     /**
@@ -152,7 +173,7 @@ public enum TokenType {
      * @param representation The static representation of the token type.
      */
     TokenType(final String representation) {
-        this(b -> b.representation(representation).ok());
+        this(builder -> builder.representation(representation).ok());
     }
 
     /**
@@ -183,6 +204,13 @@ public enum TokenType {
      */
     public boolean standaloneStatement() {
         return this.metaData.standaloneStatement();
+    }
+
+    /**
+     * @see TokenMetaData#reserved()
+     */
+    public boolean reserved() {
+        return this.metaData.reserved();
     }
 
     /**

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/FinalizedTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/FinalizedTests.java
@@ -84,14 +84,14 @@ public class FinalizedTests {
     @Test
     void testCannotReassignFinalFunctions() {
         final HslScript script = HslScript.of(this.applicationContext, """
-                final fun x() { }
-                fun x() { }
+                final function x() { }
+                function x() { }
                 """);
         final ScriptEvaluationError error = Assertions.assertThrows(ScriptEvaluationError.class, script::evaluate);
         Assertions.assertEquals("""
-                Cannot reassign final function 'x'. While resolving at line 2, column 4.
-                fun x() { }
-                    ^""", error.getMessage());
+                Cannot reassign final function 'x'. While resolving at line 2, column 9.
+                function x() { }
+                         ^""", error.getMessage());
     }
 
     @Test
@@ -110,15 +110,15 @@ public class FinalizedTests {
     @Test
     void testCannotReassignFinalNativeFunctions() {
         final HslScript script = HslScript.of(this.applicationContext, """
-                final native fun a.x();
-                fun x() { }
+                final native function a.x();
+                function x() { }
                 """);
         // Do not evaluate, as the native function does not exist in the current environment.
         final ScriptEvaluationError error = Assertions.assertThrows(ScriptEvaluationError.class, script::resolve);
         Assertions.assertEquals("""
-                Cannot reassign final native function 'x'. While resolving at line 2, column 4.
-                fun x() { }
-                    ^""", error.getMessage());
+                Cannot reassign final native function 'x'. While resolving at line 2, column 9.
+                function x() { }
+                         ^""", error.getMessage());
     }
 
     public static class User { }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/LexerTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/LexerTests.java
@@ -40,13 +40,13 @@ public class LexerTests {
             TokenType.PREFIX, TokenType.INFIX,
             TokenType.CLASS, TokenType.EXTENDS,
             TokenType.IF, TokenType.ELSE,
-            TokenType.FUN, TokenType.RETURN, TokenType.NATIVE,
+            TokenType.FUNCTION, TokenType.RETURN, TokenType.NATIVE,
             TokenType.TRUE, TokenType.FALSE,
             TokenType.FOR, TokenType.DO, TokenType.WHILE, TokenType.REPEAT,
             TokenType.BREAK, TokenType.CONTINUE,
             TokenType.SUPER, TokenType.THIS,
             TokenType.NULL, TokenType.TEST,
-            TokenType.VAR, TokenType.USING,
+            TokenType.VAR, TokenType.IMPORT,
     };
 
     private static final List<TokenType> literals = List.of(

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/VirtualClassTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/VirtualClassTests.java
@@ -82,10 +82,10 @@ public class VirtualClassTests {
                     constructor(name) {
                         this.name = name;
                     }
-                    fun getName() {
+                    function getName() {
                         return this.name;
                     }
-                    fun setName(name) {
+                    function setName(name) {
                         this.name = name;
                     }
                 }

--- a/hartshorn-hsl/src/test/resources/class/class_dynamic.hsl
+++ b/hartshorn-hsl/src/test/resources/class/class_dynamic.hsl
@@ -8,7 +8,7 @@ var v2 = Vector();
 v2.x = 20;
 v2.y = 10;
 
-fun sumVector() {
+function sumVector() {
    var result = Vector();
    result.x = v1.x + v2.x;
    result.y = v1.y + v2.y;

--- a/hartshorn-hsl/src/test/resources/class/class_extends.hsl
+++ b/hartshorn-hsl/src/test/resources/class/class_extends.hsl
@@ -1,5 +1,5 @@
 class MathSum {
-    fun sum(x,y) {
+    function sum(x,y) {
        return x + y;
     }
 }

--- a/hartshorn-hsl/src/test/resources/class/class_extension.hsl
+++ b/hartshorn-hsl/src/test/resources/class/class_extension.hsl
@@ -5,12 +5,12 @@ class Car {
       this.name = name;
    }
 
-   fun methodShowInfo() {
+   function methodShowInfo() {
       print("Car name from Method : " + this.name);
    }
 }
 
-fun Car:extensionShowInfo(){
+function Car:extensionShowInfo(){
    print("Car name from Extension : " + this.name);
 }
 

--- a/hartshorn-hsl/src/test/resources/class/class_fields.hsl
+++ b/hartshorn-hsl/src/test/resources/class/class_fields.hsl
@@ -7,11 +7,11 @@ class User {
         this.age = age;
     }
 
-    fun getAge() {
+    function getAge() {
         return this.age;
     }
 
-    fun setAge(age) {
+    function setAge(age) {
         this.age = age;
     }
 }

--- a/hartshorn-hsl/src/test/resources/class/class_function.hsl
+++ b/hartshorn-hsl/src/test/resources/class/class_function.hsl
@@ -1,5 +1,5 @@
 class Bacon {
-  fun eat() {
+  function eat() {
     print("Crunch crunch crunch!");
   }
 }

--- a/hartshorn-hsl/src/test/resources/class/class_function_reference.hsl
+++ b/hartshorn-hsl/src/test/resources/class/class_function_reference.hsl
@@ -1,5 +1,5 @@
 class Egotist {
-  fun speak() {
+  function speak() {
     print(this);
   }
 }

--- a/hartshorn-hsl/src/test/resources/class/class_inline.hsl
+++ b/hartshorn-hsl/src/test/resources/class/class_inline.hsl
@@ -1,5 +1,5 @@
 class ClassTestValue {
-  fun serveOn() {
+  function serveOn() {
     return "Scones";
   }
 }

--- a/hartshorn-hsl/src/test/resources/class/class_instance.hsl
+++ b/hartshorn-hsl/src/test/resources/class/class_instance.hsl
@@ -1,5 +1,5 @@
 class Bagel {
-   fun sum(x,y) {
+   function sum(x,y) {
       return x + y;
    }
 }

--- a/hartshorn-hsl/src/test/resources/class/class_properties.hsl
+++ b/hartshorn-hsl/src/test/resources/class/class_properties.hsl
@@ -1,7 +1,7 @@
 class Cake {
   public flavor;
 
-  fun taste() {
+  function taste() {
     var adjective = "delicious";
     print("The " + this.flavor + " cake is " + adjective + "!");
   }

--- a/hartshorn-hsl/src/test/resources/class/class_scope.hsl
+++ b/hartshorn-hsl/src/test/resources/class/class_scope.hsl
@@ -1,13 +1,13 @@
 class Function {
-    fun accept () {
+    function accept () {
         print(1);
     }
 }
 
-var function = Function();
+var sample = Function();
 
-fun callback(caller) {
+function callback(caller) {
    caller.accept();
 }
 
-callback(function);
+callback(sample);

--- a/hartshorn-hsl/src/test/resources/class/class_super.hsl
+++ b/hartshorn-hsl/src/test/resources/class/class_super.hsl
@@ -1,11 +1,11 @@
 class Human {
-   fun printType() {
+   function printType() {
       print("I am a Human");
    }
 }
 
 class Engineer extends Human {
-   fun printType() {
+   function printType() {
       super.printType();
       print("I am an Engineer");
    }

--- a/hartshorn-hsl/src/test/resources/function/function.hsl
+++ b/hartshorn-hsl/src/test/resources/function/function.hsl
@@ -1,4 +1,4 @@
-fun count(n) {
+function count(n) {
   if (n > 1) {
      count(n - 1);
   }

--- a/hartshorn-hsl/src/test/resources/function/function_fibonacci.hsl
+++ b/hartshorn-hsl/src/test/resources/function/function_fibonacci.hsl
@@ -1,4 +1,4 @@
-fun fibonacci(n) {
+function fibonacci(n) {
   if (n <= 1) {
      return n;
   }

--- a/hartshorn-hsl/src/test/resources/function/function_infix.hsl
+++ b/hartshorn-hsl/src/test/resources/function/function_infix.hsl
@@ -1,4 +1,4 @@
-infix fun orDefault(value, defaultValue) {
+infix function orDefault(value, defaultValue) {
     if (value == null) {
         return defaultValue;
     }

--- a/hartshorn-hsl/src/test/resources/function/function_nested.hsl
+++ b/hartshorn-hsl/src/test/resources/function/function_nested.hsl
@@ -1,5 +1,5 @@
-fun makePoint(x, y) {
-  fun closure(method) {
+function makePoint(x, y) {
+  function closure(method) {
     if (method == "x") {
        return x;
     }

--- a/hartshorn-hsl/src/test/resources/function/function_parameters.hsl
+++ b/hartshorn-hsl/src/test/resources/function/function_parameters.hsl
@@ -1,4 +1,4 @@
-fun sayHi(first, last) {
+function sayHi(first, last) {
   print("Hi, " + first + " " + last + "!");
 }
 

--- a/hartshorn-hsl/src/test/resources/function/function_reference.hsl
+++ b/hartshorn-hsl/src/test/resources/function/function_reference.hsl
@@ -1,8 +1,8 @@
-fun printCallback() {
+function printCallback() {
    print("Callback is run :D");
 }
 
-fun testCallback(callback) {
+function testCallback(callback) {
     callback();
 }
 

--- a/hartshorn-hsl/src/test/resources/function/function_return.hsl
+++ b/hartshorn-hsl/src/test/resources/function/function_return.hsl
@@ -1,4 +1,4 @@
-fun count(n) {
+function count(n) {
   while (n < 100) {
     if (n == 3) {
         return n;

--- a/hartshorn-hsl/src/test/resources/function/function_simple.hsl
+++ b/hartshorn-hsl/src/test/resources/function/function_simple.hsl
@@ -1,4 +1,4 @@
-fun sum(x,y) {
+function sum(x,y) {
    print(x + y);
 }
 

--- a/hartshorn-hsl/src/test/resources/function/special/infix_arrays.hsl
+++ b/hartshorn-hsl/src/test/resources/function/special/infix_arrays.hsl
@@ -1,6 +1,6 @@
 var length = 2;
 
-fun arrayContains(arr, obj) {
+function arrayContains(arr, obj) {
    for (var o in arr) {
       if (o == obj) {
          return true;
@@ -10,7 +10,7 @@ fun arrayContains(arr, obj) {
 }
 
 var arr = ["One", "Two"];
-infix fun contains(arr, obj) {
+infix function contains(arr, obj) {
     return arrayContains(arr, obj);
 }
 

--- a/hartshorn-hsl/src/test/resources/function/special/infix_prefix.hsl
+++ b/hartshorn-hsl/src/test/resources/function/special/infix_prefix.hsl
@@ -1,8 +1,8 @@
-prefix fun say(message) {
+prefix function say(message) {
    print(message + "\n");
 }
 
-infix fun to(left, right) {
+infix function to(left, right) {
    return left + " " + right;
 }
 

--- a/hartshorn-hsl/src/test/resources/function/special/infix_simple.hsl
+++ b/hartshorn-hsl/src/test/resources/function/special/infix_simple.hsl
@@ -1,4 +1,4 @@
-infix fun sum(x, y) {
+infix function sum(x, y) {
    return x + y;
 }
 

--- a/hartshorn-hsl/src/test/resources/function/special/prefix.hsl
+++ b/hartshorn-hsl/src/test/resources/function/special/prefix.hsl
@@ -1,4 +1,4 @@
-prefix fun multiByTen(x) {
+prefix function multiByTen(x) {
    return x * 10;
 }
 

--- a/hartshorn-hsl/src/test/resources/module/module_math.hsl
+++ b/hartshorn-hsl/src/test/resources/module/module_math.hsl
@@ -1,4 +1,4 @@
-using math;
+import math;
 
 var x = 9;
 var y = 2;

--- a/hartshorn-hsl/src/test/resources/module/module_system.hsl
+++ b/hartshorn-hsl/src/test/resources/module/module_system.hsl
@@ -1,4 +1,4 @@
-using system;
+import system;
 
 print("Current os name is : " + env("os.name") + "\n");
 

--- a/hartshorn-hsl/src/test/resources/other/prints.hsl
+++ b/hartshorn-hsl/src/test/resources/other/prints.hsl
@@ -1,9 +1,9 @@
-fun hello () {
+function hello () {
    print("Hello World");
 }
 
 class ClassTestValue {
-  fun serveOn() {
+  function serveOn() {
     return "Scones";
   }
 }

--- a/hartshorn-hsl/src/test/resources/other/test_assert.hsl
+++ b/hartshorn-hsl/src/test/resources/other/test_assert.hsl
@@ -1,4 +1,4 @@
-fun sum(x, y) {
+function sum(x, y) {
    return x + y;
 }
 


### PR DESCRIPTION
# Description
When initially designing HSL, we chose for a 'less is more' approach. Meaning we attempted to reduce verbosity, while retaining the availibility of functionality. While I still stand behind this goal of reducing verbosity, I have since come to notice that the reduced amount of characters does in fact not improve the readability of HSL code. As a result, this PR serves as a beginning to resolve this by tackling the most prominent issues first. This is done in three steps:
1. Renaming abbreviated/length-reduced keywords to their fully qualified counterpart (e.g. `fun` to `function`) where this is relevant (e.g. `var` will remain `var`, and will not become `variable`)
2. Aligning more with familiar keywords in Java (e.g. `import` instead of `using`)
3. Reserve keywords which are intended to be supported in future releases (e.g. `try`, `instanceof`, `yield`, and `interface`)

Fixes #931

## Type of change
- [x] New feature (reserved tokens)
- [x] Breaking change (syntax change in HSL)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
