### PR TITLE
#963 Remove redundant package check

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/TypeReferenceLookupComponentLocator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/TypeReferenceLookupComponentLocator.java
@@ -67,10 +67,6 @@ public class TypeReferenceLookupComponentLocator implements ComponentLocator, Co
         final Introspector introspector = this.applicationContext().environment();
         final TypeView<T> contract = introspector.introspect(key.type());
 
-        // Skip introspection types, to avoid infinite recursion. Introspectors are utility classes,
-        // and are never registered as components.
-        if (contract.isDeclaredIn(Introspector.class.getPackageName())) return;
-
         if (contract.annotations().has(Component.class) && this.container(contract.type()).absent()) {
             this.applicationContext().log().warn("Component key '%s' is annotated with @Component, but is not registered.".formatted(contract.qualifiedName()));
         }


### PR DESCRIPTION
# Description
The following workaround was added while Hartshorn Core was being refactored heavily, but has since lost its purpose and need.
https://github.com/Dockbox-OSS/Hartshorn/blob/5a57753ec5e9682d31cfd658001de5a8513c321a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/TypeReferenceLookupComponentLocator.java#L70-L72

This PR removes this workaround, this does not affect any other behavior.

Fixes #963

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing (existing tests)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
