### PR TITLE
#950 Resolve incorrect implementation of Closeable in ApplicationContext

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationContextConstructor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationContextConstructor.java
@@ -69,7 +69,7 @@ public class StandardApplicationContextConstructor implements ApplicationContext
                 if (!applicationContext.isClosed()) {
                     applicationContext.close();
                 }
-            } catch (final IOException e) {
+            } catch (final Exception e) {
                 this.logger.error("Failed to close application context", e);
             }
         }, "ShutdownHook"));

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
@@ -27,6 +27,7 @@ import org.dockbox.hartshorn.component.processing.ComponentProcessor;
 import org.dockbox.hartshorn.context.ApplicationAwareContext;
 import org.dockbox.hartshorn.logging.ApplicationLogger;
 import org.dockbox.hartshorn.logging.LogExclude;
+import org.dockbox.hartshorn.util.ApplicationException;
 import org.slf4j.Logger;
 
 /**
@@ -94,4 +95,7 @@ public interface ApplicationContext extends
     default Class<? extends Scope> installableScopeType() {
         return ApplicationContext.class;
     }
+
+    @Override
+    void close() throws ApplicationException;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
@@ -22,14 +22,12 @@ import org.dockbox.hartshorn.application.ApplicationPropertyHolder;
 import org.dockbox.hartshorn.application.ExceptionHandler;
 import org.dockbox.hartshorn.application.environment.ApplicationEnvironment;
 import org.dockbox.hartshorn.component.HierarchicalComponentProvider;
-import org.dockbox.hartshorn.component.processing.ComponentProcessor;
 import org.dockbox.hartshorn.component.Scope;
+import org.dockbox.hartshorn.component.processing.ComponentProcessor;
 import org.dockbox.hartshorn.context.ApplicationAwareContext;
 import org.dockbox.hartshorn.logging.ApplicationLogger;
 import org.dockbox.hartshorn.logging.LogExclude;
 import org.slf4j.Logger;
-
-import java.io.Closeable;
 
 /**
  * The primary context for an application. This context is responsible for providing the application
@@ -57,7 +55,7 @@ public interface ApplicationContext extends
         ExceptionHandler,
         ActivatorHolder,
         Scope,
-        Closeable {
+        AutoCloseable {
 
     /**
      * Registers a component processor with the application context. The processor will be invoked when

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/lifecycle/LifecycleObserverTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/lifecycle/LifecycleObserverTests.java
@@ -21,29 +21,27 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 public class LifecycleObserverTests {
 
     @Test
-    void testServiceLifecycleObserverIsPresentAndObserving() throws IOException {
+    void testServiceLifecycleObserverIsPresentAndObserving() {
         final ApplicationContext applicationContext = HartshornApplication.create();
         final TestLifecycleObserver observer = applicationContext.get(TestLifecycleObserver.class);
         Assertions.assertTrue(observer.started());
 
-        applicationContext.close();
+        Assertions.assertDoesNotThrow(applicationContext::close);
         Assertions.assertTrue(observer.stopped());
     }
 
     @Test
-    void testNonRegisteredObserverIsNotPresentOnStart() throws IOException {
+    void testNonRegisteredObserverIsNotPresentOnStart() {
         final ApplicationContext applicationContext = HartshornApplication.create();
         final NonRegisteredObserver observer = applicationContext.get(NonRegisteredObserver.class);
         Assertions.assertFalse(observer.started());
         Assertions.assertFalse(observer.stopped());
 
         applicationContext.environment().register(observer);
-        applicationContext.close();
+        Assertions.assertDoesNotThrow(applicationContext::close);
 
         // Do not late-fire events
         Assertions.assertFalse(observer.started());
@@ -51,7 +49,7 @@ public class LifecycleObserverTests {
     }
 
     @Test
-    void testRegistrationFromClassIsValid() throws IOException {
+    void testRegistrationFromClassIsValid() {
         final ApplicationContext applicationContext = HartshornApplication.create();
         // Static as observer instance is lazily created by the observable, so we cannot
         // access it directly.
@@ -59,7 +57,7 @@ public class LifecycleObserverTests {
         Assertions.assertFalse(StaticNonRegisteredObserver.stopped());
 
         applicationContext.environment().register(StaticNonRegisteredObserver.class);
-        applicationContext.close();
+        Assertions.assertDoesNotThrow(applicationContext::close);
 
         // Do not late-fire events
         Assertions.assertFalse(StaticNonRegisteredObserver.started());

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
@@ -71,7 +71,7 @@ public class HartshornLifecycleExtension implements
     }
 
     @Override
-    public void afterEach(final ExtensionContext context) throws Exception {
+    public void afterEach(final ExtensionContext context) throws ApplicationException {
         this.afterLifecycle();
     }
 
@@ -85,7 +85,7 @@ public class HartshornLifecycleExtension implements
     }
 
     @Override
-    public void afterAll(final ExtensionContext context) throws Exception {
+    public void afterAll(final ExtensionContext context) throws ApplicationException {
         if (this.isClassLifecycle(context)) {
             this.afterLifecycle();
         }
@@ -93,7 +93,7 @@ public class HartshornLifecycleExtension implements
 
     private boolean isClassLifecycle(final ExtensionContext context) {
         final Optional<Lifecycle> lifecycle = context.getTestInstanceLifecycle();
-        return lifecycle.isPresent() && Lifecycle.PER_CLASS.equals(lifecycle.get());
+        return lifecycle.isPresent() && Lifecycle.PER_CLASS == lifecycle.get();
     }
 
     protected void beforeLifecycle(final Class<?> testClass, final Object testInstance, final AnnotatedElement... testComponentSources) throws ApplicationException {
@@ -120,7 +120,7 @@ public class HartshornLifecycleExtension implements
         this.applicationContext = applicationContext;
     }
 
-    protected void afterLifecycle() throws Exception {
+    protected void afterLifecycle() throws ApplicationException {
         Mockito.clearAllCaches();
         if (this.applicationContext != null) {
             this.applicationContext.close();

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.mockito.Mockito;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -72,7 +71,7 @@ public class HartshornLifecycleExtension implements
     }
 
     @Override
-    public void afterEach(final ExtensionContext context) throws IOException {
+    public void afterEach(final ExtensionContext context) throws Exception {
         this.afterLifecycle();
     }
 
@@ -86,7 +85,7 @@ public class HartshornLifecycleExtension implements
     }
 
     @Override
-    public void afterAll(final ExtensionContext context) throws IOException {
+    public void afterAll(final ExtensionContext context) throws Exception {
         if (this.isClassLifecycle(context)) {
             this.afterLifecycle();
         }
@@ -121,7 +120,7 @@ public class HartshornLifecycleExtension implements
         this.applicationContext = applicationContext;
     }
 
-    protected void afterLifecycle() throws IOException {
+    protected void afterLifecycle() throws Exception {
         Mockito.clearAllCaches();
         if (this.applicationContext != null) {
             this.applicationContext.close();


### PR DESCRIPTION
# Description
ApplicationContext currently implements Closeable, which is designed to mark closeable data handlers. The ApplicationContext tracks resources, but is not specifically bound to persistent data, thus making Closeable incorrect in this context.

These changes replace the implementation of Closeable with AutoCloseable, and update relevant usages. Additionally, the `throws` clause is constrained to just `ApplicationException` to limit the allowed exception types to be thrown. This is a minor change, as it only changes the exception signature. Remaining details remain the same.

Fixes #950

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing (existing tests)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
