### PR TITLE
#958 Update Introspection API to support sealed classes, #959 update modifier introspection

### DIFF
--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/HashCodeKeyGenerator.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/HashCodeKeyGenerator.java
@@ -28,7 +28,7 @@ import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 public class HashCodeKeyGenerator implements KeyGenerator {
 
     @Override
-    public String generateKey(final AnnotatedElementView<?> element) {
+    public String generateKey(final AnnotatedElementView element) {
         return element.name() + "_" + element.hashCode();
     }
 }

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/KeyGenerator.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/KeyGenerator.java
@@ -33,5 +33,5 @@ public interface KeyGenerator {
      * @param element the annotated element
      * @return the generated key
      */
-    String generateKey(AnnotatedElementView<?> element);
+    String generateKey(AnnotatedElementView element);
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/CommandExecutorContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/CommandExecutorContext.java
@@ -96,7 +96,7 @@ public interface CommandExecutorContext extends ApplicationAwareContext {
      *
      * @return The annotated element.
      */
-    AnnotatedElementView<?> element();
+    AnnotatedElementView element();
 
     /**
      * Gets the suggestions to complete the currently incomplete argument or flag. This may either be an alias, or element value,

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
@@ -196,7 +196,7 @@ public class MethodCommandExecutorContext<T> extends DefaultApplicationAwareCont
     }
 
     @Override
-    public AnnotatedElementView<?> element() {
+    public AnnotatedElementView element() {
         return this.method();
     }
 

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ArgumentSerializationSourceConverter.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ArgumentSerializationSourceConverter.java
@@ -36,7 +36,7 @@ import java.nio.file.Path;
 public class ArgumentSerializationSourceConverter implements SerializationSourceConverter {
 
     @Override
-    public InputStream inputStream(final AnnotatedElementView<?> context, final Object... args) throws ApplicationException {
+    public InputStream inputStream(final AnnotatedElementView context, final Object... args) throws ApplicationException {
         if (args.length != 1) {
             return null;
         }
@@ -71,7 +71,7 @@ public class ArgumentSerializationSourceConverter implements SerializationSource
     }
 
     @Override
-    public OutputStream outputStream(final AnnotatedElementView<?> context, final Object... args) throws ApplicationException {
+    public OutputStream outputStream(final AnnotatedElementView context, final Object... args) throws ApplicationException {
         if (args.length != 1) {
             return null;
         }

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/PathSerializationSourceConverter.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/PathSerializationSourceConverter.java
@@ -40,7 +40,7 @@ public class PathSerializationSourceConverter implements SerializationSourceConv
     private ApplicationFSProvider fileSystem;
 
     @Override
-    public InputStream inputStream(final AnnotatedElementView<?> context, final Object... args) {
+    public InputStream inputStream(final AnnotatedElementView context, final Object... args) {
         return this.resolvePath(context)
                 .map(path -> {
                     try {
@@ -55,7 +55,7 @@ public class PathSerializationSourceConverter implements SerializationSourceConv
     }
 
     @Override
-    public OutputStream outputStream(final AnnotatedElementView<?> context, final Object... args) {
+    public OutputStream outputStream(final AnnotatedElementView context, final Object... args) {
         return this.resolvePath(context).map(path -> {
                     try {
                         return Files.newOutputStream(path);
@@ -67,7 +67,7 @@ public class PathSerializationSourceConverter implements SerializationSourceConv
                 .orNull();
     }
 
-    private Option<Path> resolvePath(final AnnotatedElementView<?> context) {
+    private Option<Path> resolvePath(final AnnotatedElementView context) {
         return context.annotations().get(FileSource.class)
                 .map(fileSource -> {
                     if (fileSource.relativeToApplicationPath()) {

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/SerializationSourceConverter.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/SerializationSourceConverter.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public interface SerializationSourceConverter {
-    InputStream inputStream(AnnotatedElementView<?> context, Object... args) throws ApplicationException;
+    InputStream inputStream(AnnotatedElementView context, Object... args) throws ApplicationException;
 
-    OutputStream outputStream(AnnotatedElementView<?> context, Object... args) throws ApplicationException;
+    OutputStream outputStream(AnnotatedElementView context, Object... args) throws ApplicationException;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/BeanServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/beans/BeanServicePreProcessor.java
@@ -16,6 +16,8 @@
 
 package org.dockbox.hartshorn.beans;
 
+import java.util.List;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.application.environment.ApplicationEnvironment;
 import org.dockbox.hartshorn.application.lifecycle.ObservableApplicationEnvironment;
@@ -27,15 +29,12 @@ import org.dockbox.hartshorn.introspect.ViewContextAdapter;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.ApplicationRuntimeException;
 import org.dockbox.hartshorn.util.TypeUtils;
-import org.dockbox.hartshorn.util.introspect.AccessModifier;
 import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 import org.dockbox.hartshorn.util.introspect.view.FieldView;
 import org.dockbox.hartshorn.util.introspect.view.GenericTypeView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.ModifierCarrierView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
-
-import java.util.List;
 
 public class BeanServicePreProcessor extends ComponentPreProcessor implements ExitingComponentProcessor {
 
@@ -55,7 +54,7 @@ public class BeanServicePreProcessor extends ComponentPreProcessor implements Ex
         }
     }
 
-    private <T, E extends AnnotatedElementView<T>
+    private <T, E extends AnnotatedElementView
             & ModifierCarrierView
             & GenericTypeView<T>>
     void process(final ApplicationContext applicationContext, final BeanCollector context, final List<E> elements) throws ApplicationException {
@@ -64,7 +63,7 @@ public class BeanServicePreProcessor extends ComponentPreProcessor implements Ex
         final ViewContextAdapter adapter = applicationContext.get(ViewContextAdapter.class);
         final ConditionMatcher conditionMatcher = applicationContext.get(ConditionMatcher.class);
         for (final E element : elements) {
-            if (!element.has(AccessModifier.STATIC)) {
+            if (!element.modifiers().isStatic()) {
                 throw new ApplicationException("Bean service pre-processor can only process static fields and methods");
             }
             if (conditionMatcher.match(element)) {
@@ -73,7 +72,7 @@ public class BeanServicePreProcessor extends ComponentPreProcessor implements Ex
         }
     }
 
-    private <T, E extends AnnotatedElementView<T>
+    private <T, E extends AnnotatedElementView
             & ModifierCarrierView
             & GenericTypeView<T>>
     void process(final ViewContextAdapter adapter, final E element, final BeanCollector context) throws ApplicationException {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ContextualComponentPopulator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ContextualComponentPopulator.java
@@ -184,7 +184,7 @@ public class ContextualComponentPopulator implements ComponentPopulator, Context
         field.set(instance, context.orNull());
     }
 
-    private boolean isComponentRequired(final AnnotatedElementView<?> view) {
+    private boolean isComponentRequired(final AnnotatedElementView view) {
         return Boolean.TRUE.equals(view.annotations().get(Required.class)
                 .map(Required::value)
                 .orElse(false));

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionContext.java
@@ -22,7 +22,7 @@ import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 
 public class ConditionContext extends DefaultApplicationAwareContext {
 
-    private final AnnotatedElementView<?> annotatedElementContext;
+    private final AnnotatedElementView annotatedElementContext;
     private final RequiresCondition condition;
 
     public ConditionContext(final ApplicationContext applicationContext, final AnnotatedElementView<?> annotatedElementContext, final RequiresCondition condition) {
@@ -31,7 +31,7 @@ public class ConditionContext extends DefaultApplicationAwareContext {
         this.condition = condition;
     }
 
-    public AnnotatedElementView<?> annotatedElement() {
+    public AnnotatedElementView annotatedElement() {
         return this.annotatedElementContext;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionContext.java
@@ -25,7 +25,7 @@ public class ConditionContext extends DefaultApplicationAwareContext {
     private final AnnotatedElementView annotatedElementContext;
     private final RequiresCondition condition;
 
-    public ConditionContext(final ApplicationContext applicationContext, final AnnotatedElementView<?> annotatedElementContext, final RequiresCondition condition) {
+    public ConditionContext(final ApplicationContext applicationContext, final AnnotatedElementView annotatedElementContext, final RequiresCondition condition) {
         super(applicationContext);
         this.annotatedElementContext = annotatedElementContext;
         this.condition = condition;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionMatcher.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionMatcher.java
@@ -30,7 +30,7 @@ public class ConditionMatcher {
         this.applicationContext = applicationContext;
     }
 
-    public boolean match(final AnnotatedElementView<?> annotatedElementContext, final Context... contexts) {
+    public boolean match(final AnnotatedElementView annotatedElementContext, final Context... contexts) {
         final Set<RequiresCondition> conditions = annotatedElementContext.annotations().all(RequiresCondition.class);
         for (final RequiresCondition condition : conditions) {
             final Class<? extends Condition> conditionClass = condition.condition();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionMatcher.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionMatcher.java
@@ -16,11 +16,11 @@
 
 package org.dockbox.hartshorn.component.condition;
 
+import java.util.Set;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
-
-import java.util.Set;
 
 public class ConditionMatcher {
 
@@ -43,7 +43,7 @@ public class ConditionMatcher {
         return true;
     }
 
-    public boolean match(final AnnotatedElementView<?> element, final Condition condition, final RequiresCondition requiresCondition, final Context... contexts) {
+    public boolean match(final AnnotatedElementView element, final Condition condition, final RequiresCondition requiresCondition, final Context... contexts) {
         final ConditionContext context = new ConditionContext(this.applicationContext, element, requiresCondition);
         for (final Context child : contexts) context.add(child);
         final ConditionResult result = condition.matches(context);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ProvidedParameterContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ProvidedParameterContext.java
@@ -46,7 +46,7 @@ public final class ProvidedParameterContext extends DefaultProvisionContext {
         return new ProvidedParameterContext(argumentMap);
     }
 
-    public static ProvidedParameterContext of(final ExecutableElementView<?, ?> executable, final List<Object> arguments) {
+    public static ProvidedParameterContext of(final ExecutableElementView<?> executable, final List<Object> arguments) {
         return of(executable.parameters().all(), arguments);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/FactoryServicePostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/FactoryServicePostProcessor.java
@@ -49,7 +49,7 @@ public class FactoryServicePostProcessor extends ServiceAnnotatedMethodIntercept
         final MethodView<T, R> method = (MethodView<T, R>) methodContext.method();
         final ConversionService conversionService = context.get(ConversionService.class);
         final boolean enable = Boolean.TRUE.equals(method.annotations().get(Enable.class).map(Enable::value).orElse(true));
-        if (method.isAbstract()) {
+        if (method.modifiers().isAbstract()) {
             final FactoryContext factoryContext = context.first(FactoryContext.class).get();
 
             final Option<? extends ConstructorView<?>> constructorCandidate = factoryContext.get(method);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentFinalizingPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentFinalizingPostProcessor.java
@@ -40,7 +40,7 @@ public class ComponentFinalizingPostProcessor extends ComponentPostProcessor {
                 final ProxyFactory<T> factory = processingContext.get(ComponentKey.of(ProxyFactory.class));
                 try {
                     final boolean stateModified = factory instanceof StateAwareProxyFactory<T> stateAwareProxyFactory && stateAwareProxyFactory.modified();
-                    final boolean noConcreteInstancePossible = instance == null && processingContext.type().isAbstract();
+                    final boolean noConcreteInstancePossible = instance == null && processingContext.type().modifiers().isAbstract();
                     if (stateModified || noConcreteInstancePossible) {
                         finalizingInstance = this.createProxyInstance(context, factory, instance);
                     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/proxy/PhasedProxyCallbackPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/proxy/PhasedProxyCallbackPostProcessor.java
@@ -49,7 +49,7 @@ public abstract class PhasedProxyCallbackPostProcessor extends FunctionalCompone
             final MethodWrapper<T> wrapper = MethodWrapper.of(before, after, afterThrowing);
 
             if (before != null || after != null || afterThrowing != null) {
-                factory.wrapAround(method.method(), wrapper);
+                factory.wrapAround(method, wrapper);
             }
         }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/proxy/ProxyMethodBindingException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/proxy/ProxyMethodBindingException.java
@@ -27,7 +27,7 @@ public class ProxyMethodBindingException extends RuntimeException {
     }
 
     public ProxyMethodBindingException(final MethodView<?, ?> ctx) {
-        this(ctx.method());
+        super("Could not bind proxy to " + ctx.name() + " because preconditions failed");
     }
 
     public ProxyMethodBindingException(final Method method) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/proxy/ServiceMethodInterceptorPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/proxy/ServiceMethodInterceptorPostProcessor.java
@@ -16,6 +16,8 @@
 
 package org.dockbox.hartshorn.component.processing.proxy;
 
+import java.util.Collection;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentContainer;
@@ -25,9 +27,8 @@ import org.dockbox.hartshorn.component.processing.FunctionalComponentPostProcess
 import org.dockbox.hartshorn.component.processing.ProcessingOrder;
 import org.dockbox.hartshorn.proxy.MethodInterceptor;
 import org.dockbox.hartshorn.proxy.ProxyFactory;
+import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
-
-import java.util.Collection;
 
 public abstract class ServiceMethodInterceptorPostProcessor extends FunctionalComponentPostProcessor {
 
@@ -43,11 +44,11 @@ public abstract class ServiceMethodInterceptorPostProcessor extends FunctionalCo
 
             if (this.preconditions(context, ctx, processingContext)) {
                 final MethodInterceptor<T, ?> function = this.process(context, ctx, processingContext);
-                if (function != null) factory.intercept(method.method(), function);
+                if (function != null) factory.intercept(method, TypeUtils.adjustWildcards(function, MethodInterceptor.class));
             }
             else {
                 if (this.failOnPrecondition()) {
-                    throw new ProxyMethodBindingException(method.method());
+                    throw new ProxyMethodBindingException(method);
                 }
             }
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/CyclingConstructorAnalyzer.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/CyclingConstructorAnalyzer.java
@@ -37,7 +37,7 @@ public final class CyclingConstructorAnalyzer {
     }
 
     private static <C> Attempt<ConstructorView<C>, ? extends ApplicationException> findConstructor(final TypeView<C> type, final boolean checkForCycles) {
-        if (type.isAbstract()) return Attempt.empty();
+        if (type.modifiers().isAbstract()) return Attempt.empty();
         if (cache.containsKey(type.type())) {
             return Attempt.of((ConstructorView<C>) cache.get(type.type()));
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/BindingProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/BindingProcessor.java
@@ -16,6 +16,10 @@
 
 package org.dockbox.hartshorn.inject.processing;
 
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentContainer;
 import org.dockbox.hartshorn.component.ComponentKey;
@@ -38,10 +42,6 @@ import org.dockbox.hartshorn.util.introspect.view.FieldView;
 import org.dockbox.hartshorn.util.introspect.view.GenericTypeView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.View;
-
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.inject.Singleton;
 
@@ -88,8 +88,8 @@ public class BindingProcessor {
         }
     }
 
-    private <R> void processInstanceBinding(final ApplicationContext context,
-                                            final AnnotatedElementView element, final ComponentKey<R> key,
+    private <R, E extends AnnotatedElementView & GenericTypeView<R>> void processInstanceBinding(final ApplicationContext context,
+                                            final E element, final ComponentKey<R> key,
                                             final boolean singleton, final Binds annotation) throws ApplicationException {
         final BindingFunction<R> function = context.bind(key).priority(annotation.priority());
         element.annotations().get(InstallTo.class).peek(a -> function.installTo(a.value()));
@@ -106,8 +106,9 @@ public class BindingProcessor {
         else function.to(supplier);
     }
 
-    private <R, C extends Class<R>> void processClassBinding(final ApplicationContext context, final AnnotatedElementView element,
-                                                             final ComponentKey<R> key, boolean singleton, final Binds annotation) throws ApplicationException {
+    private <R, C extends Class<R>, E extends AnnotatedElementView & GenericTypeView<C>> void processClassBinding(final ApplicationContext context,
+                                                             final E element, final ComponentKey<R> key, boolean singleton,
+                                                             final Binds annotation) throws ApplicationException {
         final ViewContextAdapter contextAdapter = new IntrospectionViewContextAdapter(context);
         final C targetType = contextAdapter.load(element)
                 .mapError(error -> new ComponentInitializationException("Failed to obtain class type for " + element.qualifiedName(), error))

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/BindingProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/BindingProcessor.java
@@ -56,7 +56,7 @@ public class BindingProcessor {
             for (final ProviderContext provider : elements.get(phase)) {
 
                 final ComponentKey<?> key = provider.key();
-                final AnnotatedElementView<?> element = provider.element();
+                final AnnotatedElementView element = provider.element();
 
                 applicationContext.log().debug("Processing provider context of " + element.qualifiedName() + " for " + key + " in phase " + phase);
 
@@ -70,8 +70,8 @@ public class BindingProcessor {
         }
     }
 
-    private <R, E extends AnnotatedElementView<?> & GenericTypeView<?>> void process(final ComponentKey<R> key, final E element,
-                                                                                     final ApplicationContext applicationContext) throws ApplicationException {
+    private <R, E extends AnnotatedElementView & GenericTypeView<?>> void process(final ComponentKey<R> key, final E element,
+                                                                                  final ApplicationContext applicationContext) throws ApplicationException {
         final ConditionMatcher conditionMatcher = applicationContext.get(ConditionMatcher.class);
         final Binds annotation = element.annotations().get(Binds.class).get();
 
@@ -89,7 +89,7 @@ public class BindingProcessor {
     }
 
     private <R> void processInstanceBinding(final ApplicationContext context,
-                                            final AnnotatedElementView<R> element, final ComponentKey<R> key,
+                                            final AnnotatedElementView element, final ComponentKey<R> key,
                                             final boolean singleton, final Binds annotation) throws ApplicationException {
         final BindingFunction<R> function = context.bind(key).priority(annotation.priority());
         element.annotations().get(InstallTo.class).peek(a -> function.installTo(a.value()));
@@ -106,7 +106,7 @@ public class BindingProcessor {
         else function.to(supplier);
     }
 
-    private <R, C extends Class<R>> void processClassBinding(final ApplicationContext context, final AnnotatedElementView<C> element,
+    private <R, C extends Class<R>> void processClassBinding(final ApplicationContext context, final AnnotatedElementView element,
                                                              final ComponentKey<R> key, boolean singleton, final Binds annotation) throws ApplicationException {
         final ViewContextAdapter contextAdapter = new IntrospectionViewContextAdapter(context);
         final C targetType = contextAdapter.load(element)

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ComponentContextInjectionPreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ComponentContextInjectionPreProcessor.java
@@ -39,17 +39,17 @@ public class ComponentContextInjectionPreProcessor extends ComponentPreProcessor
         for (final FieldView<T, ?> field : processingContext.type().fields().annotatedWith(Context.class))
             this.validate(field, processingContext);
 
-        final List<ExecutableElementView<T, ?>> constructors = processingContext.type().constructors().injectable()
-                .stream().map(c -> (ExecutableElementView<T, ?>) c)
+        final List<ExecutableElementView<T>> constructors = processingContext.type().constructors().injectable()
+                .stream().map(c -> (ExecutableElementView<T>) c)
                 .collect(Collectors.toList());
 
-        final List<ExecutableElementView<T, ?>> methods = processingContext.type().methods().all().stream()
-                .map(m -> (ExecutableElementView<T, ?>) m)
+        final List<ExecutableElementView<T>> methods = processingContext.type().methods().all().stream()
+                .map(m -> (ExecutableElementView<T>) m)
                 .collect(Collectors.toList());
 
-        final Collection<ExecutableElementView<T, ?>> executables = CollectionUtilities.merge(constructors, methods);
+        final Collection<ExecutableElementView<T>> executables = CollectionUtilities.merge(constructors, methods);
 
-        for (final ExecutableElementView<T, ?> executable : executables)
+        for (final ExecutableElementView<T> executable : executables)
             for (final ParameterView<?> parameter : executable.parameters().annotedWith(Context.class))
                 this.validate(parameter, processingContext);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContext.java
@@ -23,10 +23,10 @@ import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 public class ProviderContext {
 
     private final ComponentKey<?> key;
-    private final AnnotatedElementView<?> element;
+    private final AnnotatedElementView element;
     private final Binds binding;
 
-    public ProviderContext(final ComponentKey<?> key, final AnnotatedElementView<?> element, final Binds binding) {
+    public ProviderContext(final ComponentKey<?> key, final AnnotatedElementView element, final Binds binding) {
         this.key = key;
         this.element = element;
         this.binding = binding;
@@ -36,7 +36,7 @@ public class ProviderContext {
         return this.key;
     }
 
-    public AnnotatedElementView<?> element() {
+    public AnnotatedElementView element() {
         return this.element;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderServicePreProcessor.java
@@ -51,7 +51,7 @@ public final class ProviderServicePreProcessor extends ComponentPreProcessor imp
         }
     }
 
-    private <E extends AnnotatedElementView<?> & GenericTypeView<?>> void register(final ProviderContextList context, final E element) {
+    private <E extends AnnotatedElementView & GenericTypeView<?>> void register(final ProviderContextList context, final E element) {
         final ComponentKey<?> key = this.key(element);
         final Binds binding = element.annotations().get(Binds.class).get();
         final ProviderContext providerContext = new ProviderContext(key, element, binding);
@@ -71,7 +71,7 @@ public final class ProviderServicePreProcessor extends ComponentPreProcessor imp
         }
     }
 
-    private <E extends AnnotatedElementView<?> & GenericTypeView<?>> ComponentKey<?> key(final E element) {
+    private <E extends AnnotatedElementView & GenericTypeView<?>> ComponentKey<?> key(final E element) {
         final Binds annotation = element.annotations().get(Binds.class).get();
         if (element.type().is(Class.class) || element.type().is(TypeView.class)) {
             final TypeView<?> view = element.genericType().typeParameters().at(0).get();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/IntrospectionViewContextAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/IntrospectionViewContextAdapter.java
@@ -20,10 +20,11 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.Scope;
 import org.dockbox.hartshorn.util.ApplicationBoundParameterLoaderContext;
-import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
+import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 import org.dockbox.hartshorn.util.introspect.view.FieldView;
+import org.dockbox.hartshorn.util.introspect.view.GenericTypeView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.ParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
@@ -95,21 +96,22 @@ public class IntrospectionViewContextAdapter implements ViewContextAdapter {
     }
 
     @Override
-    public <T> Attempt<T, Throwable> load(final AnnotatedElementView element) {
-        if (element instanceof TypeView<T> typeView) {
-            return Attempt.of(this.applicationContext().get(this.key(typeView.type())));
+    public <T> Attempt<T, Throwable> load(final GenericTypeView<T> element) {
+        if (element instanceof TypeView<?> typeView) {
+            final ComponentKey<T> key = this.key(TypeUtils.adjustWildcards(typeView.type(), Class.class));
+            return Attempt.of(this.applicationContext().get(key));
         }
-        else if (element instanceof FieldView<?, T> fieldView) {
-            return this.load(fieldView);
+        else if (element instanceof FieldView<?, ?> fieldView) {
+            return this.load(TypeUtils.adjustWildcards(fieldView, FieldView.class));
         }
-        else if (element instanceof MethodView<?, T> methodView) {
-            return this.invoke(methodView);
+        else if (element instanceof MethodView<?, ?> methodView) {
+            return this.invoke(TypeUtils.adjustWildcards(methodView, MethodView.class));
         }
-        else if (element instanceof ConstructorView<T> constructorView) {
-            return this.create(constructorView);
+        else if (element instanceof ConstructorView<?> constructorView) {
+            return this.create(TypeUtils.adjustWildcards(constructorView, ConstructorView.class));
         }
-        else if (element instanceof ParameterView<T> parameterView) {
-            final ComponentKey<T> key = this.key(parameterView.type().type());
+        else if (element instanceof ParameterView<?> parameterView) {
+            final ComponentKey<T> key = this.key(TypeUtils.adjustWildcards(parameterView.type().type(), Class.class));
             return Attempt.of(this.applicationContext().get(key));
         }
         return Attempt.of(new IllegalArgumentException("Unsupported element type: " + element.getClass().getName()));

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/IntrospectionViewContextAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/IntrospectionViewContextAdapter.java
@@ -63,7 +63,7 @@ public class IntrospectionViewContextAdapter implements ViewContextAdapter {
     }
 
     @Override
-    public Object[] loadParameters(final ExecutableElementView<?, ?> element) {
+    public Object[] loadParameters(final ExecutableElementView<?> element) {
         final ExecutableElementContextParameterLoader parameterLoader = new ExecutableElementContextParameterLoader();
         final ApplicationBoundParameterLoaderContext loaderContext = new ApplicationBoundParameterLoaderContext(element, null, this.applicationContext(), this.scope);
         return parameterLoader.loadArguments(loaderContext).toArray();
@@ -71,7 +71,7 @@ public class IntrospectionViewContextAdapter implements ViewContextAdapter {
 
     @Override
     public <P, R> Attempt<R, Throwable> invoke(final MethodView<P, R> method) {
-        if (method.isStatic()) {
+        if (method.modifiers().isStatic()) {
             return this.invokeStatic(method);
         }
         final Object[] parameters = this.loadParameters(method);
@@ -81,7 +81,7 @@ public class IntrospectionViewContextAdapter implements ViewContextAdapter {
 
     @Override
     public <P, R> Attempt<R, Throwable> invokeStatic(final MethodView<P, R> method) {
-        if (!method.isStatic()) {
+        if (!method.modifiers().isStatic()) {
             return this.invoke(method);
         }
         final Object[] parameters = this.loadParameters(method);
@@ -95,7 +95,7 @@ public class IntrospectionViewContextAdapter implements ViewContextAdapter {
     }
 
     @Override
-    public <T> Attempt<T, Throwable> load(final AnnotatedElementView<T> element) {
+    public <T> Attempt<T, Throwable> load(final AnnotatedElementView element) {
         if (element instanceof TypeView<T> typeView) {
             return Attempt.of(this.applicationContext().get(this.key(typeView.type())));
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/ViewContextAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/ViewContextAdapter.java
@@ -32,7 +32,7 @@ public interface ViewContextAdapter extends ContextCarrier {
 
     <T> Attempt<T, Throwable> create(ConstructorView<T> constructor);
 
-    Object[] loadParameters(ExecutableElementView<?, ?> element);
+    Object[] loadParameters(ExecutableElementView<?> element);
 
     <P, R> Attempt<R, Throwable> invoke(MethodView<P, R> method);
 
@@ -40,7 +40,7 @@ public interface ViewContextAdapter extends ContextCarrier {
     
     <P, R> Attempt<R, Throwable> load(FieldView<P, R> field);
 
-    <T> Attempt<T, Throwable> load(AnnotatedElementView<T> element);
+    <T> Attempt<T, Throwable> load(AnnotatedElementView element);
 
     boolean isProxy(TypeView<?> type);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/ViewContextAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/ViewContextAdapter.java
@@ -18,10 +18,10 @@ package org.dockbox.hartshorn.introspect;
 
 import org.dockbox.hartshorn.component.Scope;
 import org.dockbox.hartshorn.context.ContextCarrier;
-import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 import org.dockbox.hartshorn.util.introspect.view.FieldView;
+import org.dockbox.hartshorn.util.introspect.view.GenericTypeView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Attempt;
@@ -40,7 +40,7 @@ public interface ViewContextAdapter extends ContextCarrier {
     
     <P, R> Attempt<R, Throwable> load(FieldView<P, R> field);
 
-    <T> Attempt<T, Throwable> load(AnnotatedElementView element);
+    <T> Attempt<T, Throwable> load(GenericTypeView<T> element);
 
     boolean isProxy(TypeView<?> type);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
@@ -39,11 +39,11 @@ public class ApplicationBoundParameterLoaderContext extends ParameterLoaderConte
 
     private final Context context = new DefaultProvisionContext() {};
 
-    public ApplicationBoundParameterLoaderContext(final ExecutableElementView<?, ?> executable, final Object instance, final ApplicationContext applicationContext) {
+    public ApplicationBoundParameterLoaderContext(final ExecutableElementView<?> executable, final Object instance, final ApplicationContext applicationContext) {
         this(executable, instance, applicationContext, applicationContext);
     }
 
-    public ApplicationBoundParameterLoaderContext(final ExecutableElementView<?, ?> executable, final Object instance, final ApplicationContext applicationContext, final Scope scope) {
+    public ApplicationBoundParameterLoaderContext(final ExecutableElementView<?> executable, final Object instance, final ApplicationContext applicationContext, final Scope scope) {
         this(executable, instance, applicationContext, applicationContext, scope);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
@@ -47,7 +47,7 @@ public class ApplicationBoundParameterLoaderContext extends ParameterLoaderConte
         this(executable, instance, applicationContext, applicationContext, scope);
     }
 
-    public ApplicationBoundParameterLoaderContext(ExecutableElementView<?, ?> executable, Object instance, ApplicationContext applicationContext, ComponentProvider provider, Scope scope) {
+    public ApplicationBoundParameterLoaderContext(ExecutableElementView<?> executable, Object instance, ApplicationContext applicationContext, ComponentProvider provider, Scope scope) {
         super(executable, instance);
         this.applicationContext = applicationContext;
         this.provider = provider;

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
@@ -63,7 +63,7 @@ public class EventBusImpl implements EventBus {
         });
         // Event listeners cannot be abstract
         this.addValidationRule(method -> {
-            if (method.isAbstract()) {
+            if (method.modifiers().isAbstract()) {
                 return Attempt.of(false, new InvalidEventListenerException("Method cannot be abstract: " + method.qualifiedName()));
             }
             return Attempt.of(true);

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventValidator.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventValidator.java
@@ -45,7 +45,7 @@ public class EventValidator implements LifecycleObserver {
 
         final List<TypeView<? extends Event>> allEvents = applicationContext.environment().children(Event.class)
                 .stream()
-                .filter(type -> !type.isAbstract())
+                .filter(type -> !type.modifiers().isAbstract())
                 // Anonymous classes indicate the event carries type parameters when posted (e.g. EngineChangedState<State>)
                 // These are only created when the event is posted, so they can be ignored here, as they are not explicit
                 // definitions.

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterRule.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterRule.java
@@ -25,7 +25,7 @@ import org.dockbox.hartshorn.util.introspect.util.ParameterLoaderRule;
 public class EventParameterRule implements ParameterLoaderRule<EventParameterLoaderContext> {
     @Override
     public boolean accepts(final ParameterView<?> parameter, final int index, final EventParameterLoaderContext context, final Object... args) {
-        TypeView<Event> typeView = context.applicationContext().environment().introspect(context.event());
+        final TypeView<Event> typeView = context.applicationContext().environment().introspect(context.event());
         return typeView.isChildOf(parameter.type().type());
     }
 

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AbstractNativeModule.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AbstractNativeModule.java
@@ -109,7 +109,7 @@ public abstract class AbstractNativeModule implements NativeModule {
 
             final TypeView<?> typeView = this.applicationContext().environment().introspect(this.moduleClass());
             for (final MethodView<?, ?> method : typeView.methods().all()) {
-                if (!method.isPublic()) continue;
+                if (!method.modifiers().isPublic()) continue;
                 if (method.declaredBy().is(Object.class)) continue;
 
                 final Token token = new Token(TokenType.IDENTIFIER, method.name(), -1, -1);

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExecutableLookup.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExecutableLookup.java
@@ -77,7 +77,7 @@ public class ExecutableLookup {
      * @param <P> The type of the declaring parent of the executable.
      * @param <T> The context type representing the executable.
      */
-    public static <P, T extends ExecutableElementView<P, ?>> T executable(final List<T> executables, final List<Object> arguments) {
+    public static <P, T extends ExecutableElementView<P>> T executable(final List<T> executables, final List<Object> arguments) {
         for (final T executable : executables) {
             boolean pass = true;
             if (executable.parameters().count() != arguments.size()) continue;

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExternalClass.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExternalClass.java
@@ -105,7 +105,7 @@ public record ExternalClass<T>(TypeView<T> type) implements ClassReference {
 
     @Override
     public boolean isFinal() {
-        return this.type().isFinal();
+        return this.type().modifiers().isFinal();
     }
 
     @Override

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExternalInstance.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExternalInstance.java
@@ -17,15 +17,14 @@
 package org.dockbox.hartshorn.hsl.objects.external;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.dockbox.hartshorn.hsl.runtime.ExecutionOptions;
 import org.dockbox.hartshorn.hsl.interpreter.VariableScope;
 import org.dockbox.hartshorn.hsl.objects.ClassReference;
 import org.dockbox.hartshorn.hsl.objects.ExternalObjectReference;
 import org.dockbox.hartshorn.hsl.objects.InstanceReference;
+import org.dockbox.hartshorn.hsl.runtime.ExecutionOptions;
 import org.dockbox.hartshorn.hsl.runtime.RuntimeError;
 import org.dockbox.hartshorn.hsl.runtime.ScriptRuntime;
 import org.dockbox.hartshorn.hsl.token.Token;
-import org.dockbox.hartshorn.util.introspect.view.FieldView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
 import java.util.Map;
@@ -64,7 +63,6 @@ public class ExternalInstance implements InstanceReference, ExternalObjectRefere
     @Override
     public void set(final Token name, final Object value, final VariableScope fromScope, final ExecutionOptions options) {
         this.type.fields().named(name.lexeme())
-                .map(field -> (FieldView<Object, Object>) field)
                 .peek(field -> field.set(this.instance(), value))
                 .orElseThrow(() -> this.propertyDoesNotExist(name));
     }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ConditionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ConditionTests.java
@@ -85,13 +85,13 @@ public class ConditionTests {
 
     ConditionResult match(final String expression, final Context... contexts) {
         final ExpressionCondition condition = this.applicationContext.get(ExpressionCondition.class);
-        final AnnotatedElementView<?> element = this.createAnnotatedElement(expression);
+        final AnnotatedElementView element = this.createAnnotatedElement(expression);
         final ConditionContext context = new ConditionContext(this.applicationContext, element, null);
         for (final Context child : contexts) context.add(child);
         return condition.matches(context);
     }
 
-    private AnnotatedElementView<?> createAnnotatedElement(final String expression) {
+    private AnnotatedElementView createAnnotatedElement(final String expression) {
         final RequiresExpression condition = Mockito.mock(RequiresExpression.class);
         Mockito.when(condition.value()).thenReturn(expression);
         Mockito.doReturn(RequiresExpression.class).when(condition).annotationType();
@@ -99,7 +99,7 @@ public class ConditionTests {
         final ElementAnnotationsIntrospector annotationsIntrospector = Mockito.mock(ElementAnnotationsIntrospector.class);
         Mockito.when(annotationsIntrospector.get(RequiresExpression.class)).thenReturn(Option.of(condition));
 
-        final AnnotatedElementView<?> elementView = Mockito.mock(AnnotatedElementView.class);
+        final AnnotatedElementView elementView = Mockito.mock(AnnotatedElementView.class);
         Mockito.when(elementView.annotations()).thenReturn(annotationsIntrospector);
 
         return elementView;

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionElementModifiersIntrospector.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionElementModifiersIntrospector.java
@@ -1,0 +1,129 @@
+package org.dockbox.hartshorn.util.introspect.reflect;
+
+import org.dockbox.hartshorn.util.introspect.AccessModifier;
+import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public class ReflectionElementModifiersIntrospector implements ElementModifiersIntrospector {
+
+    private static final int SYNTHETIC;
+    private static final int MANDATED;
+
+    static {
+        int syntheticModifier;
+        int mandatedModifier;
+        try {
+            final Class<Modifier> modifier = Modifier.class;
+            final Field synthetic = modifier.getDeclaredField("SYNTHETIC");
+            synthetic.setAccessible(true);
+            syntheticModifier = (int) synthetic.get(null);
+
+            final Field mandated = modifier.getDeclaredField("MANDATED");
+            mandated.setAccessible(true);
+            mandatedModifier = (int) mandated.get(null);
+        }
+        catch (final NoSuchFieldException | IllegalAccessException e) {
+            syntheticModifier = 0x00001000;
+            mandatedModifier  = 0x00008000;
+        }
+        SYNTHETIC = syntheticModifier;
+        MANDATED = mandatedModifier;
+    }
+
+    private final int modifiers;
+    private final Member member;
+
+    public ReflectionElementModifiersIntrospector(final Member member) {
+        this.modifiers = member.getModifiers();
+        this.member = member;
+    }
+
+    public ReflectionElementModifiersIntrospector(final int modifiers) {
+        this.modifiers = modifiers;
+        this.member = null;
+    }
+
+    @Override
+    public int asInt() {
+        return this.modifiers;
+    }
+
+    @Override
+    public boolean has(final AccessModifier modifier) {
+        return modifier.test(this.asInt());
+    }
+
+    @Override
+    public boolean isPublic() {
+        return Modifier.isPublic(this.asInt());
+    }
+
+    @Override
+    public boolean isPrivate() {
+        return Modifier.isPrivate(this.asInt());
+    }
+
+    @Override
+    public boolean isProtected() {
+        return Modifier.isProtected(this.asInt());
+    }
+
+    @Override
+    public boolean isStatic() {
+        return Modifier.isStatic(this.asInt());
+    }
+
+    @Override
+    public boolean isFinal() {
+        return Modifier.isFinal(this.asInt());
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return Modifier.isAbstract(this.asInt());
+    }
+
+    @Override
+    public boolean isTransient() {
+        return Modifier.isTransient(this.asInt());
+    }
+
+    @Override
+    public boolean isVolatile() {
+        return Modifier.isVolatile(this.asInt());
+    }
+
+    @Override
+    public boolean isSynchronized() {
+        return Modifier.isSynchronized(this.asInt());
+    }
+
+    @Override
+    public boolean isNative() {
+        return Modifier.isNative(this.asInt());
+    }
+
+    @Override
+    public boolean isStrict() {
+        return Modifier.isStrict(this.asInt());
+    }
+
+    @Override
+    public boolean isMandated() {
+        return (this.asInt() & MANDATED) != 0;
+    }
+
+    @Override
+    public boolean isSynthetic() {
+        return (this.asInt() & SYNTHETIC) != 0;
+    }
+
+    @Override
+    public boolean isDefault() {
+        return member instanceof Method method && method.isDefault();
+    }
+}

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionElementModifiersIntrospector.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionElementModifiersIntrospector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.util.introspect.reflect;
 
 import org.dockbox.hartshorn.util.introspect.AccessModifier;

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionElementModifiersIntrospector.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionElementModifiersIntrospector.java
@@ -20,6 +20,7 @@ import org.dockbox.hartshorn.util.introspect.AccessModifier;
 import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -42,7 +43,7 @@ public class ReflectionElementModifiersIntrospector implements ElementModifiersI
             mandated.setAccessible(true);
             mandatedModifier = (int) mandated.get(null);
         }
-        catch (final NoSuchFieldException | IllegalAccessException e) {
+        catch (final NoSuchFieldException | IllegalAccessException | InaccessibleObjectException e) {
             syntheticModifier = 0x00001000;
             mandatedModifier  = 0x00008000;
         }

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionExecutableParametersIntrospector.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionExecutableParametersIntrospector.java
@@ -33,12 +33,12 @@ import java.util.stream.Collectors;
 public class ReflectionExecutableParametersIntrospector implements ExecutableParametersIntrospector {
 
     private final Introspector introspector;
-    private final ReflectionExecutableElementView<?, ?> executable;
+    private final ReflectionExecutableElementView<?> executable;
     private List<ParameterView<?>> parameters;
     private List<TypeView<?>> parameterTypes;
     private List<TypeView<?>> genericParameterTypes;
 
-    public ReflectionExecutableParametersIntrospector(final Introspector introspector, final ReflectionExecutableElementView<?, ?> executable) {
+    public ReflectionExecutableParametersIntrospector(final Introspector introspector, final ReflectionExecutableElementView<?> executable) {
         this.introspector = introspector;
         this.executable = executable;
     }

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionMethodInvoker.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionMethodInvoker.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.util.introspect.reflect;
 import org.dockbox.hartshorn.util.introspect.MethodInvoker;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.option.Attempt;
+import org.dockbox.hartshorn.util.option.Option;
 
 import java.lang.reflect.Method;
 
@@ -27,11 +28,13 @@ public class ReflectionMethodInvoker<T, P> implements MethodInvoker<T, P> {
     @Override
     public Attempt<T, Throwable> invoke(final MethodView<P, T> method, final P instance, final Object[] args) {
         final Attempt<T, Throwable> result = Attempt.of(() -> {
-            final Method jlrMethod = method.method();
+            final Option<Method> jlrMethod = method.method();
+            if (jlrMethod.absent()) return null;
+
             // Do not use explicit casting here, as it will cause a ClassCastException if the method
             // returns a primitive type. Instead, use the inferred type from the method view.
             //noinspection unchecked
-            return (T) jlrMethod.invoke(instance, args);
+            return (T) jlrMethod.get().invoke(instance, args);
         }, Throwable.class);
 
         if (result.errorPresent()) {

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionModifierCarrierView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionModifierCarrierView.java
@@ -21,10 +21,8 @@ import org.dockbox.hartshorn.util.introspect.AccessModifier;
 
 public interface ReflectionModifierCarrierView extends ModifierCarrierView {
 
-    int modifiers();
-
     @Override
     default boolean has(final AccessModifier modifier) {
-        return modifier.test(this.modifiers());
+        return modifier.test(this.modifiers().asInt());
     }
 }

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionAnnotatedElementView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionAnnotatedElementView.java
@@ -25,7 +25,7 @@ import org.dockbox.hartshorn.util.introspect.view.IntrospectorAwareView;
 
 import java.lang.reflect.AnnotatedElement;
 
-public abstract class ReflectionAnnotatedElementView<T> implements AnnotatedElementView<T>, IntrospectorAwareView {
+public abstract class ReflectionAnnotatedElementView implements AnnotatedElementView, IntrospectorAwareView {
 
     private final ReflectionIntrospector introspector;
     private ElementAnnotationsIntrospector annotationsIntrospector;

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionConstructorView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionConstructorView.java
@@ -21,11 +21,13 @@ import org.dockbox.hartshorn.reporting.Reportable;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.TypeVariablesIntrospector;
 import org.dockbox.hartshorn.util.introspect.reflect.ReflectionIntrospector;
+import org.dockbox.hartshorn.util.introspect.reflect.ReflectionModifierCarrierView;
 import org.dockbox.hartshorn.util.introspect.reflect.ReflectionTypeVariablesIntrospector;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.ParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Attempt;
+import org.dockbox.hartshorn.util.option.Option;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -34,7 +36,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class ReflectionConstructorView<T> extends ReflectionExecutableElementView<T, T> implements ConstructorView<T> {
+public class ReflectionConstructorView<T> extends ReflectionExecutableElementView<T, T> implements ConstructorView<T>, ReflectionModifierCarrierView {
 
     private final Constructor<T> constructor;
     private final Introspector introspector;
@@ -64,8 +66,8 @@ public class ReflectionConstructorView<T> extends ReflectionExecutableElementVie
     }
 
     @Override
-    public Constructor<T> constructor() {
-        return this.constructor;
+    public Option<Constructor<T>> constructor() {
+        return Option.of(this.constructor);
     }
 
     @Override

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionConstructorView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionConstructorView.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class ReflectionConstructorView<T> extends ReflectionExecutableElementView<T, T> implements ConstructorView<T>, ReflectionModifierCarrierView {
+public class ReflectionConstructorView<T> extends ReflectionExecutableElementView<T> implements ConstructorView<T>, ReflectionModifierCarrierView {
 
     private final Constructor<T> constructor;
     private final Introspector introspector;

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionExecutableElementView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionExecutableElementView.java
@@ -16,13 +16,14 @@
 
 package org.dockbox.hartshorn.util.introspect.reflect.view;
 
+import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
 import org.dockbox.hartshorn.util.introspect.ExecutableParametersIntrospector;
 import org.dockbox.hartshorn.util.introspect.IllegalIntrospectionException;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.TypeVariablesIntrospector;
+import org.dockbox.hartshorn.util.introspect.reflect.ReflectionElementModifiersIntrospector;
 import org.dockbox.hartshorn.util.introspect.reflect.ReflectionExecutableParametersIntrospector;
 import org.dockbox.hartshorn.util.introspect.reflect.ReflectionIntrospector;
-import org.dockbox.hartshorn.util.introspect.reflect.ReflectionModifierCarrierView;
 import org.dockbox.hartshorn.util.introspect.reflect.ReflectionTypeVariablesIntrospector;
 import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
@@ -31,7 +32,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Executable;
 import java.util.List;
 
-public abstract class ReflectionExecutableElementView<Parent, ResultType> extends ReflectionAnnotatedElementView<ResultType> implements ExecutableElementView<Parent, ResultType>, ReflectionModifierCarrierView {
+public abstract class ReflectionExecutableElementView<Parent, ResultType> extends ReflectionAnnotatedElementView implements ExecutableElementView<Parent> {
 
     private final Introspector introspector;
     private final Executable executable;
@@ -44,7 +45,7 @@ public abstract class ReflectionExecutableElementView<Parent, ResultType> extend
         this.executable = executable;
         this.introspector = introspector;
         if (!executable.trySetAccessible()) {
-            String packageName = executable.getDeclaringClass().getPackageName();
+            final String packageName = executable.getDeclaringClass().getPackageName();
             if (!(packageName.startsWith("java.") || packageName.startsWith("jdk.") || packageName.startsWith("sun.") || packageName.startsWith("com.sun.") || packageName.startsWith("javax."))) {
                 throw new IllegalIntrospectionException(executable, "Unable to set executable " + executable.getName() + " accessible");
             }
@@ -82,7 +83,7 @@ public abstract class ReflectionExecutableElementView<Parent, ResultType> extend
     }
 
     @Override
-    public int modifiers() {
-        return this.executable.getModifiers();
+    public ElementModifiersIntrospector modifiers() {
+        return new ReflectionElementModifiersIntrospector(this.executable);
     }
 }

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionExecutableElementView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionExecutableElementView.java
@@ -32,7 +32,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Executable;
 import java.util.List;
 
-public abstract class ReflectionExecutableElementView<Parent, ResultType> extends ReflectionAnnotatedElementView implements ExecutableElementView<Parent> {
+public abstract class ReflectionExecutableElementView<Parent> extends ReflectionAnnotatedElementView implements ExecutableElementView<Parent> {
 
     private final Introspector introspector;
     private final Executable executable;

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionFieldView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionFieldView.java
@@ -16,6 +16,12 @@
 
 package org.dockbox.hartshorn.util.introspect.reflect.view;
 
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
 import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
 import org.dockbox.hartshorn.util.introspect.IllegalIntrospectionException;
@@ -29,12 +35,6 @@ import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Attempt;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
 
 public class ReflectionFieldView<Parent, FieldType> extends ReflectionAnnotatedElementView implements FieldView<Parent, FieldType>, ReflectionModifierCarrierView {
 
@@ -95,7 +95,8 @@ public class ReflectionFieldView<Parent, FieldType> extends ReflectionAnnotatedE
                 final String getter = property.get().getter();
                 final Option<MethodView<Parent, ?>> method = this.declaredBy().methods().named(getter);
                 final MethodView<Parent, ?> methodContext = method.orElseThrow(() -> new IllegalIntrospectionException(this, "Getter for field '" + this.name() + "' (" + getter + ") does not exist!"));
-                this.getter = object -> methodContext.invoke(instance).cast(this.type().type());
+                this.getter = object -> methodContext.invoke(instance)
+                        .map(o -> this.type().cast(o));
             } else {
                 this.getter = object -> Attempt.of(() -> {
                     try {

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionMethodView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionMethodView.java
@@ -18,21 +18,23 @@ package org.dockbox.hartshorn.util.introspect.reflect.view;
 
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
 import org.dockbox.hartshorn.reporting.Reportable;
+import org.dockbox.hartshorn.util.introspect.IllegalIntrospectionException;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.MethodInvoker;
 import org.dockbox.hartshorn.util.introspect.reflect.ReflectionIntrospector;
 import org.dockbox.hartshorn.util.introspect.reflect.ReflectionMethodInvoker;
+import org.dockbox.hartshorn.util.introspect.reflect.ReflectionModifierCarrierView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Attempt;
+import org.dockbox.hartshorn.util.option.Option;
 
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.StringJoiner;
 
-public class ReflectionMethodView<Parent, ReturnType> extends ReflectionExecutableElementView<Parent, ReturnType> implements MethodView<Parent, ReturnType> {
+public class ReflectionMethodView<Parent, ReturnType> extends ReflectionExecutableElementView<Parent, ReturnType> implements MethodView<Parent, ReturnType>, ReflectionModifierCarrierView {
 
     private final Introspector introspector;
     private final Method method;
@@ -47,8 +49,8 @@ public class ReflectionMethodView<Parent, ReturnType> extends ReflectionExecutab
     }
 
     @Override
-    public Method method() {
-        return this.method;
+    public Option<Method> method() {
+        return Option.of(this.method);
     }
 
     @Override
@@ -61,8 +63,8 @@ public class ReflectionMethodView<Parent, ReturnType> extends ReflectionExecutab
 
     @Override
     public Attempt<ReturnType, Throwable> invokeStatic(final Collection<?> arguments) {
-        if (this.isStatic()) return this.invoke(null, arguments);
-        else return Attempt.of(new IllegalAccessException("Method is not static"));
+        if (this.modifiers().isStatic()) return this.invoke(null, arguments);
+        else throw new IllegalIntrospectionException(this, "Method is not static");
     }
 
     @Override
@@ -84,9 +86,9 @@ public class ReflectionMethodView<Parent, ReturnType> extends ReflectionExecutab
     public String qualifiedName() {
         if (this.qualifiedName == null) {
             final StringJoiner j = new StringJoiner(" ");
-            final String shortSig = MethodType.methodType(this.method().getReturnType(), this.method().getParameterTypes()).toString();
+            final String shortSig = MethodType.methodType(this.method.getReturnType(), this.method.getParameterTypes()).toString();
             final int split = shortSig.lastIndexOf(')') + 1;
-            j.add(shortSig.substring(split)).add(this.method().getName() + shortSig.substring(0, split));
+            j.add(shortSig.substring(split)).add(this.method.getName() + shortSig.substring(0, split));
             final String k = j.toString();
             this.qualifiedName = this.declaredBy().qualifiedName() + '#' + k.substring(k.indexOf(' ') + 1);
         }
@@ -95,37 +97,37 @@ public class ReflectionMethodView<Parent, ReturnType> extends ReflectionExecutab
 
     @Override
     public boolean isProtected() {
-        return Modifier.isProtected(this.method.getModifiers());
+        return this.modifiers().isProtected();
     }
 
     @Override
     public boolean isPublic() {
-        return Modifier.isPublic(this.method.getModifiers());
+        return this.modifiers().isPublic();
     }
 
     @Override
     public boolean isPrivate() {
-        return Modifier.isPrivate(this.method.getModifiers());
+        return this.modifiers().isPrivate();
     }
 
     @Override
     public boolean isStatic() {
-        return Modifier.isStatic(this.method.getModifiers());
+        return this.modifiers().isStatic();
     }
 
     @Override
     public boolean isFinal() {
-        return Modifier.isFinal(this.method.getModifiers());
+        return this.modifiers().isFinal();
     }
 
     @Override
     public boolean isAbstract() {
-        return Modifier.isAbstract(this.method.getModifiers());
+        return this.modifiers().isAbstract();
     }
 
     @Override
     public boolean isDefault() {
-        return this.method.isDefault();
+        return this.modifiers().isDefault();
     }
 
     @Override

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionMethodView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionMethodView.java
@@ -34,7 +34,7 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.StringJoiner;
 
-public class ReflectionMethodView<Parent, ReturnType> extends ReflectionExecutableElementView<Parent, ReturnType> implements MethodView<Parent, ReturnType>, ReflectionModifierCarrierView {
+public class ReflectionMethodView<Parent, ReturnType> extends ReflectionExecutableElementView<Parent> implements MethodView<Parent, ReturnType>, ReflectionModifierCarrierView {
 
     private final Introspector introspector;
     private final Method method;

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionParameterView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionParameterView.java
@@ -29,12 +29,12 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 
-public class ReflectionParameterView<T> extends ReflectionAnnotatedElementView<T> implements ParameterView<T> {
+public class ReflectionParameterView<T> extends ReflectionAnnotatedElementView implements ParameterView<T> {
 
     private final Introspector introspector;
     private final Parameter parameter;
     private String name;
-    private ExecutableElementView<?, ?> declaredBy;
+    private ExecutableElementView<?> declaredBy;
 
     public ReflectionParameterView(final ReflectionIntrospector introspector, final Parameter parameter) {
         super(introspector);
@@ -81,7 +81,7 @@ public class ReflectionParameterView<T> extends ReflectionAnnotatedElementView<T
     }
 
     @Override
-    public ExecutableElementView<?, ?> declaredBy() {
+    public ExecutableElementView<?> declaredBy() {
         if (this.declaredBy == null) {
             final Executable executable = this.parameter.getDeclaringExecutable();
             if (executable instanceof Method method) this.declaredBy = this.introspector.introspect(method);

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionTypeView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionTypeView.java
@@ -16,14 +16,26 @@
 
 package org.dockbox.hartshorn.util.introspect.reflect.view;
 
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
 import org.dockbox.hartshorn.reporting.Reportable;
+import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.collections.BiMap;
+import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.TypeConstructorsIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeFieldsIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeMethodsIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeParametersIntrospector;
+import org.dockbox.hartshorn.util.introspect.reflect.ReflectionElementModifiersIntrospector;
 import org.dockbox.hartshorn.util.introspect.reflect.ReflectionIntrospector;
 import org.dockbox.hartshorn.util.introspect.reflect.ReflectionModifierCarrierView;
 import org.dockbox.hartshorn.util.introspect.reflect.ReflectionTypeConstructorsIntrospector;
@@ -34,16 +46,7 @@ import org.dockbox.hartshorn.util.introspect.view.PackageView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-public class ReflectionTypeView<T> extends ReflectionAnnotatedElementView<T> implements ReflectionModifierCarrierView, TypeView<T> {
+public class ReflectionTypeView<T> extends ReflectionAnnotatedElementView implements ReflectionModifierCarrierView, TypeView<T> {
 
     private static final BiMap<Class<?>, Class<?>> WRAPPERS = BiMap.ofEntries(
             Map.entry(Boolean.class, boolean.class),
@@ -143,17 +146,17 @@ public class ReflectionTypeView<T> extends ReflectionAnnotatedElementView<T> imp
 
     @Override
     public boolean isAbstract() {
-        return this.isInterface() || Modifier.isAbstract(this.type.getModifiers());
+        return this.isInterface() || this.modifiers().isAbstract();
     }
 
     @Override
     public boolean isFinal() {
-        return Modifier.isFinal(this.type.getModifiers());
+        return this.modifiers().isFinal();
     }
 
     @Override
     public boolean isStatic() {
-        return Modifier.isStatic(this.type.getModifiers());
+        return this.modifiers().isStatic();
     }
 
     @Override
@@ -331,11 +334,6 @@ public class ReflectionTypeView<T> extends ReflectionAnnotatedElementView<T> imp
     }
 
     @Override
-    public int modifiers() {
-        return this.type.getModifiers();
-    }
-
-    @Override
     public PackageView packageInfo() {
         return new ReflectionPackageView(this.introspector, this.type.getPackage());
     }
@@ -349,5 +347,10 @@ public class ReflectionTypeView<T> extends ReflectionAnnotatedElementView<T> imp
         if (typeParameters.count() > 0) {
             collector.property("typeParameters").write(typeParameters.all().toArray(Reportable[]::new));
         }
+    }
+
+    @Override
+    public ElementModifiersIntrospector modifiers() {
+        return new ReflectionElementModifiersIntrospector(this.type.getModifiers());
     }
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ElementModifiersIntrospector.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ElementModifiersIntrospector.java
@@ -1,0 +1,36 @@
+package org.dockbox.hartshorn.util.introspect;
+
+public interface ElementModifiersIntrospector {
+
+    int asInt();
+
+    boolean has(AccessModifier modifier);
+
+    boolean isPublic();
+
+    boolean isPrivate();
+
+    boolean isProtected();
+
+    boolean isStatic();
+
+    boolean isFinal();
+
+    boolean isAbstract();
+
+    boolean isTransient();
+
+    boolean isVolatile();
+
+    boolean isSynchronized();
+
+    boolean isNative();
+
+    boolean isStrict();
+
+    boolean isMandated();
+
+    boolean isSynthetic();
+
+    boolean isDefault();
+}

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ElementModifiersIntrospector.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ElementModifiersIntrospector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.util.introspect;
 
 public interface ElementModifiersIntrospector {

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/DefaultValueProvider.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/DefaultValueProvider.java
@@ -27,7 +27,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public interface DefaultValueProvider<T> extends Converter<Null, T> {
 
     @Override
-    default @Nullable T convert(@Nullable Null input) {
+    default @Nullable T convert(final @Nullable Null input) {
         assert input == null;
         return this.defaultValue();
     }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/util/ParameterLoaderContext.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/util/ParameterLoaderContext.java
@@ -20,15 +20,15 @@ import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 
 public class ParameterLoaderContext {
 
-    private final ExecutableElementView<?, ?> executable;
+    private final ExecutableElementView<?> executable;
     private final Object instance;
 
-    public ParameterLoaderContext(final ExecutableElementView<?, ?> executable, final Object instance) {
+    public ParameterLoaderContext(final ExecutableElementView<?> executable, final Object instance) {
         this.executable = executable;
         this.instance = instance;
     }
 
-    public ExecutableElementView<?, ?> executable() {
+    public ExecutableElementView<?> executable() {
         return this.executable;
     }
 

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/AnnotatedElementView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/AnnotatedElementView.java
@@ -18,12 +18,37 @@ package org.dockbox.hartshorn.util.introspect.view;
 
 import org.dockbox.hartshorn.util.introspect.ElementAnnotationsIntrospector;
 
-public interface AnnotatedElementView<T> extends View {
+/**
+ * Represents a view of an annotated element, such as a field or method. This view can be
+ * used to introspect the element's annotations, as well as its name and qualified name.
+ *
+ * @author Guus Lieben
+ * @since 22.5
+ */
+public interface AnnotatedElementView extends View {
 
+    /**
+     * Returns an {@link ElementAnnotationsIntrospector} for the element. This introspector
+     * can be used to introspect the element's annotations.
+     *
+     * @return an introspector for the element's annotations
+     */
     ElementAnnotationsIntrospector annotations();
 
+    /**
+     * Returns the simple name of the element. For example, if the element is a field, this
+     * method will return the field's name, without further qualification.
+     *
+     * @return the simple name of the element
+     */
     String name();
 
+    /**
+     * Returns the qualified name of the element. For example, if the element is a field,
+     * this method will return the field's name, qualified by the declaring class.
+     *
+     * @return the qualified name of the element
+     */
     String qualifiedName();
 
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/ConstructorView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/ConstructorView.java
@@ -17,25 +17,58 @@
 package org.dockbox.hartshorn.util.introspect.view;
 
 import org.dockbox.hartshorn.util.option.Attempt;
+import org.dockbox.hartshorn.util.option.Option;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Collection;
 
-public interface ConstructorView<T> extends ExecutableElementView<T, T> {
+/**
+ * Represents a view of a constructor. This view can be used to invoke the constructor and to
+ * retrieve information about the constructor.
+ *
+ * @param <T> the type of the class that declares the constructor
+ *
+ * @author Guus Lieben
+ * @since 22.5
+ */
+public interface ConstructorView<T> extends ExecutableElementView<T> {
 
-    Constructor<T> constructor();
+    /**
+     * Returns the constructor represented by this view.
+     *
+     * @return the constructor, if available
+     */
+    Option<Constructor<T>> constructor();
 
+    /**
+     * Creates a new instance of the class that declares the constructor represented by this view.
+     * The provided arguments are passed to the constructor. If the constructor is not accessible,
+     * it will be made accessible. If the constructor is not available, an empty {@link Attempt} is
+     * returned. If the constructor throws an exception, the exception is wrapped in an {@link Attempt}.
+     *
+     * @param arguments the arguments to pass to the constructor
+     * @return a new instance of the class that declares the constructor
+     */
     default Attempt<T, Throwable> create(final Object... arguments) {
         return this.create(Arrays.asList(arguments));
     }
 
+    /**
+     * Creates a new instance of the class that declares the constructor represented by this view.
+     * The provided arguments are passed to the constructor. If the constructor is not accessible,
+     * it will be made accessible. If the constructor is not available, an empty {@link Attempt} is
+     * returned. If the constructor throws an exception, the exception is wrapped in an {@link Attempt}.
+     *
+     * @param arguments the arguments to pass to the constructor
+     * @return a new instance of the class that declares the constructor
+     */
     Attempt<T, Throwable> create(Collection<?> arguments);
 
+    /**
+     * Returns the type of the class that declares the constructor represented by this view.
+     *
+     * @return the type of the class that declares the constructor
+     */
     TypeView<T> type();
-
-    String name();
-
-    String qualifiedName();
-
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/ExecutableElementView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/ExecutableElementView.java
@@ -19,15 +19,37 @@ package org.dockbox.hartshorn.util.introspect.view;
 import org.dockbox.hartshorn.util.introspect.ExecutableParametersIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeVariablesIntrospector;
 
-public interface ExecutableElementView<Parent, ResultType> extends AnnotatedElementView<ResultType>, ModifierCarrierView {
+/**
+ * Represents a view of an executable element, such as a method or constructor. This view can be
+ * used to introspect the element's parameters, type variables, and declaring type.
+ *
+ * @param <Parent> the type of the element's parent
+ *
+ * @author Guus Lieben
+ * @since 22.5
+ */
+public interface ExecutableElementView<Parent> extends AnnotatedElementView, ModifierCarrierView {
 
+    /**
+     * Returns an {@link ExecutableParametersIntrospector} for the element. This introspector
+     * can be used to introspect the element's parameters.
+     *
+     * @return an introspector for the element's parameters
+     */
     ExecutableParametersIntrospector parameters();
 
+    /**
+     * Returns an {@link TypeVariablesIntrospector} for the element. This introspector
+     * can be used to introspect the element's type variables.
+     *
+     * @return an introspector for the element's type variables
+     */
     TypeVariablesIntrospector typeVariables();
 
-    String name();
-
-    String qualifiedName();
-
+    /**
+     * Returns the element's declaring type.
+     *
+     * @return the element's declaring type
+     */
     TypeView<Parent> declaredBy();
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/FieldView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/FieldView.java
@@ -16,36 +16,92 @@
 
 package org.dockbox.hartshorn.util.introspect.view;
 
+import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
+import org.dockbox.hartshorn.util.introspect.IllegalIntrospectionException;
+import org.dockbox.hartshorn.util.introspect.annotations.Property;
 import org.dockbox.hartshorn.util.option.Attempt;
+import org.dockbox.hartshorn.util.option.Option;
 
 import java.lang.reflect.Field;
 
-public interface FieldView<Parent, FieldType> extends AnnotatedElementView<FieldType>, ModifierCarrierView, GenericTypeView<FieldType> {
+/**
+ * Represents a view of a field. This view is used to access the field's value, and to set the field's value.
+ *
+ * @param <Parent> The type of the field's declaring class
+ * @param <FieldType> The type of the field
+ *
+ * @author Guus Lieben
+ * @since 22.5
+ */
+public interface FieldView<Parent, FieldType> extends AnnotatedElementView, ModifierCarrierView, GenericTypeView<FieldType> {
 
-    Field field();
+    /**
+     * Returns the {@link Field} represented by this view, if available.
+     *
+     * @return the field represented by this view, if available
+     */
+    Option<Field> field();
 
+    /**
+     * Sets the value of the field represented by this view on the given instance. If the field is static, the instance
+     * is ignored. If the field is annotated with {@link Property}, an attempt is made to use the field's setter method
+     * as configured in {@link Property#setter()}, if available.
+     *
+     * @param instance the instance on which to set the field's value
+     * @param value the value to set
+     * @throws IllegalIntrospectionException if the field is final, the given value does not match the field's type, or
+     *        if the field is not accessible. Also thrown if the configured setter method does not exist.
+     */
     void set(Object instance, Object value);
 
+    /**
+     * Gets the value of the field represented by this view on the given instance. If the field is static, the instance
+     * is ignored. If the field is annotated with {@link Property}, an attempt is made to use the field's getter method
+     * as configured in {@link Property#getter()}, if available.
+     *
+     * @param instance the instance from which to get the field's value
+     * @throws IllegalIntrospectionException if the field is not accessible, or the configured getter method does not exist
+     * @return the value of the field represented by this view on the given instance
+     */
     Attempt<FieldType, Throwable> get(Parent instance);
 
+    /**
+     * Gets the value of the field represented by this view, as a static field. If the field is annotated with
+     * {@link Property}, an attempt is made to use the field's getter method as configured in {@link Property#getter()},
+     * if available.
+     *
+     * @throws IllegalIntrospectionException if the field is not accessible, not static, or the configured getter method
+     *       does not exist
+     * @return the value of the field represented by this view
+     */
     Attempt<FieldType, Throwable> getStatic();
 
-    String name();
-
-    String qualifiedName();
-
+    /**
+     * Returns the element's declaring type.
+     *
+     * @return the element's declaring type
+     */
     TypeView<Parent> declaredBy();
 
-    boolean isProtected();
-
-    boolean isPublic();
-
-    boolean isPrivate();
-
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isStatic()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     boolean isStatic();
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isFinal()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     boolean isFinal();
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isTransient()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     boolean isTransient();
 
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/GenericTypeView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/GenericTypeView.java
@@ -16,10 +16,32 @@
 
 package org.dockbox.hartshorn.util.introspect.view;
 
+/**
+ * Represents a view of an element which may have a generic type. This view can be used to
+ * introspect the element's generic type, allowing you to extract information about the type's
+ * type parameters.
+ *
+ * @param <T> the type of the element's generic type
+ *
+ * @author Guus Lieben
+ * @since 22.5
+ */
 public interface GenericTypeView<T> extends View {
 
+    /**
+     * Returns a {@link TypeView} for the element's non-generic type. A non-generic type can be
+     * for example {@code TypeView<List>} for a {@code List<String>}.
+     *
+     * @return a view of the element's non-generic type
+     */
     TypeView<T> type();
 
+    /**
+     * Returns a {@link TypeView} for the element's generic type. A generic type can be for
+     * example {@code TypeView<List<String>>} for a {@code List<String>}.
+     *
+     * @return a view of the element's generic type
+     */
     TypeView<T> genericType();
 
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/IntrospectorAwareView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/IntrospectorAwareView.java
@@ -18,7 +18,18 @@ package org.dockbox.hartshorn.util.introspect.view;
 
 import org.dockbox.hartshorn.util.introspect.Introspector;
 
+/**
+ * Specialized view that is aware of the {@link Introspector} that created it.
+ *
+ * @author Guus Lieben
+ * @since 22.5
+ */
 public interface IntrospectorAwareView {
 
+    /**
+     * Returns the {@link Introspector} that created this view.
+     *
+     * @return the introspector that created this view
+     */
     Introspector introspector();
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/MethodView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/MethodView.java
@@ -16,44 +16,126 @@
 
 package org.dockbox.hartshorn.util.introspect.view;
 
+import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
+import org.dockbox.hartshorn.util.introspect.IllegalIntrospectionException;
 import org.dockbox.hartshorn.util.option.Attempt;
+import org.dockbox.hartshorn.util.option.Option;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 
-public interface MethodView<Parent, ReturnType> extends ExecutableElementView<Parent, ReturnType>, GenericTypeView<ReturnType> {
+/**
+ * Represents a view of a {@link Method} instance. This view provides access various properties of
+ * the method, such as its name, return type, and parameter types. It also provides the ability to
+ * invoke the method.
+ *
+ * @param <Parent> the type of the method's parent
+ * @param <ReturnType> the type of the method's return type
+ *
+ * @author Guus Lieben
+ * @since 22.5
+ */
+public interface MethodView<Parent, ReturnType> extends ExecutableElementView<Parent>, GenericTypeView<ReturnType> {
 
-    Method method();
+    /**
+     * Returns the {@link Method} instance represented by this view, if it exists.
+     *
+     * @return the method instance, if it exists
+     */
+    Option<Method> method();
 
+    /**
+     * Invokes the method represented by this view on the given instance with the given arguments. If
+     * the method is static, the instance may be {@code null}. Any exceptions thrown by the method
+     * will be caught and returned as a failed {@link Attempt}.
+     *
+     * @param instance the instance to invoke the method on
+     * @param arguments the arguments to pass to the method
+     * @return the result of the method invocation
+     */
     default Attempt<ReturnType, Throwable> invoke(final Parent instance, final Object... arguments) {
         return this.invoke(instance, Arrays.asList(arguments));
     }
 
+    /**
+     * Invokes the method represented by this view on the given instance with the given arguments. If
+     * the method is static, the instance may be {@code null}. Any exceptions thrown by the method
+     * will be caught and returned as a failed {@link Attempt}.
+     *
+     * @param instance the instance to invoke the method on
+     * @param arguments the arguments to pass to the method
+     * @return the result of the method invocation
+     */
     Attempt<ReturnType, Throwable> invoke(Parent instance, Collection<?> arguments);
 
+    /**
+     * Invokes the method represented by this view as a static method call with the given arguments.
+     * If the method is not static, a {@link IllegalIntrospectionException} will be thrown. Any
+     * exceptions thrown by the method will be caught and returned as a failed {@link Attempt}.
+     *
+     * @param arguments the arguments to pass to the method
+     * @throws IllegalIntrospectionException if the method is not static
+     * @return the result of the method invocation
+     */
     default Attempt<ReturnType, Throwable> invokeStatic(final Object... arguments) {
         return this.invokeStatic(Arrays.asList(arguments));
     }
 
+    /**
+     * Invokes the method represented by this view as a static method call with the given arguments.
+     * If the method is not static, a {@link IllegalIntrospectionException} will be thrown. Any
+     * exceptions thrown by the method will be caught and returned as a failed {@link Attempt}.
+     *
+     * @param arguments the arguments to pass to the method
+     * @throws IllegalIntrospectionException if the method is not static
+     * @return the result of the method invocation
+     */
     Attempt<ReturnType, Throwable> invokeStatic(Collection<?> arguments);
 
+    /**
+     * Returns a {@link TypeView} representing the non-generic return type of the method.
+     *
+     * @return a view of the method's return type
+     * @see #type()
+     */
     TypeView<ReturnType> returnType();
 
+    /**
+     * Returns a {@link TypeView} representing the generic return type of the method. If the method
+     * is not generic, this will return the same value as {@link #returnType()}.
+     *
+     * @return a view of the method's generic return type
+     * @see #genericType()
+     */
     TypeView<ReturnType> genericReturnType();
 
-    boolean isProtected();
-
-    boolean isPublic();
-
-    boolean isPrivate();
-
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isStatic()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     boolean isStatic();
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isFinal()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     boolean isFinal();
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isAbstract()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     boolean isAbstract();
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isDefault()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     boolean isDefault();
 
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/ModifierCarrierView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/ModifierCarrierView.java
@@ -17,21 +17,45 @@
 package org.dockbox.hartshorn.util.introspect.view;
 
 import org.dockbox.hartshorn.util.introspect.AccessModifier;
+import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
 
 public interface ModifierCarrierView extends View {
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isPublic()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     default boolean isPublic() {
         return this.has(AccessModifier.PUBLIC);
     }
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isProtected()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     default boolean isProtected() {
         return this.has(AccessModifier.PROTECTED);
     }
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isPrivate()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     default boolean isPrivate() {
         return this.has(AccessModifier.PRIVATE);
     }
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#has(AccessModifier)} instead
+     *
+     * @param modifier the modifier to check for
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     boolean has(AccessModifier modifier);
 
+    ElementModifiersIntrospector modifiers();
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/ParameterView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/ParameterView.java
@@ -16,13 +16,11 @@
 
 package org.dockbox.hartshorn.util.introspect.view;
 
-public interface ParameterView<T> extends AnnotatedElementView<T>, GenericTypeView<T> {
-
-    String name();
+public interface ParameterView<T> extends AnnotatedElementView, GenericTypeView<T> {
 
     boolean isVarArgs();
 
     boolean isNamePresent();
 
-    ExecutableElementView<?, ?> declaredBy();
+    ExecutableElementView<?> declaredBy();
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/TypeView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/TypeView.java
@@ -68,6 +68,16 @@ public interface TypeView<T> extends AnnotatedElementView, ModifierCarrierView {
 
     boolean isWildcard();
 
+    boolean isSealed();
+
+    boolean isNonSealed();
+
+    boolean isPermittedSubclass();
+
+    boolean isPermittedSubclass(Class<?> subclass);
+
+    List<TypeView<? extends T>> permittedSubclasses();
+
     boolean isDeclaredIn(String prefix);
 
     boolean isInstance(Object object);
@@ -89,10 +99,6 @@ public interface TypeView<T> extends AnnotatedElementView, ModifierCarrierView {
     boolean isChildOf(Class<?> type);
 
     boolean is(Class<?> type);
-
-    String name();
-
-    String qualifiedName();
 
     Option<TypeView<?>> elementType() throws IllegalArgumentException;
 

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/TypeView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/TypeView.java
@@ -16,15 +16,16 @@
 
 package org.dockbox.hartshorn.util.introspect.view;
 
+import java.util.List;
+
+import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeConstructorsIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeFieldsIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeMethodsIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeParametersIntrospector;
 import org.dockbox.hartshorn.util.option.Option;
 
-import java.util.List;
-
-public interface TypeView<T> extends AnnotatedElementView<T>, ModifierCarrierView {
+public interface TypeView<T> extends AnnotatedElementView, ModifierCarrierView {
 
     Class<T> type();
 
@@ -42,10 +43,25 @@ public interface TypeView<T> extends AnnotatedElementView<T>, ModifierCarrierVie
 
     boolean isRecord();
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isAbstract()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     boolean isAbstract();
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isFinal()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     boolean isFinal();
 
+    /**
+     * @deprecated use {@link #modifiers()} and {@link ElementModifiersIntrospector#isStatic()} instead
+     * @return true if the modifier is present
+     */
+    @Deprecated(forRemoval = true, since = "23.1")
     boolean isStatic();
 
     boolean isArray();

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardElementModifiersIntrospector.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardElementModifiersIntrospector.java
@@ -1,0 +1,87 @@
+package org.dockbox.hartshorn.util.introspect.view.wildcard;
+
+import org.dockbox.hartshorn.util.introspect.AccessModifier;
+import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
+
+public class WildcardElementModifiersIntrospector implements ElementModifiersIntrospector {
+
+    @Override
+    public int asInt() {
+        return 0;
+    }
+
+    @Override
+    public boolean has(final AccessModifier modifier) {
+        return false;
+    }
+
+    @Override
+    public boolean isPublic() {
+        return false;
+    }
+
+    @Override
+    public boolean isPrivate() {
+        return false;
+    }
+
+    @Override
+    public boolean isProtected() {
+        return false;
+    }
+
+    @Override
+    public boolean isStatic() {
+        return false;
+    }
+
+    @Override
+    public boolean isFinal() {
+        return false;
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return false;
+    }
+
+    @Override
+    public boolean isTransient() {
+        return false;
+    }
+
+    @Override
+    public boolean isVolatile() {
+        return false;
+    }
+
+    @Override
+    public boolean isSynchronized() {
+        return false;
+    }
+
+    @Override
+    public boolean isNative() {
+        return false;
+    }
+
+    @Override
+    public boolean isStrict() {
+        return false;
+    }
+
+    @Override
+    public boolean isMandated() {
+        return false;
+    }
+
+    @Override
+    public boolean isSynthetic() {
+        return false;
+    }
+
+    @Override
+    public boolean isDefault() {
+        return false;
+    }
+}

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardElementModifiersIntrospector.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardElementModifiersIntrospector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.util.introspect.view.wildcard;
 
 import org.dockbox.hartshorn.util.introspect.AccessModifier;

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardTypeView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardTypeView.java
@@ -124,6 +124,11 @@ public class WildcardTypeView implements TypeView<Object> {
     }
 
     @Override
+    public List<TypeView<?>> permittedSubclasses() {
+        return List.of();
+    }
+
+    @Override
     public boolean isDeclaredIn(final String prefix) {
         return false;
     }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardTypeView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardTypeView.java
@@ -104,6 +104,26 @@ public class WildcardTypeView implements TypeView<Object> {
     }
 
     @Override
+    public boolean isSealed() {
+        return false;
+    }
+
+    @Override
+    public boolean isNonSealed() {
+        return false;
+    }
+
+    @Override
+    public boolean isPermittedSubclass() {
+        return false;
+    }
+
+    @Override
+    public boolean isPermittedSubclass(final Class<?> subclass) {
+        return false;
+    }
+
+    @Override
     public boolean isDeclaredIn(final String prefix) {
         return false;
     }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardTypeView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardTypeView.java
@@ -16,9 +16,13 @@
 
 package org.dockbox.hartshorn.util.introspect.view.wildcard;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
 import org.dockbox.hartshorn.util.introspect.AccessModifier;
 import org.dockbox.hartshorn.util.introspect.ElementAnnotationsIntrospector;
+import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeConstructorsIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeFieldsIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeMethodsIntrospector;
@@ -26,9 +30,6 @@ import org.dockbox.hartshorn.util.introspect.TypeParametersIntrospector;
 import org.dockbox.hartshorn.util.introspect.view.PackageView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class WildcardTypeView implements TypeView<Object> {
 
@@ -190,6 +191,11 @@ public class WildcardTypeView implements TypeView<Object> {
     @Override
     public boolean has(final AccessModifier modifier) {
         return false;
+    }
+
+    @Override
+    public ElementModifiersIntrospector modifiers() {
+        return new WildcardElementModifiersIntrospector();
     }
 
     @Override

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/WildcardIntrospectorTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/WildcardIntrospectorTests.java
@@ -87,7 +87,7 @@ public class WildcardIntrospectorTests {
     void testWildcardHasNoModifiers() {
         final TypeView<Object> view = new WildcardTypeView();
         for (final AccessModifier modifier : AccessModifier.values()) {
-            Assertions.assertFalse(view.has(modifier));
+            Assertions.assertFalse(view.modifiers().has(modifier));
         }
     }
 

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConverterIntrospectionHelper.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConverterIntrospectionHelper.java
@@ -16,6 +16,11 @@
 
 package test.org.dockbox.hartshorn.introspect.convert;
 
+import java.lang.reflect.Constructor;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.TypeConstructorsIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeParametersIntrospector;
@@ -26,11 +31,6 @@ import org.dockbox.hartshorn.util.option.Option;
 import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 
-import java.lang.reflect.Constructor;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.Supplier;
-
 public class ConverterIntrospectionHelper {
 
     public static <T extends Collection<?>> Introspector createIntrospectorForCollection(final Class<T> type, final Supplier<T> supplier) {
@@ -40,7 +40,7 @@ public class ConverterIntrospectionHelper {
             Assertions.assertNotNull(defaultConstructor);
 
             final ConstructorView<T> constructorView = Mockito.mock(ConstructorView.class);
-            Mockito.when(constructorView.constructor()).thenReturn(defaultConstructor);
+            Mockito.when(constructorView.constructor()).thenReturn(Option.of(defaultConstructor));
             Mockito.when(constructorView.create()).thenAnswer(invocation -> Attempt.of(supplier.get()));
 
             Mockito.when(constructors.defaultConstructor()).thenReturn(Option.of(constructorView));

--- a/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/ElementContextTests.java
+++ b/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/ElementContextTests.java
@@ -17,6 +17,7 @@
 package test.org.dockbox.hartshorn.util.introspect;
 
 import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.util.introspect.IllegalIntrospectionException;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.TypeParametersIntrospector;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
@@ -354,9 +355,7 @@ public abstract class ElementContextTests {
         Assertions.assertTrue(test.present());
         final MethodView<ElementContextTests, ?> methodContext = test.get();
         Assertions.assertFalse(methodContext.modifiers().isStatic());
-        final Attempt<?, ?> result = methodContext.invokeStatic();
-        Assertions.assertTrue(result.errorPresent());
-        Assertions.assertTrue(result.error() instanceof IllegalAccessException);
+        Assertions.assertThrows(IllegalIntrospectionException.class, () -> methodContext.invokeStatic());
     }
 
     public void testNonStatic() {}

--- a/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/ElementContextTests.java
+++ b/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/ElementContextTests.java
@@ -339,7 +339,7 @@ public abstract class ElementContextTests {
                 .named("testStatic");
         Assertions.assertTrue(test.present());
         final MethodView<ElementContextTests, ?> methodContext = test.get();
-        Assertions.assertTrue(methodContext.isStatic());
+        Assertions.assertTrue(methodContext.modifiers().isStatic());
         final Attempt<?, ?> result = methodContext.invokeStatic();
         Assertions.assertTrue(result.errorAbsent());
     }
@@ -353,7 +353,7 @@ public abstract class ElementContextTests {
                 .named("testNonStatic");
         Assertions.assertTrue(test.present());
         final MethodView<ElementContextTests, ?> methodContext = test.get();
-        Assertions.assertFalse(methodContext.isStatic());
+        Assertions.assertFalse(methodContext.modifiers().isStatic());
         final Attempt<?, ?> result = methodContext.invokeStatic();
         Assertions.assertTrue(result.errorPresent());
         Assertions.assertTrue(result.error() instanceof IllegalAccessException);

--- a/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
+++ b/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -204,7 +205,9 @@ public abstract class IntrospectorTests {
         final TypeView<BridgeImpl> bridge = this.introspector().introspect(BridgeImpl.class);
         final List<MethodView<BridgeImpl, ?>> methods = bridge.methods().all();
         for (final MethodView<BridgeImpl, ?> method : methods) {
-            Assertions.assertFalse(method.method().isBridge());
+            final Option<Method> nativeMethod = method.method();
+            Assertions.assertTrue(nativeMethod.present());
+            Assertions.assertFalse(nativeMethod.get().isBridge());
         }
     }
 
@@ -214,7 +217,8 @@ public abstract class IntrospectorTests {
         final List<MethodView<BridgeImpl, ?>> methods = bridge.methods().bridges();
         Assertions.assertEquals(1, methods.size());
         Assertions.assertSame(Object.class, methods.get(0).returnType().type());
-        Assertions.assertTrue(methods.get(0).method().isBridge());
+        Assertions.assertTrue(methods.get(0).method().present());
+        Assertions.assertTrue(methods.get(0).method().get().isBridge());
     }
 
     @Test

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/DefaultProxyFactory.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/DefaultProxyFactory.java
@@ -16,13 +16,6 @@
 
 package org.dockbox.hartshorn.proxy;
 
-import org.dockbox.hartshorn.util.TypeUtils;
-import org.dockbox.hartshorn.util.collections.ConcurrentClassMap;
-import org.dockbox.hartshorn.util.collections.MultiMap;
-import org.dockbox.hartshorn.util.collections.StandardMultiMap.ConcurrentSetMultiMap;
-import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -31,6 +24,13 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import org.dockbox.hartshorn.util.TypeUtils;
+import org.dockbox.hartshorn.util.collections.ConcurrentClassMap;
+import org.dockbox.hartshorn.util.collections.MultiMap;
+import org.dockbox.hartshorn.util.collections.StandardMultiMap.ConcurrentSetMultiMap;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
 /**
  * The default implementation of {@link ProxyFactory}. This implementation is state-aware, as is suggested by its
@@ -86,7 +86,7 @@ public abstract class DefaultProxyFactory<T> implements StateAwareProxyFactory<T
     private boolean trackState = true;
     private boolean modified;
 
-    protected DefaultProxyFactory(final Class<T> type, ApplicationProxier applicationProxier) {
+    protected DefaultProxyFactory(final Class<T> type, final ApplicationProxier applicationProxier) {
         this.type = type;
         this.applicationProxier = applicationProxier;
         this.validate();
@@ -213,31 +213,31 @@ public abstract class DefaultProxyFactory<T> implements StateAwareProxyFactory<T
     }
 
     @Override
-    public StateAwareProxyFactory<T> wrapAround(Method method, Consumer<MethodWrapperFactory<T>> wrapper) {
-        StandardMethodWrapperFactory<T> factory = new StandardMethodWrapperFactory<>(this);
+    public StateAwareProxyFactory<T> wrapAround(final Method method, final Consumer<MethodWrapperFactory<T>> wrapper) {
+        final StandardMethodWrapperFactory<T> factory = new StandardMethodWrapperFactory<>(this);
         wrapper.accept(factory);
         return this.wrapAround(method, factory.create());
     }
 
     @Override
-    public StateAwareProxyFactory<T> wrapAround(MethodView<T, ?> method, Consumer<MethodWrapperFactory<T>> wrapper) {
-        return this.wrapAround(method.method(), wrapper);
+    public StateAwareProxyFactory<T> wrapAround(final MethodView<T, ?> method, final Consumer<MethodWrapperFactory<T>> wrapper) {
+        return method.method().map(m -> this.wrapAround(m, wrapper)).orElse(this);
     }
 
 
     @Override
-    public StateAwareProxyFactory<T> delegate(MethodView<T, ?> method, T delegate) {
-        return this.delegate(method.method(), delegate);
+    public StateAwareProxyFactory<T> delegate(final MethodView<T, ?> method, final T delegate) {
+        return method.method().map(m -> this.delegate(m, delegate)).orElse(this);
     }
 
     @Override
-    public <R> StateAwareProxyFactory<T> intercept(MethodView<T, R> method, org.dockbox.hartshorn.proxy.MethodInterceptor<T, R> interceptor) {
-        return this.intercept(method.method(), interceptor);
+    public <R> StateAwareProxyFactory<T> intercept(final MethodView<T, R> method, final MethodInterceptor<T, R> interceptor) {
+        return method.method().map(m -> this.intercept(m, interceptor)).orElse(this);
     }
 
     @Override
-    public StateAwareProxyFactory<T> wrapAround(MethodView<T, ?> method, MethodWrapper<T> wrapper) {
-        return this.wrapAround(method.method(), wrapper);
+    public StateAwareProxyFactory<T> wrapAround(final MethodView<T, ?> method, final MethodWrapper<T> wrapper) {
+        return method.method().map(m -> this.wrapAround(m, wrapper)).orElse(this);
     }
 
     @Override
@@ -328,6 +328,6 @@ public abstract class DefaultProxyFactory<T> implements StateAwareProxyFactory<T
     }
 
     public ApplicationProxier applicationProxier() {
-        return applicationProxier;
+        return this.applicationProxier;
     }
 }

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/JDKInterfaceProxyFactory.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/JDKInterfaceProxyFactory.java
@@ -51,8 +51,13 @@ public abstract class JDKInterfaceProxyFactory<T> extends DefaultProxyFactory<T>
     }
 
     @Override
-    public Attempt<T, Throwable> proxy(ConstructorView<T> constructor, Object[] args) throws ApplicationException {
-        return this.proxy(constructor.constructor(), args);
+    public Attempt<T, Throwable> proxy(final ConstructorView<T> constructor, final Object[] args) throws ApplicationException {
+        if (constructor.constructor().present()) {
+            return this.proxy(constructor.constructor().get(), args);
+        }
+        else {
+            throw new ApplicationException("Constructor " + constructor + " is not present on type " + this.type());
+        }
     }
 
     protected Attempt<T, Throwable> createProxy(final CheckedFunction<ProxyMethodInterceptor<T>, Attempt<T, Throwable>> instantiate) throws ApplicationException {
@@ -116,7 +121,7 @@ public abstract class JDKInterfaceProxyFactory<T> extends DefaultProxyFactory<T>
                 : this.applicationProxier().introspector().introspect(this.typeDelegate());
 
         for (final FieldView<T, ?> field : typeView.fields().all()) {
-            if (field.isStatic()) continue;
+            if (field.modifiers().isStatic()) continue;
             field.set(proxy, field.get(existing).orNull());
         }
     }

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/loaders/ObjectEqualsParameterLoaderRule.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/loaders/ObjectEqualsParameterLoaderRule.java
@@ -26,7 +26,7 @@ public class ObjectEqualsParameterLoaderRule implements ParameterLoaderRule<Prox
 
     @Override
     public boolean accepts(final ParameterView<?> parameter, final int index, final ProxyParameterLoaderContext context, final Object... args) {
-        final ExecutableElementView<?, ?> executable = parameter.declaredBy();
+        final ExecutableElementView<?> executable = parameter.declaredBy();
         return executable.declaredBy().is(Object.class) && "equals".equals(executable.name());
     }
 

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/loaders/ProxyParameterLoaderContext.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/loaders/ProxyParameterLoaderContext.java
@@ -24,7 +24,7 @@ public class ProxyParameterLoaderContext extends ParameterLoaderContext {
 
     private final ApplicationProxier applicationProxier;
 
-    public ProxyParameterLoaderContext(final ExecutableElementView<?, ?> executable, final Object instance, final ApplicationProxier applicationProxier) {
+    public ProxyParameterLoaderContext(final ExecutableElementView<?> executable, final Object instance, final ApplicationProxier applicationProxier) {
         super(executable, instance);
         this.applicationProxier = applicationProxier;
     }


### PR DESCRIPTION
# Description
## #958 Support for sealed classes
Currently it is not possible to check whether a given type is sealed, has permitted subclasses, or is a permitted subclass itself. Sealed classes were introduced in [JEP 360](https://openjdk.org/jeps/360), which were first introduced in JDK 15, and finalized them in JDK 17 through [JEP 409](https://openjdk.org/jeps/409).

These changes add support for sealed classes and permitted subclasses. This supports the following options:
* Check if a class is `sealed`
* Check if a class is `non-sealed`
* Check if a given class is a permitted subclass of the current type
* Check if the current type is a permitted subclass of its parent
* Get the permitted subclasses of the current type

Fixes #958

## #959
Currently the ability to check for specific modifiers is highly restrictive in the Introspection API. It is only possible to check for specific modifiers on given views, but there is no general guideline as to which modifiers should be checked.

These changes add a new `ElementModifiersIntrospector`, which allows you to inspect the modifiers of any member or type. Additional views can be supported by providing their direct `modifiers` as `int` to the introspector.

Fixes #959

## Type of change
- [x] New feature (non-breaking change that does affect the code)
- [x] Refactor (code changes that do not affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
