### PR TITLE
#966 Code cleanup before RC23.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@
 #
 # Versions in alphabetical order.
 #
+autoService = "1.0-rc7"
 antlr = "4.10.1"
 caffeine = "3.1.1"
 cglib = "3.3.0"
@@ -97,6 +98,7 @@ testContainersMssqlserver = { module = "org.testcontainers:mssqlserver", version
 # Libraries in alphabetical order
 #
 antlr = { module = "org.antlr:antlr4", version.ref = "antlr" }
+autoService = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 cglib = { module = "cglib:cglib", version.ref = "cglib" }
 derby = { module = "org.apache.derby:derby", version.ref = "derby" }

--- a/gradle/plugins/src/main/java/org/dockbox/hartshorn/gradle/javadoc/JavadocVerifierPlugin.java
+++ b/gradle/plugins/src/main/java/org/dockbox/hartshorn/gradle/javadoc/JavadocVerifierPlugin.java
@@ -18,15 +18,17 @@ package org.dockbox.hartshorn.gradle.javadoc;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.plugins.JavaPluginExtension;
 
 import java.io.File;
+import java.io.IOException;
 
 public class JavadocVerifierPlugin implements Plugin<Project> {
 
     @Override
     public void apply(final Project target) {
-        target.getTasks().register("verifyJavadoc", task -> task.doLast(t -> {
+        target.getTasks().register("verifyJavadoc", task -> task.doLast(task0 -> {
             final Project project = task.getProject();
             try {
                 final File javaSourceDirectory = project.getExtensions().getByType(JavaPluginExtension.class)
@@ -46,7 +48,7 @@ public class JavadocVerifierPlugin implements Plugin<Project> {
                     assert project.getParent() == null;
                 }
             }
-            catch (final Exception e) {
+            catch (IOException | UnknownDomainObjectException | IllegalStateException e) {
                 throw new RuntimeException(e);
             }
         }));

--- a/hartshorn-cache/hartshorn-cache-caffeine/hartshorn-cache-caffeine.gradle.kts
+++ b/hartshorn-cache/hartshorn-cache-caffeine/hartshorn-cache-caffeine.gradle.kts
@@ -19,9 +19,7 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-cache")
+    api("org.dockbox.hartshorn:hartshorn-cache")
 
     implementation(libs.caffeine)
 

--- a/hartshorn-cache/hartshorn-cache-caffeine/src/main/java/org/dockbox/hartshorn/cache/caffeine/CaffeineCache.java
+++ b/hartshorn-cache/hartshorn-cache-caffeine/src/main/java/org/dockbox/hartshorn/cache/caffeine/CaffeineCache.java
@@ -71,7 +71,7 @@ public class CaffeineCache<K, V> implements Cache<K, V> {
 
     @Override
     public void putIfAbsent(final K key, final V value) {
-        this.cache.get(key, k -> value);
+        this.cache.get(key, key0 -> value);
     }
 
     @Override

--- a/hartshorn-cache/hartshorn-cache.gradle.kts
+++ b/hartshorn-cache/hartshorn-cache.gradle.kts
@@ -20,11 +20,7 @@ apply {
 
 dependencies {
     api(libs.caffeine)
-
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
+    api("org.dockbox.hartshorn:hartshorn-core")
 
     testImplementation("org.dockbox.hartshorn:hartshorn-introspect-reflection")
     testImplementation("org.dockbox.hartshorn:hartshorn-proxy-javassist")

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheManagerImpl.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheManagerImpl.java
@@ -52,7 +52,7 @@ public class CacheManagerImpl implements CacheManager {
 
     @Override
     public <K, V> Option<Cache<K, V>> get(final String cache) {
-        return Option.of(this.caches.get(cache)).map(c -> (Cache<K, V>) c);
+        return Option.of(this.caches.get(cache)).map(storedCache -> (Cache<K, V>) storedCache);
     }
 
     @Override
@@ -64,7 +64,7 @@ public class CacheManagerImpl implements CacheManager {
                     this.caches.put(name, cache);
                     return cache;
                 })
-                .map(c -> (Cache<K, V>) c)
+                .map(storedCache -> (Cache<K, V>) storedCache)
                 .get();
     }
 

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/Expiration.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/Expiration.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  * @author Guus Lieben
  * @since 21.2
  */
-public class Expiration {
+public final class Expiration {
 
     private static final Expiration NEVER = new Expiration(-1, TimeUnit.MILLISECONDS);
     private final long amount;

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodInterceptor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodInterceptor.java
@@ -1,0 +1,30 @@
+package org.dockbox.hartshorn.cache.modifiers;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.cache.Cache;
+import org.dockbox.hartshorn.cache.context.CacheContext;
+import org.dockbox.hartshorn.proxy.MethodInterceptor;
+import org.dockbox.hartshorn.proxy.MethodInterceptorContext;
+import org.dockbox.hartshorn.util.ApplicationException;
+
+public class CacheEvictionMethodInterceptor<T, R> implements MethodInterceptor<T, R> {
+    private final CacheContext cacheContext;
+    private final ApplicationContext context;
+
+    public CacheEvictionMethodInterceptor(final CacheContext cacheContext, final ApplicationContext context) {
+        this.cacheContext = cacheContext;
+        this.context = context;
+    }
+
+    @Override
+    public R intercept(final MethodInterceptorContext<T, R> interceptorContext) throws Throwable {
+        try {
+            this.cacheContext.manager().get(this.cacheContext.cacheName()).peek(Cache::invalidate);
+            return interceptorContext.invokeDefault();
+        }
+        catch (final ApplicationException e) {
+            this.context.handle(e);
+        }
+        return null; // Should be void anyway
+    }
+}

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodInterceptor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.cache.modifiers;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodPostProcessor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodPostProcessor.java
@@ -17,7 +17,6 @@
 package org.dockbox.hartshorn.cache.modifiers;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.cache.Cache;
 import org.dockbox.hartshorn.cache.Expiration;
 import org.dockbox.hartshorn.cache.annotations.EvictCache;
 import org.dockbox.hartshorn.cache.context.CacheContext;
@@ -26,7 +25,6 @@ import org.dockbox.hartshorn.cache.context.CacheMethodContextImpl;
 import org.dockbox.hartshorn.proxy.MethodInterceptor;
 import org.dockbox.hartshorn.component.processing.proxy.MethodProxyContext;
 import org.dockbox.hartshorn.component.processing.proxy.ServiceAnnotatedMethodInterceptorPostProcessor;
-import org.dockbox.hartshorn.util.ApplicationException;
 
 /**
  * The {@link ServiceAnnotatedMethodInterceptorPostProcessor} responsible for {@link EvictCache}
@@ -46,15 +44,7 @@ public class CacheEvictionMethodPostProcessor extends CacheServicePostProcessor<
 
     @Override
     protected <T, R> MethodInterceptor<T, R> process(final ApplicationContext context, final CacheContext cacheContext) {
-        return interceptorContext -> {
-            try {
-                cacheContext.manager().get(cacheContext.cacheName()).peek(Cache::invalidate);
-                return interceptorContext.invokeDefault();
-            } catch (final ApplicationException e) {
-                context.handle(e);
-            }
-            return null; // Should be void anyway
-        };
+        return new CacheEvictionMethodInterceptor<>(cacheContext, context);
     }
 
     @Override

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheServicePostProcessor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheServicePostProcessor.java
@@ -52,7 +52,7 @@ public abstract class CacheServicePostProcessor<A extends Annotation> extends Se
         final CacheManager manager = context.get(CacheManager.class);
 
         String name = cacheMethodContext.name();
-        if ("".equals(name)) {
+        if (name != null && name.isEmpty()) {
             final Option<CacheService> annotation = proxyContext.type().annotations().get(CacheService.class);
             if (annotation.present()) {
                 name = annotation.get().value();

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodInterceptor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.cache.modifiers;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodInterceptor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodInterceptor.java
@@ -1,0 +1,31 @@
+package org.dockbox.hartshorn.cache.modifiers;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.cache.context.CacheContext;
+import org.dockbox.hartshorn.proxy.MethodInterceptor;
+import org.dockbox.hartshorn.proxy.MethodInterceptorContext;
+import org.dockbox.hartshorn.util.ApplicationException;
+
+public class CacheUpdateMethodInterceptor<T, R> implements MethodInterceptor<T, R> {
+    private final CacheContext cacheContext;
+    private final ApplicationContext context;
+
+    public CacheUpdateMethodInterceptor(final CacheContext cacheContext, final ApplicationContext context) {
+        this.cacheContext = cacheContext;
+        this.context = context;
+    }
+
+    @Override
+    public R intercept(final MethodInterceptorContext<T, R> interceptorContext) throws Throwable {
+        try {
+            final Object o = interceptorContext.args()[0];
+            this.cacheContext.manager().get(this.cacheContext.cacheName())
+                    .peek(cache -> cache.put(this.cacheContext.key(), o));
+            return interceptorContext.invokeDefault();
+        }
+        catch (final ApplicationException e) {
+            this.context.handle(e);
+            return interceptorContext.method().returnType().defaultOrNull();
+        }
+    }
+}

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodPostProcessor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodPostProcessor.java
@@ -26,7 +26,6 @@ import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.proxy.MethodInterceptor;
 import org.dockbox.hartshorn.component.processing.proxy.MethodProxyContext;
 import org.dockbox.hartshorn.component.processing.proxy.ServiceAnnotatedMethodInterceptorPostProcessor;
-import org.dockbox.hartshorn.util.ApplicationException;
 
 /**
  * The {@link ServiceAnnotatedMethodInterceptorPostProcessor} responsible for {@link UpdateCache}
@@ -46,17 +45,7 @@ public class CacheUpdateMethodPostProcessor extends CacheServicePostProcessor<Up
 
     @Override
     protected <T, R> MethodInterceptor<T, R> process(final ApplicationContext context, final CacheContext cacheContext) {
-        return interceptorContext -> {
-            try {
-                final Object o = interceptorContext.args()[0];
-                cacheContext.manager().get(cacheContext.cacheName())
-                        .peek(cache -> cache.put(cacheContext.key(), o));
-                return interceptorContext.invokeDefault();
-            } catch (final ApplicationException e) {
-                context.handle(e);
-                return interceptorContext.method().returnType().defaultOrNull();
-            }
-        };
+        return new CacheUpdateMethodInterceptor<>(cacheContext, context);
     }
 
     @Override

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CachedMethodInterceptor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CachedMethodInterceptor.java
@@ -1,0 +1,43 @@
+package org.dockbox.hartshorn.cache.modifiers;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.cache.Cache;
+import org.dockbox.hartshorn.cache.context.CacheContext;
+import org.dockbox.hartshorn.proxy.MethodInterceptor;
+import org.dockbox.hartshorn.proxy.MethodInterceptorContext;
+import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
+import org.dockbox.hartshorn.util.option.Option;
+
+public class CachedMethodInterceptor<T, R> implements MethodInterceptor<T, R> {
+    private final CacheContext cacheContext;
+    private final String elementKey;
+    private final ConversionService conversionService;
+    private final ApplicationContext context;
+
+    public CachedMethodInterceptor(final CacheContext cacheContext, final String elementKey, final ConversionService conversionService, final ApplicationContext context) {
+        this.cacheContext = cacheContext;
+        this.elementKey = elementKey;
+        this.conversionService = conversionService;
+        this.context = context;
+    }
+
+    @Override
+    public R intercept(final MethodInterceptorContext<T, R> interceptorContext) {
+        final Cache<String, Object> cache = this.cacheContext.cache();
+        final Option<R> content = cache.get(this.elementKey)
+                .map(result -> this.conversionService.convert(result, interceptorContext.method().returnType().type()));
+
+        return content.orElseGet(() -> {
+            this.context.log().debug("Cache " + this.cacheContext.cacheName() + " has not been populated yet, or content has expired.");
+            try {
+                final R out = interceptorContext.invokeDefault();
+                cache.putIfAbsent(this.elementKey, out);
+                return out;
+            }
+            catch (final Throwable e) {
+                this.context.handle(e);
+                return null;
+            }
+        });
+    }
+}

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CachedMethodInterceptor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CachedMethodInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.cache.modifiers;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-cache/src/testFixtures/java/test/org/dockbox/hartshorn/cache/NonAbstractCacheService.java
+++ b/hartshorn-cache/src/testFixtures/java/test/org/dockbox/hartshorn/cache/NonAbstractCacheService.java
@@ -24,8 +24,8 @@ import org.dockbox.hartshorn.cache.annotations.UpdateCache;
 public class NonAbstractCacheService {
 
     @UpdateCache
-    public long update(final long s) {
-        return s*2;
+    public long update(final long number) {
+        return number*2;
     }
 
     @EvictCache

--- a/hartshorn-cache/src/testFixtures/java/test/org/dockbox/hartshorn/cache/TestCacheService.java
+++ b/hartshorn-cache/src/testFixtures/java/test/org/dockbox/hartshorn/cache/TestCacheService.java
@@ -31,7 +31,7 @@ public abstract class TestCacheService {
     }
 
     @UpdateCache(key = "sample_key")
-    public abstract void update(long s);
+    public abstract void update(long number);
 
     @EvictCache(key = "sample_key")
     public abstract void evict();

--- a/hartshorn-commands/hartshorn-commands.gradle.kts
+++ b/hartshorn-commands/hartshorn-commands.gradle.kts
@@ -19,12 +19,8 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-i18n")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-events")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
+    api("org.dockbox.hartshorn:hartshorn-i18n")
+    api("org.dockbox.hartshorn:hartshorn-events")
 
     testImplementation("org.dockbox.hartshorn:hartshorn-hsl")
     testImplementation("org.dockbox.hartshorn:hartshorn-introspect-reflection")

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
@@ -185,7 +185,7 @@ public class CommandGatewayImpl implements CommandGateway {
             for (final String contextAlias : executorContext.aliases()) {
                 if (contextAlias.startsWith(command)) {
                     final String stripped = contextAlias.replaceFirst(alias + " ", "");
-                    if (!"".equals(stripped)) suggestions.add(stripped);
+                    if (!stripped.isEmpty()) suggestions.add(stripped);
                 }
             }
         }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
@@ -135,7 +135,7 @@ public class CommandGatewayImpl implements CommandGateway {
     @Override
     public void accept(final CommandContext context) throws ParsingException {
         final Option<CommandExecutorContext> executor = this.get(context);
-        executor.peek(e -> this.execute(e, context))
+        executor.peek(executorContext -> this.execute(executorContext, context))
                 .orElseThrow(() -> new ParsingException(this.resources.missingExecutor(context.alias(), context.arguments().size())));
     }
 

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandListenerImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandListenerImpl.java
@@ -82,24 +82,26 @@ public class CommandListenerImpl implements CommandListener {
     }
 
     protected Runnable createTask() {
-        return () -> {
-            try (
-                    final InputStream input = this.input();
-                    final Scanner scanner = new Scanner(input)
-            ) {
-                this.context.log().debug("Starting command CLI input listener");
-                while (this.running()) {
-                    final String next = scanner.nextLine();
-                    try {
-                        this.gateway.accept(this.source(), next);
-                    } catch (final ParsingException e) {
-                        this.context.handle(e);
-                    }
+        return this::listenForInput;
+    }
+
+    private void listenForInput() {
+        try (
+                final InputStream input = this.input();
+                final Scanner scanner = new Scanner(input)
+        ) {
+            this.context.log().debug("Starting command CLI input listener");
+            while (this.running()) {
+                final String next = scanner.nextLine();
+                try {
+                    this.gateway.accept(this.source(), next);
+                } catch (final ParsingException e) {
+                    this.context.handle(e);
                 }
-            } catch (final IOException e) {
-                this.context.handle(e);
             }
-        };
+        } catch (final IOException e) {
+            this.context.handle(e);
+        }
     }
 
     /**

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandSource.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandSource.java
@@ -31,7 +31,7 @@ public interface CommandSource extends MessageReceiver, ContextCarrier {
      *
      * @param command The raw command
      */
-    default void execute(String command) throws ParsingException {
+    default void execute(final String command) throws ParsingException {
         final CommandGateway gateway = this.applicationContext().get(CommandGateway.class);
         gateway.accept(this, command);
     }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoaderContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoaderContext.java
@@ -20,17 +20,17 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.commands.context.CommandContext;
 import org.dockbox.hartshorn.commands.context.MethodCommandExecutorContext;
 import org.dockbox.hartshorn.util.ApplicationBoundParameterLoaderContext;
-import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 
 public class CommandParameterLoaderContext extends ApplicationBoundParameterLoaderContext {
 
     private final CommandContext commandContext;
     private final MethodCommandExecutorContext<?> executorContext;
 
-    public CommandParameterLoaderContext(final MethodView<?, ?> method, final TypeView<?> type, final Object instance, final ApplicationContext applicationContext, final CommandContext commandContext,
+    public CommandParameterLoaderContext(final ExecutableElementView<?> element, final Object instance,
+                                         final ApplicationContext applicationContext, final CommandContext commandContext,
                                          final MethodCommandExecutorContext<?> executorContext) {
-        super(method, instance, applicationContext);
+        super(element, instance, applicationContext);
         this.commandContext = commandContext;
         this.executorContext = executorContext;
     }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverter.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverter.java
@@ -44,10 +44,12 @@ public abstract class DefaultArgumentConverter<T> implements ArgumentConverter<T
         this.size = size;
     }
 
+    @Override
     public Class<T> type() {
         return this.type;
     }
 
+    @Override
     public List<String> keys() {
         return Arrays.asList(this.keys);
     }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
@@ -156,7 +156,7 @@ public class DefaultArgumentConverters {
     public static ArgumentConverter<Integer[]> remainingIntegersArgumentConverter() {
         final Converter<String, Integer> integerConverter = new StringToNumberConverterFactory().create(Integer.class);
         return ArgumentConverterImpl.builder(Integer[].class, "remainingInt")
-                .withConverter((String in) -> {
+                .withConverter((final String in) -> {
                     final String[] parts = in.split(" ");
                     final Integer[] integers = new Integer[parts.length];
                     for (int i = 0; i < parts.length; i++) {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/PrefixedParameterPattern.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/PrefixedParameterPattern.java
@@ -25,7 +25,6 @@ import org.dockbox.hartshorn.util.option.Attempt;
 
 import java.util.ArrayList;
 import java.util.List;
-
 /**
  * Converts prefixed patterns into type instances used by command executors. The
  * pattern is decided on by any implementation of this type.
@@ -34,7 +33,7 @@ public abstract class PrefixedParameterPattern implements CustomParameterPattern
 
     @Override
     public <T> Attempt<Boolean, ConverterException> preconditionsMatch(final Class<T> type, final CommandSource source, final String raw) {
-        String prefix = this.prefix() + "";
+        String prefix = String.valueOf(this.prefix());
         if (this.requiresTypeName()) {
             final ApplicationContext applicationContext = source.applicationContext();
             final TypeView<T> typeView = applicationContext.environment().introspect(type);
@@ -73,7 +72,7 @@ public abstract class PrefixedParameterPattern implements CustomParameterPattern
 
     @Override
     public Attempt<String, ConverterException> parseIdentifier(final String argument) {
-        if (argument.startsWith(this.prefix() + "")) {
+        if (argument.startsWith(String.valueOf(this.prefix()))) {
             return Attempt.of(argument.substring(1, argument.indexOf(this.opening())));
         }
         else {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/CommandContextImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/CommandContextImpl.java
@@ -45,10 +45,12 @@ public class CommandContextImpl extends DefaultProvisionContext implements Comma
         this.applicationContext = applicationContext;
     }
 
+    @Override
     public CommandSource source() {
         return this.source;
     }
 
+    @Override
     public ApplicationContext applicationContext() {
         return this.applicationContext;
     }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutor.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutor.java
@@ -1,0 +1,56 @@
+package org.dockbox.hartshorn.commands.context;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.commands.CommandExecutor;
+import org.dockbox.hartshorn.commands.CommandResources;
+import org.dockbox.hartshorn.commands.arguments.CommandParameterLoaderContext;
+import org.dockbox.hartshorn.commands.events.CommandEvent;
+import org.dockbox.hartshorn.commands.events.CommandEvent.Before;
+import org.dockbox.hartshorn.component.condition.ConditionMatcher;
+import org.dockbox.hartshorn.component.condition.ProvidedParameterContext;
+import org.dockbox.hartshorn.events.parents.Cancellable;
+import org.dockbox.hartshorn.i18n.Message;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+
+import java.util.List;
+
+public class MethodCommandExecutor<T> implements CommandExecutor {
+    private final ConditionMatcher conditionMatcher;
+    private final MethodCommandExecutorContext<T> executorContext;
+    private final ApplicationContext applicationContext;
+    private final MethodView<T, ?> method;
+
+    public MethodCommandExecutor(final ConditionMatcher conditionMatcher, final MethodCommandExecutorContext<T> context) {
+        this.conditionMatcher = conditionMatcher;
+        this.executorContext = context;
+        this.applicationContext = context.applicationContext();
+        this.method = context.method();
+    }
+
+    @Override
+    public void execute(final CommandContext commandContext) {
+        final Cancellable before = new Before(commandContext.source(), commandContext).with(this.applicationContext).post();
+        if (before.cancelled()) {
+            this.applicationContext.log().debug("Execution cancelled for " + this.method.qualifiedName());
+            final Message cancelled = this.applicationContext.get(CommandResources.class).cancelled();
+            commandContext.source().send(cancelled);
+            return;
+        }
+
+        final T instance = this.applicationContext.get(this.executorContext.key());
+        final CommandParameterLoaderContext loaderContext = new CommandParameterLoaderContext(this.method, null, this.applicationContext, commandContext, this.executorContext);
+        final List<Object> arguments = this.executorContext.parameterLoader().loadArguments(loaderContext);
+
+        if (this.conditionMatcher.match(this.method, ProvidedParameterContext.of(this.method, arguments))) {
+            this.applicationContext.log().debug("Invoking command method %s with %d arguments".formatted(this.method.qualifiedName(), arguments.size()));
+            this.method.invoke(instance, arguments.toArray())
+                    .peekError(error -> this.applicationContext.handle("Encountered unexpected error while performing command executor", error));
+            new CommandEvent.After(commandContext.source(), commandContext).with(this.applicationContext).post();
+        }
+        else {
+            this.applicationContext.log().debug("Conditions didn't match for " + this.method.qualifiedName());
+            final Message cancelled = this.applicationContext.get(CommandResources.class).cancelled();
+            commandContext.source().send(cancelled);
+        }
+    }
+}

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutor.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.commands.context;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
@@ -19,20 +19,15 @@ package org.dockbox.hartshorn.commands.context;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.commands.CommandExecutor;
 import org.dockbox.hartshorn.commands.CommandParser;
-import org.dockbox.hartshorn.commands.CommandResources;
 import org.dockbox.hartshorn.commands.CommandSource;
 import org.dockbox.hartshorn.commands.annotations.Command;
 import org.dockbox.hartshorn.commands.arguments.CommandParameterLoaderContext;
 import org.dockbox.hartshorn.commands.definition.CommandElement;
 import org.dockbox.hartshorn.commands.events.CommandEvent;
-import org.dockbox.hartshorn.commands.events.CommandEvent.Before;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.condition.ConditionMatcher;
-import org.dockbox.hartshorn.component.condition.ProvidedParameterContext;
 import org.dockbox.hartshorn.context.DefaultApplicationAwareContext;
 import org.dockbox.hartshorn.events.annotations.Posting;
-import org.dockbox.hartshorn.events.parents.Cancellable;
-import org.dockbox.hartshorn.i18n.Message;
 import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.ParameterView;
@@ -40,7 +35,11 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 import org.dockbox.hartshorn.util.introspect.util.ParameterLoader;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -112,8 +111,6 @@ public class MethodCommandExecutorContext<T> extends DefaultApplicationAwareCont
         return this.isChild;
     }
 
-
-
     protected ParameterLoader<CommandParameterLoaderContext> parameterLoader() {
         return this.parameterLoader;
     }
@@ -134,32 +131,7 @@ public class MethodCommandExecutorContext<T> extends DefaultApplicationAwareCont
     @Override
     public CommandExecutor executor() {
         final ConditionMatcher conditionMatcher = this.applicationContext().get(ConditionMatcher.class);
-
-        return (ctx) -> {
-            final Cancellable before = new Before(ctx.source(), ctx).with(this.applicationContext()).post();
-            if (before.cancelled()) {
-                this.applicationContext().log().debug("Execution cancelled for " + this.method().qualifiedName());
-                final Message cancelled = this.applicationContext().get(CommandResources.class).cancelled();
-                ctx.source().send(cancelled);
-                return;
-            }
-
-            final T instance = this.applicationContext().get(this.key());
-            final CommandParameterLoaderContext loaderContext = new CommandParameterLoaderContext(this.method(), null, this.applicationContext(), ctx, this);
-            final List<Object> arguments = this.parameterLoader().loadArguments(loaderContext);
-
-            if (conditionMatcher.match(this.method(), ProvidedParameterContext.of(this.method(), arguments))) {
-                this.applicationContext().log().debug("Invoking command method %s with %d arguments".formatted(this.method().qualifiedName(), arguments.size()));
-                this.method().invoke(instance, arguments.toArray())
-                        .peekError(error -> this.applicationContext().handle("Encountered unexpected error while performing command executor", error));
-                new CommandEvent.After(ctx.source(), ctx).with(this.applicationContext()).post();
-            }
-            else {
-                this.applicationContext().log().debug("Conditions didn't match for " + this.method().qualifiedName());
-                final Message cancelled = this.applicationContext().get(CommandResources.class).cancelled();
-                ctx.source().send(cancelled);
-            }
-        };
+        return new MethodCommandExecutor<>(conditionMatcher, this);
     }
 
     @Override

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
@@ -134,7 +134,6 @@ public class MethodCommandExecutorContext<T> extends DefaultApplicationAwareCont
     @Override
     public CommandExecutor executor() {
         final ConditionMatcher conditionMatcher = this.applicationContext().get(ConditionMatcher.class);
-        final TypeView<T> typeView = this.applicationContext().environment().introspect(this.key().type());
 
         return (ctx) -> {
             final Cancellable before = new Before(ctx.source(), ctx).with(this.applicationContext()).post();
@@ -146,7 +145,7 @@ public class MethodCommandExecutorContext<T> extends DefaultApplicationAwareCont
             }
 
             final T instance = this.applicationContext().get(this.key());
-            final CommandParameterLoaderContext loaderContext = new CommandParameterLoaderContext(this.method(), typeView, null, this.applicationContext(), ctx, this);
+            final CommandParameterLoaderContext loaderContext = new CommandParameterLoaderContext(this.method(), null, this.applicationContext(), ctx, this);
             final List<Object> arguments = this.parameterLoader().loadArguments(loaderContext);
 
             if (conditionMatcher.match(this.method(), ProvidedParameterContext.of(this.method(), arguments))) {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/events/CommandEvent.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/events/CommandEvent.java
@@ -50,10 +50,12 @@ public abstract class CommandEvent extends AbstractTargetEvent {
             super(source, context);
         }
 
+        @Override
         public boolean cancelled() {
             return this.cancelled;
         }
 
+        @Override
         public Before cancelled(final boolean cancelled) {
             this.cancelled = cancelled;
             return this;

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/extension/CooldownExtension.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/extension/CooldownExtension.java
@@ -71,26 +71,26 @@ public class CooldownExtension implements CommandExecutorExtension {
      * Places an object in the cooldown queue for a given amount of time. If the object is already in
      * the cooldown queue it will not be overwritten and the existing queue position with be kept.
      *
-     * @param o The object to place in cooldown
+     * @param target The object to place in cooldown
      * @param duration The duration
      * @param timeUnit The time unit in which the duration is kept
      */
-    protected void cooldown(final Object o, final long duration, final TemporalUnit timeUnit) {
-        if (this.inCooldown(o)) return;
-        this.activeCooldowns.put(o, new CooldownEntry(LocalDateTime.now(), duration, timeUnit));
+    protected void cooldown(final Object target, final long duration, final TemporalUnit timeUnit) {
+        if (this.inCooldown(target)) return;
+        this.activeCooldowns.put(target, new CooldownEntry(LocalDateTime.now(), duration, timeUnit));
     }
 
     /**
      * Returns true if an object is in an active cooldown queue. Otherwise false
      *
-     * @param o The object
+     * @param target The object to check
      *
      * @return true if an object is in an active cooldown queue. Otherwise false
      */
-    protected boolean inCooldown(final Object o) {
-        if (this.activeCooldowns.containsKey(o)) {
+    protected boolean inCooldown(final Object target) {
+        if (this.activeCooldowns.containsKey(target)) {
             final LocalDateTime now = LocalDateTime.now();
-            final CooldownEntry cooldown = this.activeCooldowns.get(o);
+            final CooldownEntry cooldown = this.activeCooldowns.get(target);
             final LocalDateTime timeCooledDown = cooldown.startTime();
             final long duration = cooldown.duration();
             final TemporalUnit timeUnit = cooldown.timeUnit();

--- a/hartshorn-config/hartshorn-config-jackson/hartshorn-config-jackson.gradle.kts
+++ b/hartshorn-config/hartshorn-config-jackson/hartshorn-config-jackson.gradle.kts
@@ -19,11 +19,7 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    implementation("org.dockbox.hartshorn:hartshorn-config")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
+    api("org.dockbox.hartshorn:hartshorn-config")
 
     implementation(libs.bundles.jackson)
 

--- a/hartshorn-config/hartshorn-config-jackson/src/main/java/org/dockbox/hartshorn/config/jackson/JacksonObjectMapper.java
+++ b/hartshorn-config/hartshorn-config-jackson/src/main/java/org/dockbox/hartshorn/config/jackson/JacksonObjectMapper.java
@@ -68,7 +68,7 @@ public class JacksonObjectMapper extends DefaultObjectMapper {
     @Override
     public <T> Attempt<T, ObjectMappingException> read(final String content, final Class<T> type) {
         this.context.log().debug("Reading content from string value to type " + type.getName());
-        return Attempt.<T, JsonProcessingException>of(() -> this.configureMapper().readValue(content, type), JsonProcessingException.class)
+        return Attempt.of(() -> this.configureMapper().readValue(content, type), JsonProcessingException.class)
                 .mapError(ObjectMappingException::new);
     }
 

--- a/hartshorn-config/hartshorn-config-jackson/src/main/java/org/dockbox/hartshorn/config/jackson/JacksonProviders.java
+++ b/hartshorn-config/hartshorn-config-jackson/src/main/java/org/dockbox/hartshorn/config/jackson/JacksonProviders.java
@@ -16,35 +16,20 @@
 
 package org.dockbox.hartshorn.config.jackson;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonSetter.Value;
-import com.fasterxml.jackson.annotation.Nulls;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.core.JsonParser.Feature;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.cfg.MapperBuilder;
-
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.condition.RequiresClass;
 import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.component.processing.ProcessingOrder;
-import org.dockbox.hartshorn.config.JsonInclusionRule;
 import org.dockbox.hartshorn.config.ObjectMapper;
 import org.dockbox.hartshorn.config.annotations.UseConfigurations;
-import org.dockbox.hartshorn.config.jackson.introspect.HartshornJacksonAnnotationIntrospector;
 import org.dockbox.hartshorn.config.jackson.mapping.JavaPropsDataMapper;
 import org.dockbox.hartshorn.config.jackson.mapping.JsonDataMapper;
 import org.dockbox.hartshorn.config.jackson.mapping.TomlDataMapper;
 import org.dockbox.hartshorn.config.jackson.mapping.XmlDataMapper;
 import org.dockbox.hartshorn.config.jackson.mapping.YamlDataMapper;
 import org.dockbox.hartshorn.util.introspect.Introspector;
-
-import java.util.function.Function;
 
 @Service
 @RequiresActivator(UseConfigurations.class)
@@ -90,30 +75,6 @@ public class JacksonProviders {
 
     @Binds(phase = DATA_MAPPER_PHASE + 16) // Before ObjectMapper
     public JacksonObjectMapperConfigurator mapperConfigurator(final Introspector introspector) {
-        final Function<JsonInclusionRule, Include> rules = (rule) -> switch (rule) {
-            case SKIP_EMPTY -> Include.NON_EMPTY;
-            case SKIP_NULL -> Include.NON_NULL;
-            case SKIP_DEFAULT -> Include.NON_DEFAULT;
-            case SKIP_NONE -> Include.ALWAYS;
-        };
-        return (builder, format, inclusionRule) -> {
-            MapperBuilder<?, ?> mb = builder
-                    .annotationIntrospector(new HartshornJacksonAnnotationIntrospector(introspector))
-                    .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
-                    .enable(Feature.ALLOW_COMMENTS)
-                    .enable(Feature.ALLOW_YAML_COMMENTS)
-                    .enable(SerializationFeature.INDENT_OUTPUT)
-                    .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-                    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                    .defaultSetterInfo(Value.forContentNulls(Nulls.AS_EMPTY))
-                    // Hartshorn convention uses fluent style getters/setters, these are not picked up by Jackson
-                    // which would otherwise cause it to fail due to it recognizing the object as an empty bean,
-                    // even if it is not empty.
-                    .visibility(PropertyAccessor.FIELD, Visibility.ANY);
-            if (inclusionRule != null) {
-                mb = mb.serializationInclusion(rules.apply(inclusionRule));
-            }
-            return mb;
-        };
+        return new StandardJacksonObjectMapperConfigurator(introspector);
     }
 }

--- a/hartshorn-config/hartshorn-config-jackson/src/main/java/org/dockbox/hartshorn/config/jackson/StandardJacksonObjectMapperConfigurator.java
+++ b/hartshorn-config/hartshorn-config-jackson/src/main/java/org/dockbox/hartshorn/config/jackson/StandardJacksonObjectMapperConfigurator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.config.jackson;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;

--- a/hartshorn-config/hartshorn-config-jackson/src/main/java/org/dockbox/hartshorn/config/jackson/StandardJacksonObjectMapperConfigurator.java
+++ b/hartshorn-config/hartshorn-config-jackson/src/main/java/org/dockbox/hartshorn/config/jackson/StandardJacksonObjectMapperConfigurator.java
@@ -1,0 +1,60 @@
+package org.dockbox.hartshorn.config.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonSetter.Value;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonParser.Feature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
+
+import org.dockbox.hartshorn.config.FileFormat;
+import org.dockbox.hartshorn.config.JsonInclusionRule;
+import org.dockbox.hartshorn.config.jackson.introspect.HartshornJacksonAnnotationIntrospector;
+import org.dockbox.hartshorn.util.introspect.Introspector;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class StandardJacksonObjectMapperConfigurator implements JacksonObjectMapperConfigurator {
+
+    private static final Map<JsonInclusionRule, Include> RULE_MAPPINGS = new EnumMap<>(JsonInclusionRule.class);
+
+    static {
+        RULE_MAPPINGS.put(JsonInclusionRule.SKIP_EMPTY, Include.NON_EMPTY);
+        RULE_MAPPINGS.put(JsonInclusionRule.SKIP_NULL, Include.NON_NULL);
+        RULE_MAPPINGS.put(JsonInclusionRule.SKIP_DEFAULT, Include.NON_DEFAULT);
+        RULE_MAPPINGS.put(JsonInclusionRule.SKIP_NONE, Include.ALWAYS);
+    }
+
+    private final Introspector introspector;
+
+    public StandardJacksonObjectMapperConfigurator(final Introspector introspector) {
+        this.introspector = introspector;
+    }
+
+    @Override
+    public MapperBuilder<?, ?> configure(final MapperBuilder<?, ?> builder, final FileFormat format, final JsonInclusionRule inclusionRule) {
+        MapperBuilder<?, ?> mb = builder
+                .annotationIntrospector(new HartshornJacksonAnnotationIntrospector(this.introspector))
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+                .enable(Feature.ALLOW_COMMENTS)
+                .enable(Feature.ALLOW_YAML_COMMENTS)
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .defaultSetterInfo(Value.forContentNulls(Nulls.AS_EMPTY))
+                // Hartshorn convention uses fluent style getters/setters, these are not picked up by Jackson
+                // which would otherwise cause it to fail due to it recognizing the object as an empty bean,
+                // even if it is not empty.
+                .visibility(PropertyAccessor.FIELD, Visibility.ANY);
+        if (inclusionRule != null) {
+            assert RULE_MAPPINGS.containsKey(inclusionRule) : "Unknown inclusion rule " + inclusionRule;
+            mb = mb.serializationInclusion(RULE_MAPPINGS.get(inclusionRule));
+        }
+        return mb;
+    }
+}

--- a/hartshorn-config/hartshorn-config-jackson/src/main/java/org/dockbox/hartshorn/config/jackson/introspect/HartshornJacksonAnnotationIntrospector.java
+++ b/hartshorn-config/hartshorn-config-jackson/src/main/java/org/dockbox/hartshorn/config/jackson/introspect/HartshornJacksonAnnotationIntrospector.java
@@ -45,9 +45,9 @@ public class HartshornJacksonAnnotationIntrospector extends JacksonAnnotationInt
     }
 
     @Override
-    public JavaType refineSerializationType(final MapperConfig<?> config, final Annotated a, final JavaType baseType) throws JsonMappingException {
-        if (a.hasAnnotation(Property.class)) {
-            final Property property = a.getAnnotation(Property.class);
+    public JavaType refineSerializationType(final MapperConfig<?> config, final Annotated annotated, final JavaType baseType) throws JsonMappingException {
+        if (annotated.hasAnnotation(Property.class)) {
+            final Property property = annotated.getAnnotation(Property.class);
             final TypeFactory typeFactory = config.getTypeFactory();
             JavaType type = baseType;
 
@@ -82,7 +82,7 @@ public class HartshornJacksonAnnotationIntrospector extends JacksonAnnotationInt
 
             return type;
         }
-        return super.refineSerializationType(config, a, baseType);
+        return super.refineSerializationType(config, annotated, baseType);
     }
 
     private JavaType refineAssignableType(final TypeFactory typeFactory, final JavaType javaType, final Class<?> type) throws JacksonIntrospectionException {
@@ -93,9 +93,9 @@ public class HartshornJacksonAnnotationIntrospector extends JacksonAnnotationInt
     }
 
     @Override
-    public JavaType refineDeserializationType(final MapperConfig<?> config, final Annotated a, final JavaType baseType) throws JsonMappingException {
-        if (a.hasAnnotation(Property.class)) {
-            final Property property = a.getAnnotation(Property.class);
+    public JavaType refineDeserializationType(final MapperConfig<?> config, final Annotated annotated, final JavaType baseType) throws JsonMappingException {
+        if (annotated.hasAnnotation(Property.class)) {
+            final Property property = annotated.getAnnotation(Property.class);
             final TypeFactory typeFactory = config.getTypeFactory();
             JavaType type = baseType;
 
@@ -129,29 +129,29 @@ public class HartshornJacksonAnnotationIntrospector extends JacksonAnnotationInt
 
             return type;
         }
-        return super.refineDeserializationType(config, a, baseType);
+        return super.refineDeserializationType(config, annotated, baseType);
     }
 
     @Override
-    public PropertyName findNameForSerialization(final Annotated a) {
-        return this.findName(a, super::findNameForSerialization);
+    public PropertyName findNameForSerialization(final Annotated annotated) {
+        return this.findName(annotated, super::findNameForSerialization);
     }
 
     @Override
-    public PropertyName findNameForDeserialization(final Annotated a) {
-        return this.findName(a, super::findNameForDeserialization);
+    public PropertyName findNameForDeserialization(final Annotated annotated) {
+        return this.findName(annotated, super::findNameForDeserialization);
     }
 
-    private PropertyName findName(final Annotated a, final Function<Annotated, PropertyName> defaultValue) {
-        final AnnotatedElement annotated = a.getAnnotated();
-        if (annotated != null) {
-            final ElementAnnotationsIntrospector introspector = this.introspector.introspect(annotated);
+    private PropertyName findName(final Annotated annotated, final Function<Annotated, PropertyName> defaultValue) {
+        final AnnotatedElement element = annotated.getAnnotated();
+        if (element != null) {
+            final ElementAnnotationsIntrospector introspector = this.introspector.introspect(element);
             final Option<Property> annotation = introspector.get(Property.class);
             if (annotation.present()) {
                 return new PropertyName(annotation.get().name());
             }
         }
-        return defaultValue.apply(a);
+        return defaultValue.apply(annotated);
     }
 
     @Override

--- a/hartshorn-config/hartshorn-config.gradle.kts
+++ b/hartshorn-config/hartshorn-config.gradle.kts
@@ -19,10 +19,7 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
+    api("org.dockbox.hartshorn:hartshorn-core")
 
     testImplementation("org.dockbox.hartshorn:hartshorn-introspect-reflection")
     testImplementation("org.dockbox.hartshorn:hartshorn-proxy-javassist")

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServicePreProcessor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServicePreProcessor.java
@@ -20,6 +20,7 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
+import org.dockbox.hartshorn.component.processing.ProcessingOrder;
 import org.dockbox.hartshorn.config.annotations.Configuration;
 import org.dockbox.hartshorn.config.properties.PropertyHolder;
 import org.dockbox.hartshorn.util.option.Option;
@@ -70,7 +71,7 @@ public class ConfigurationServicePreProcessor extends ComponentPreProcessor {
             return false;
         }
 
-        final ResourceLookup resourceLookup = new FallbackResourceLookup(context, new FileSystemLookupStrategy());;
+        final ResourceLookup resourceLookup = new FallbackResourceLookup(context, new FileSystemLookupStrategy());
         final Set<URI> config = resourceLookup.lookup(source);
 
         if (config.isEmpty()) {
@@ -93,6 +94,6 @@ public class ConfigurationServicePreProcessor extends ComponentPreProcessor {
     @Override
     public Integer order() {
         // Run before the ProviderServicePreProcessor, so this context is available for configuration objects
-        return (Integer.MIN_VALUE / 2) - 256;
+        return (Integer.MIN_VALUE / 2) - ProcessingOrder.LAST;
     }
 }

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/DeserializerMethodInterceptor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/DeserializerMethodInterceptor.java
@@ -1,0 +1,36 @@
+package org.dockbox.hartshorn.config;
+
+import org.dockbox.hartshorn.proxy.MethodInterceptor;
+import org.dockbox.hartshorn.proxy.MethodInterceptorContext;
+import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.option.Option;
+
+import java.io.InputStream;
+
+public class DeserializerMethodInterceptor<T, R> implements MethodInterceptor<T, R> {
+    private final SerializationSourceConverter converter;
+    private final MethodView<T, R> method;
+    private final ObjectMapper mapper;
+    private final TypeView<R> returnType;
+    private final ConversionService conversionService;
+
+    public DeserializerMethodInterceptor(final SerializationSourceConverter converter, final MethodView<T, R> method,
+                                         final ObjectMapper mapper, final TypeView<R> returnType,
+                                         final ConversionService conversionService) {
+        this.converter = converter;
+        this.method = method;
+        this.mapper = mapper;
+        this.returnType = returnType;
+        this.conversionService = conversionService;
+    }
+
+    @Override
+    public R intercept(final MethodInterceptorContext<T, R> interceptorContext) throws Throwable {
+        try (final InputStream inputStream = this.converter.inputStream(this.method, interceptorContext.args())) {
+            final Option<?> result = this.mapper.read(inputStream, this.returnType.type());
+            return this.conversionService.convert(result, this.returnType.type());
+        }
+    }
+}

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/DeserializerMethodInterceptor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/DeserializerMethodInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.config;
 
 import org.dockbox.hartshorn.proxy.MethodInterceptor;

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/DeserializerMethodPostProcessor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/DeserializerMethodPostProcessor.java
@@ -18,15 +18,12 @@ package org.dockbox.hartshorn.config;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
+import org.dockbox.hartshorn.component.processing.proxy.MethodProxyContext;
 import org.dockbox.hartshorn.config.annotations.Deserialize;
 import org.dockbox.hartshorn.proxy.MethodInterceptor;
-import org.dockbox.hartshorn.component.processing.proxy.MethodProxyContext;
 import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
-import org.dockbox.hartshorn.util.option.Option;
-
-import java.io.InputStream;
 
 public class DeserializerMethodPostProcessor extends AbstractSerializerPostProcessor<Deserialize> {
 
@@ -45,12 +42,6 @@ public class DeserializerMethodPostProcessor extends AbstractSerializerPostProce
         final TypeView<R> returnType = method.genericReturnType();
         final ConversionService conversionService = context.get(ConversionService.class);
 
-        return interceptorContext -> {
-            try (final InputStream inputStream = converter.inputStream(method, interceptorContext.args())) {
-                final Option<?> result = mapper.read(inputStream, returnType.type());
-                final Object serializationResult = this.wrapSerializationResult(method, result);
-                return conversionService.convert(serializationResult, returnType.type());
-            }
-        };
+        return new DeserializerMethodInterceptor<>(converter, method, mapper, returnType, conversionService);
     }
 }

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/FileFormats.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/FileFormats.java
@@ -37,10 +37,12 @@ public enum FileFormats implements FileFormat {
         this.aliases = aliases;
     }
 
+    @Override
     public String extension() {
         return this.extension;
     }
 
+    @Override
     public DataStorageType type() {
         return this.type;
     }

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ObjectMapper.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ObjectMapper.java
@@ -41,7 +41,7 @@ public interface ObjectMapper {
     default <T> Attempt<T, ObjectMappingException> read(final URI uri, final Class<T> type) {
         return (Attempt<T, ObjectMappingException>) Attempt.of(() -> this.read(uri.toURL(), type), IOException.class)
                 .mapError(ObjectMappingException::new)
-                .flatMap(o -> o);
+                .flatMap(object -> object);
     }
 
     <T> Attempt<T, ObjectMappingException> read(String content, GenericType<T> type);
@@ -55,7 +55,7 @@ public interface ObjectMapper {
     default <T> Attempt<T, ObjectMappingException> read(final URI uri, final GenericType<T> type) {
         return (Attempt<T, ObjectMappingException>) Attempt.of(() -> this.read(uri.toURL(), type), IOException.class)
                 .mapError(ObjectMappingException::new)
-                .flatMap(o -> o);
+                .flatMap(object -> object);
     }
 
     <T> Attempt<T, ObjectMappingException> update(T object, String content, Class<T> type);
@@ -69,7 +69,7 @@ public interface ObjectMapper {
     default <T> Attempt<T, ObjectMappingException> update(final T object, final URI uri, final Class<T> type) {
         return (Attempt<T, ObjectMappingException>) Attempt.of(() -> this.update(object, uri.toURL(), type), IOException.class)
                 .mapError(ObjectMappingException::new)
-                .flatMap(o -> o);
+                .flatMap(updatedObject -> updatedObject);
     }
 
     Map<String, Object> flat(String content);

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/SerializerMethodInterceptor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/SerializerMethodInterceptor.java
@@ -1,0 +1,41 @@
+package org.dockbox.hartshorn.config;
+
+import org.dockbox.hartshorn.proxy.MethodInterceptor;
+import org.dockbox.hartshorn.proxy.MethodInterceptorContext;
+import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.option.Option;
+
+import java.io.OutputStream;
+
+public class SerializerMethodInterceptor<T, R> implements MethodInterceptor<T, R> {
+    private final SerializationSourceConverter converter;
+    private final MethodView<T, R> method;
+    private final boolean returnsStringOrWrapper;
+    private final ObjectMapper mapper;
+    private final ConversionService conversionService;
+
+    public SerializerMethodInterceptor(final SerializationSourceConverter converter, final MethodView<T, R> method,
+                                       final boolean returnsStringOrWrapper, final ObjectMapper mapper,
+                                       final ConversionService conversionService) {
+        this.converter = converter;
+        this.method = method;
+        this.returnsStringOrWrapper = returnsStringOrWrapper;
+        this.mapper = mapper;
+        this.conversionService = conversionService;
+    }
+
+    @Override
+    public R intercept(final MethodInterceptorContext<T, R> interceptorContext) throws Throwable {
+        final Object[] arguments = interceptorContext.args();
+
+        try (final OutputStream outputStream = this.converter.outputStream(this.method, arguments)) {
+            final Option<?> result;
+
+            if (outputStream == null && this.returnsStringOrWrapper) result = this.mapper.write(arguments[0]);
+            else result = this.mapper.write(outputStream, arguments[0]);
+
+            return this.conversionService.convert(result, this.method.returnType().type());
+        }
+    }
+}

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/SerializerMethodInterceptor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/SerializerMethodInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.config;
 
 import org.dockbox.hartshorn.proxy.MethodInterceptor;

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/SerializerMethodPostProcessor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/SerializerMethodPostProcessor.java
@@ -24,9 +24,6 @@ import org.dockbox.hartshorn.component.processing.proxy.MethodProxyContext;
 import org.dockbox.hartshorn.util.introspect.TypeParametersIntrospector;
 import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.dockbox.hartshorn.util.option.Option;
-
-import java.io.OutputStream;
 
 public class SerializerMethodPostProcessor extends AbstractSerializerPostProcessor<Serialize> {
 
@@ -45,19 +42,7 @@ public class SerializerMethodPostProcessor extends AbstractSerializerPostProcess
         final boolean returnsStringOrWrapper = this.returnsStringOrWrapper(method);
         final ConversionService conversionService = context.get(ConversionService.class);
 
-        return interceptorContext -> {
-            final Object[] arguments = interceptorContext.args();
-
-            try (final OutputStream outputStream = converter.outputStream(method, arguments)) {
-                final Option<?> result;
-
-                if (outputStream == null && returnsStringOrWrapper) result = mapper.write(arguments[0]);
-                else result = mapper.write(outputStream, arguments[0]);
-
-                final Object serializationResult = this.wrapSerializationResult(method, result);
-                return conversionService.convert(serializationResult, method.returnType().type());
-            }
-        };
+        return new SerializerMethodInterceptor<>(converter, method, returnsStringOrWrapper, mapper, conversionService);
     }
 
     private boolean returnsStringOrWrapper(final MethodView<?, ?> method) {

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/properties/StandardPropertyHolder.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/properties/StandardPropertyHolder.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.function.Function;
 
@@ -152,15 +153,20 @@ public class StandardPropertyHolder implements PropertyHolder {
     }
 
     protected void patchConfigurationMap(final Map<String, Object> origin, final Map<String, Object> patch) {
-        for (final String key : patch.keySet()) {
-            final Object patchValue = patch.get(key);
+        for (final Entry<String, Object> entry : patch.entrySet()) {
+            final String key = entry.getKey();
+            final Object patchValue = entry.getValue();
             if (origin.containsKey(key)) {
                 final Object originValue = origin.get(key);
-                if (originValue instanceof Map && patchValue instanceof Map)
+                if (originValue instanceof Map && patchValue instanceof Map) {
                     this.patchConfigurationMap((Map<String, Object>) originValue, (Map<String, Object>) patchValue);
-                else if (originValue instanceof Collection<?> && patchValue instanceof Collection<?>)
+                }
+                else if (originValue instanceof List<?> && patchValue instanceof List<?>) {
                     origin.put(key, this.merge((List<Object>) originValue, (List<Object>) patchValue));
-                else origin.put(key, patchValue);
+                }
+                else {
+                    origin.put(key, patchValue);
+                }
             }
             else origin.put(key, patchValue);
         }

--- a/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/EntityElement.java
+++ b/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/EntityElement.java
@@ -32,10 +32,12 @@ public class EntityElement implements Element {
         this.name = name;
     }
 
+    @Override
     public String name() {
         return this.name;
     }
 
+    @Override
     public EntityElement name(final String name) {
         this.name = name;
         return this;

--- a/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/EntityElement.java
+++ b/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/EntityElement.java
@@ -44,11 +44,11 @@ public class EntityElement implements Element {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
-        final EntityElement that = (EntityElement) o;
-        return Objects.equals(this.name, that.name);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (other == null || this.getClass() != other.getClass()) return false;
+        final EntityElement element = (EntityElement) other;
+        return Objects.equals(this.name, element.name);
     }
 
     @Override

--- a/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/MultiElement.java
+++ b/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/MultiElement.java
@@ -53,11 +53,11 @@ public class MultiElement implements Element {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
-        final MultiElement that = (MultiElement) o;
-        return Objects.equals(this.name, that.name) && Objects.equals(this.other, that.other);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (other == null || this.getClass() != other.getClass()) return false;
+        final MultiElement element = (MultiElement) other;
+        return Objects.equals(this.name, element.name) && Objects.equals(this.other, element.other);
     }
 
     @Override

--- a/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/NestedElement.java
+++ b/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/NestedElement.java
@@ -54,11 +54,11 @@ public class NestedElement implements Element {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
-        final NestedElement that = (NestedElement) o;
-        return Objects.equals(this.child, that.child);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (other == null || this.getClass() != other.getClass()) return false;
+        final NestedElement element = (NestedElement) other;
+        return Objects.equals(this.child, element.child);
     }
 
     @Override

--- a/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/PersistentElement.java
+++ b/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/PersistentElement.java
@@ -41,11 +41,11 @@ public class PersistentElement implements Element {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
-        final PersistentElement that = (PersistentElement) o;
-        return Objects.equals(this.name, that.name);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (other == null || this.getClass() != other.getClass()) return false;
+        final PersistentElement element = (PersistentElement) other;
+        return Objects.equals(this.name, element.name);
     }
 
     @Override

--- a/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/PersistentElement.java
+++ b/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/PersistentElement.java
@@ -29,10 +29,12 @@ public class PersistentElement implements Element {
         this.name = name;
     }
 
+    @Override
     public String name() {
         return this.name;
     }
 
+    @Override
     public PersistentElement name(final String name) {
         this.name = name;
         return this;

--- a/hartshorn-core/hartshorn-core.gradle.kts
+++ b/hartshorn-core/hartshorn-core.gradle.kts
@@ -34,14 +34,12 @@ tasks {
 
 dependencies {
     api(libs.bundles.jakarta)
-    api(libs.javassist)
-    api(libs.cglib)
+    api("org.dockbox.hartshorn:hartshorn-introspect")
+    api("org.dockbox.hartshorn:hartshorn-util")
+    api("org.dockbox.hartshorn:hartshorn-discovery")
+    api("org.dockbox.hartshorn:hartshorn-proxy")
 
     implementation(libs.logback)
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-discovery")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
 
     testImplementation(libs.scala)
     testImplementation(libs.groovy)

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationBuilder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationBuilder.java
@@ -29,6 +29,7 @@ import org.dockbox.hartshorn.component.condition.ConditionMatcher;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 import org.dockbox.hartshorn.component.processing.ServiceActivator;
+import org.dockbox.hartshorn.introspect.ViewContextAdapter;
 import org.dockbox.hartshorn.logging.ApplicationLogger;
 import org.dockbox.hartshorn.proxy.ApplicationProxier;
 import org.dockbox.hartshorn.reporting.Reportable;
@@ -282,6 +283,17 @@ public interface ApplicationBuilder<Self extends ApplicationBuilder<Self, C>, C 
     Self componentPopulator(Initializer<ComponentPopulator> componentPopulator);
 
     ComponentPopulator componentPopulator(final InitializingContext context);
+
+    /**
+     * Sets the {@link ViewContextAdapter} to use. The view context adapter is responsible for adapting various
+     * {@link org.dockbox.hartshorn.util.introspect.view.View} implementations to the application context.
+     *
+     * @param viewContextAdapter The view context adapter to use.
+     * @return The {@link ApplicationBuilder} instance.
+     */
+    Self viewContextAdapter(Initializer<ViewContextAdapter> viewContextAdapter);
+
+    ViewContextAdapter viewContextAdapter(final InitializingContext context);
 
     /**
      * Registers a custom {@link ComponentPostProcessor}. Unlike automatically activated {@link ComponentPostProcessor}s,

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationContextShutdownHook.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationContextShutdownHook.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.application;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationContextShutdownHook.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationContextShutdownHook.java
@@ -1,0 +1,27 @@
+package org.dockbox.hartshorn.application;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.slf4j.Logger;
+
+public class ApplicationContextShutdownHook implements Runnable {
+    private final Logger logger;
+    private final ApplicationContext applicationContext;
+
+    public ApplicationContextShutdownHook(final Logger logger, final ApplicationContext applicationContext) {
+        this.logger = logger;
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void run() {
+        try {
+            if (!this.applicationContext.isClosed()) {
+                this.applicationContext.close();
+            }
+        }
+        catch (final ApplicationException e) {
+            this.logger.error("Failed to close application context", e);
+        }
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ContextBinderConfiguration.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ContextBinderConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.application;
 
 import org.dockbox.hartshorn.context.Context;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ContextBinderConfiguration.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ContextBinderConfiguration.java
@@ -1,0 +1,9 @@
+package org.dockbox.hartshorn.application;
+
+import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.inject.binding.Binder;
+
+public interface ContextBinderConfiguration<C extends Context> {
+
+    void configureBindings(C context, Binder binder);
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/DefaultApplicationBuilder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/DefaultApplicationBuilder.java
@@ -38,6 +38,8 @@ import org.dockbox.hartshorn.component.condition.ConditionMatcher;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 import org.dockbox.hartshorn.discovery.DiscoveryService;
+import org.dockbox.hartshorn.introspect.IntrospectionViewContextAdapter;
+import org.dockbox.hartshorn.introspect.ViewContextAdapter;
 import org.dockbox.hartshorn.logging.ApplicationLogger;
 import org.dockbox.hartshorn.logging.logback.LogbackApplicationLogger;
 import org.dockbox.hartshorn.proxy.ApplicationProxier;
@@ -113,6 +115,7 @@ public abstract class DefaultApplicationBuilder<Self extends DefaultApplicationB
     private final ComponentInitializer<ClasspathResourceLocator> resourceLocator = ComponentInitializer.of(ctx -> new ClassLoaderClasspathResourceLocator(ctx.environment()));
     private final ComponentInitializer<ComponentProvider> componentProvider = ComponentInitializer.of(ScopeAwareComponentProvider::new);
     private final ComponentInitializer<ComponentPopulator> componentPopulator = ComponentInitializer.of(ctx -> new ContextualComponentPopulator(ctx.applicationContext()));
+    private final ComponentInitializer<ViewContextAdapter> viewContextAdapter = ComponentInitializer.of(ctx -> new IntrospectionViewContextAdapter(ctx.applicationContext()));
     private final ComponentInitializer<ConditionMatcher> conditionMatcher = ComponentInitializer.of(ctx -> new ConditionMatcher(ctx.applicationContext()));
     private final ComponentInitializer<AnnotationLookup> annotationLookup = ComponentInitializer.of(ctx -> new VirtualHierarchyAnnotationLookup());
 
@@ -394,6 +397,17 @@ public abstract class DefaultApplicationBuilder<Self extends DefaultApplicationB
     @Override
     public ComponentPopulator componentPopulator(final InitializingContext context) {
         return this.componentPopulator.initialize(context);
+    }
+
+    @Override
+    public Self viewContextAdapter(Initializer<ViewContextAdapter> viewContextAdapter) {
+        this.viewContextAdapter.initializer(viewContextAdapter);
+        return this.self();
+    }
+
+    @Override
+    public ViewContextAdapter viewContextAdapter(InitializingContext context) {
+        return this.viewContextAdapter.initialize(context);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/DefaultApplicationBuilder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/DefaultApplicationBuilder.java
@@ -86,35 +86,35 @@ public abstract class DefaultApplicationBuilder<Self extends DefaultApplicationB
         }
     }
 
-    protected Class<?> mainClass;
-    protected boolean includeBasePackages = true;
-    protected boolean enableBanner = true;
+    private Class<?> mainClass;
+    private boolean includeBasePackages = true;
+    private boolean enableBanner = true;
     private boolean enableBatchMode = false;
 
-    protected final Set<Annotation> serviceActivators = ConcurrentHashMap.newKeySet();
-    protected final Set<String> arguments = ConcurrentHashMap.newKeySet();
-    protected final Set<String> prefixes = ConcurrentHashMap.newKeySet();
-    protected final Set<ComponentPostProcessor> componentPostProcessors = ConcurrentHashMap.newKeySet();
-    protected final Set<ComponentPreProcessor> componentPreProcessors = ConcurrentHashMap.newKeySet();
-    protected final Set<Class<?>> standaloneComponents = ConcurrentHashMap.newKeySet();
+    private final Set<Annotation> serviceActivators = ConcurrentHashMap.newKeySet();
+    private final Set<String> arguments = ConcurrentHashMap.newKeySet();
+    private final Set<String> prefixes = ConcurrentHashMap.newKeySet();
+    private final Set<ComponentPostProcessor> componentPostProcessors = ConcurrentHashMap.newKeySet();
+    private final Set<ComponentPreProcessor> componentPreProcessors = ConcurrentHashMap.newKeySet();
+    private final Set<Class<?>> standaloneComponents = ConcurrentHashMap.newKeySet();
 
-    protected ComponentInitializer<ApplicationConfigurator> applicationConfigurator = ComponentInitializer.of(ctx -> new EnvironmentDrivenApplicationConfigurator());
-    protected ComponentInitializer<ApplicationProxier> applicationProxier = ComponentInitializer.of(ctx -> {
+    private final ComponentInitializer<ApplicationConfigurator> applicationConfigurator = ComponentInitializer.of(ctx -> new EnvironmentDrivenApplicationConfigurator());
+    private final ComponentInitializer<ApplicationProxier> applicationProxier = ComponentInitializer.of(ctx -> {
         ApplicationProxierLoader loader = DiscoveryService.instance().discover(ApplicationProxierLoader.class);
         return loader.create(ctx.environment());
     });
-    protected ComponentInitializer<ApplicationFSProvider> applicationFSProvider = ComponentInitializer.of(ctx -> new ApplicationFSProviderImpl());
-    protected ComponentInitializer<ExceptionHandler> exceptionHandler = ComponentInitializer.of(ctx -> new LoggingExceptionHandler());
-    protected ComponentInitializer<ApplicationArgumentParser> argumentParser = ComponentInitializer.of(ctx -> new StandardApplicationArgumentParser());
-    protected ComponentInitializer<ApplicationLogger> applicationLogger = ComponentInitializer.of(ctx -> new LogbackApplicationLogger());
-    protected ComponentInitializer<ApplicationEnvironment> applicationEnvironment = ComponentInitializer.of(ContextualApplicationEnvironment::new);
-    protected ComponentInitializer<ComponentLocator> componentLocator = ComponentInitializer.of(ctx -> new TypeReferenceLookupComponentLocator(ctx.applicationContext()));
-    protected ComponentInitializer<ComponentPostConstructor> componentPostConstructor = ComponentInitializer.of(ComponentPostConstructorImpl::new);
-    protected ComponentInitializer<ClasspathResourceLocator> resourceLocator = ComponentInitializer.of(ctx -> new ClassLoaderClasspathResourceLocator(ctx.environment()));
-    protected ComponentInitializer<ComponentProvider> componentProvider = ComponentInitializer.of(ScopeAwareComponentProvider::new);
-    protected ComponentInitializer<ComponentPopulator> componentPopulator = ComponentInitializer.of(ctx -> new ContextualComponentPopulator(ctx.applicationContext()));
-    protected ComponentInitializer<ConditionMatcher> conditionMatcher = ComponentInitializer.of(ctx -> new ConditionMatcher(ctx.applicationContext()));
-    protected ComponentInitializer<AnnotationLookup> annotationLookup = ComponentInitializer.of(ctx -> new VirtualHierarchyAnnotationLookup());
+    private final ComponentInitializer<ApplicationFSProvider> applicationFSProvider = ComponentInitializer.of(ctx -> new ApplicationFSProviderImpl());
+    private final ComponentInitializer<ExceptionHandler> exceptionHandler = ComponentInitializer.of(ctx -> new LoggingExceptionHandler());
+    private final ComponentInitializer<ApplicationArgumentParser> argumentParser = ComponentInitializer.of(ctx -> new StandardApplicationArgumentParser());
+    private final ComponentInitializer<ApplicationLogger> applicationLogger = ComponentInitializer.of(ctx -> new LogbackApplicationLogger());
+    private final ComponentInitializer<ApplicationEnvironment> applicationEnvironment = ComponentInitializer.of(ContextualApplicationEnvironment::new);
+    private final ComponentInitializer<ComponentLocator> componentLocator = ComponentInitializer.of(ctx -> new TypeReferenceLookupComponentLocator(ctx.applicationContext()));
+    private final ComponentInitializer<ComponentPostConstructor> componentPostConstructor = ComponentInitializer.of(ComponentPostConstructorImpl::new);
+    private final ComponentInitializer<ClasspathResourceLocator> resourceLocator = ComponentInitializer.of(ctx -> new ClassLoaderClasspathResourceLocator(ctx.environment()));
+    private final ComponentInitializer<ComponentProvider> componentProvider = ComponentInitializer.of(ScopeAwareComponentProvider::new);
+    private final ComponentInitializer<ComponentPopulator> componentPopulator = ComponentInitializer.of(ctx -> new ContextualComponentPopulator(ctx.applicationContext()));
+    private final ComponentInitializer<ConditionMatcher> conditionMatcher = ComponentInitializer.of(ctx -> new ConditionMatcher(ctx.applicationContext()));
+    private final ComponentInitializer<AnnotationLookup> annotationLookup = ComponentInitializer.of(ctx -> new VirtualHierarchyAnnotationLookup());
 
     @Override
     public Self mainClass(final Class<?> mainClass) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ExceptionHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ExceptionHandler.java
@@ -55,13 +55,13 @@ public interface ExceptionHandler {
      * the link below for more details. The return result is only used to mimic a return value when it is needed, as the
      * {@code throws} cause is not enough to make the compiler know that the method will throw an exception.
      *
-     * @param t The exception to throw.
+     * @param throwable The exception to throw.
      * @param <T> The type of the exception.
      * @throws T The exception to throw.
      * @see <a href="https://blog.jooq.org/throw-checked-exceptions-like-runtime-exceptions-in-java/">Throw checked exceptions like runtime exceptions in Java</a>
      */
     @Deprecated
-    static <T extends Throwable, R> R unchecked(final Throwable t) throws T {
-        throw (T) t;
+    static <T extends Throwable, R> R unchecked(final Throwable throwable) throws T {
+        throw (T) throwable;
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/InitializingContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/InitializingContext.java
@@ -21,25 +21,18 @@ import org.dockbox.hartshorn.application.environment.ApplicationArgumentParser;
 import org.dockbox.hartshorn.application.environment.ApplicationEnvironment;
 import org.dockbox.hartshorn.application.environment.ApplicationFSProvider;
 import org.dockbox.hartshorn.application.environment.ClasspathResourceLocator;
-import org.dockbox.hartshorn.application.lifecycle.LifecycleObservable;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.ComponentPopulator;
 import org.dockbox.hartshorn.component.ComponentPostConstructor;
 import org.dockbox.hartshorn.component.ComponentProvider;
-import org.dockbox.hartshorn.component.PostProcessingComponentProvider;
 import org.dockbox.hartshorn.component.condition.ConditionMatcher;
 import org.dockbox.hartshorn.context.DefaultApplicationAwareContext;
-import org.dockbox.hartshorn.inject.binding.Binder;
-import org.dockbox.hartshorn.introspect.IntrospectionViewContextAdapter;
 import org.dockbox.hartshorn.introspect.ViewContextAdapter;
 import org.dockbox.hartshorn.logging.ApplicationLogger;
 import org.dockbox.hartshorn.proxy.ApplicationProxier;
-import org.dockbox.hartshorn.util.introspect.ProxyLookup;
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
 import org.dockbox.hartshorn.reporting.Reportable;
-import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.annotations.AnnotationLookup;
-import org.slf4j.Logger;
 
 import java.util.Objects;
 
@@ -124,44 +117,12 @@ public final class InitializingContext extends DefaultApplicationAwareContext im
         return this.configuration.componentPopulator(this);
     }
 
-    public ApplicationBuilder<?, ?> builder() {
-        return this.configuration;
+    public ViewContextAdapter viewContextAdapter() {
+        return this.configuration.viewContextAdapter(this);
     }
 
-    public void applyTo(final Binder binder) {
-        // Application context
-        binder.bind(ComponentProvider.class).singleton(this.applicationContext());
-        binder.bind(ExceptionHandler.class).singleton(this.applicationContext());
-        binder.bind(ApplicationContext.class).singleton(this.applicationContext());
-        binder.bind(ApplicationPropertyHolder.class).singleton(this.applicationContext());
-
-        // TODO: Make configurable
-        binder.bind(ViewContextAdapter.class).singleton(new IntrospectionViewContextAdapter(this.applicationContext()));
-
-        // Application environment
-        binder.bind(Introspector.class).singleton(this.environment());
-        binder.bind(ApplicationEnvironment.class).singleton(this.environment());
-        binder.bind(ProxyLookup.class).singleton(this.environment());
-        binder.bind(ApplicationLogger.class).singleton(this.environment());
-        binder.bind(ApplicationProxier.class).singleton(this.environment());
-        binder.bind(LifecycleObservable.class).singleton(this.environment());
-        binder.bind(ApplicationFSProvider.class).singleton(this.environment());
-
-        // Standalone components - alphabetical order
-        binder.bind(AnnotationLookup.class).singleton(this.annotationLookup());
-        binder.bind(ComponentLocator.class).singleton(this.componentLocator());
-        binder.bind(ComponentPopulator.class).singleton(this.componentPopulator());
-        binder.bind(ComponentPostConstructor.class).singleton(this.componentPostConstructor());
-        binder.bind(ComponentProvider.class).singleton(this.componentProvider());
-        binder.bind(ConditionMatcher.class).singleton(this.conditionMatcher());
-        binder.bind(ClasspathResourceLocator.class).singleton(this.resourceLocator());
-
-        // Standalone components - special behavior
-        if (this.componentProvider() instanceof PostProcessingComponentProvider provider)
-            binder.bind(PostProcessingComponentProvider.class).singleton(provider);
-
-        // Dynamic components
-        binder.bind(Logger.class).to(this.applicationContext()::log);
+    public ApplicationBuilder<?, ?> builder() {
+        return this.configuration;
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/InitializingContextBinderConfiguration.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/InitializingContextBinderConfiguration.java
@@ -1,0 +1,59 @@
+package org.dockbox.hartshorn.application;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.application.environment.ApplicationEnvironment;
+import org.dockbox.hartshorn.application.environment.ApplicationFSProvider;
+import org.dockbox.hartshorn.application.environment.ClasspathResourceLocator;
+import org.dockbox.hartshorn.application.lifecycle.LifecycleObservable;
+import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentPopulator;
+import org.dockbox.hartshorn.component.ComponentPostConstructor;
+import org.dockbox.hartshorn.component.ComponentProvider;
+import org.dockbox.hartshorn.component.PostProcessingComponentProvider;
+import org.dockbox.hartshorn.component.condition.ConditionMatcher;
+import org.dockbox.hartshorn.inject.binding.Binder;
+import org.dockbox.hartshorn.introspect.ViewContextAdapter;
+import org.dockbox.hartshorn.logging.ApplicationLogger;
+import org.dockbox.hartshorn.proxy.ApplicationProxier;
+import org.dockbox.hartshorn.util.introspect.Introspector;
+import org.dockbox.hartshorn.util.introspect.ProxyLookup;
+import org.dockbox.hartshorn.util.introspect.annotations.AnnotationLookup;
+import org.slf4j.Logger;
+
+public class InitializingContextBinderConfiguration implements ContextBinderConfiguration<InitializingContext> {
+
+    @Override
+    public void configureBindings(final InitializingContext context, final Binder binder) {
+        // Application context
+        binder.bind(ComponentProvider.class).singleton(context.applicationContext());
+        binder.bind(ExceptionHandler.class).singleton(context.applicationContext());
+        binder.bind(ApplicationContext.class).singleton(context.applicationContext());
+        binder.bind(ApplicationPropertyHolder.class).singleton(context.applicationContext());
+
+        // Application environment
+        binder.bind(Introspector.class).singleton(context.environment());
+        binder.bind(ApplicationEnvironment.class).singleton(context.environment());
+        binder.bind(ProxyLookup.class).singleton(context.environment());
+        binder.bind(ApplicationLogger.class).singleton(context.environment());
+        binder.bind(ApplicationProxier.class).singleton(context.environment());
+        binder.bind(LifecycleObservable.class).singleton(context.environment());
+        binder.bind(ApplicationFSProvider.class).singleton(context.environment());
+
+        // Standalone components - alphabetical order
+        binder.bind(AnnotationLookup.class).singleton(context.annotationLookup());
+        binder.bind(ComponentLocator.class).singleton(context.componentLocator());
+        binder.bind(ComponentPopulator.class).singleton(context.componentPopulator());
+        binder.bind(ComponentPostConstructor.class).singleton(context.componentPostConstructor());
+        binder.bind(ComponentProvider.class).singleton(context.componentProvider());
+        binder.bind(ConditionMatcher.class).singleton(context.conditionMatcher());
+        binder.bind(ClasspathResourceLocator.class).singleton(context.resourceLocator());
+        binder.bind(ViewContextAdapter.class).singleton(context.viewContextAdapter());
+
+        // Standalone components - special behavior
+        if (context.componentProvider() instanceof PostProcessingComponentProvider provider)
+            binder.bind(PostProcessingComponentProvider.class).singleton(provider);
+
+        // Dynamic components
+        binder.bind(Logger.class).to(context.applicationContext()::log);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/InitializingContextBinderConfiguration.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/InitializingContextBinderConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.application;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/LoggingExceptionHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/LoggingExceptionHandler.java
@@ -35,6 +35,7 @@ public class LoggingExceptionHandler implements ExceptionHandler, ApplicationMan
     private boolean stacktraces;
     private ApplicationEnvironment environment;
 
+    @Override
     public LoggingExceptionHandler stacktraces(final boolean stacktraces) {
         this.stacktraces = stacktraces;
         this.findLogger().debug("{} stacktraces for all reported errors", stacktraces ? "Enabled" : "Disabled");
@@ -45,6 +46,7 @@ public class LoggingExceptionHandler implements ExceptionHandler, ApplicationMan
         return this.stacktraces;
     }
 
+    @Override
     public ApplicationEnvironment environment() {
         return this.environment;
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ServiceActivatorContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ServiceActivatorContext.java
@@ -69,7 +69,7 @@ public class ServiceActivatorContext extends DefaultProvisionContext implements 
     @Override
     public void report(final DiagnosticsPropertyCollector collector) {
         final String[] activators = this.activators().stream()
-                .map(a -> a.annotationType().getCanonicalName())
+                .map(activator -> activator.annotationType().getCanonicalName())
                 .toArray(String[]::new);
         collector.property("activators").write(activators);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationContextConstructor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationContextConstructor.java
@@ -22,20 +22,19 @@ import org.dockbox.hartshorn.application.context.ProcessableApplicationContext;
 import org.dockbox.hartshorn.application.environment.ApplicationEnvironment;
 import org.dockbox.hartshorn.application.lifecycle.LifecycleObserver;
 import org.dockbox.hartshorn.application.lifecycle.ObservableApplicationEnvironment;
-import org.dockbox.hartshorn.util.introspect.scan.PredefinedSetTypeReferenceCollector;
-import org.dockbox.hartshorn.util.introspect.scan.TypeReferenceCollectorContext;
-import org.dockbox.hartshorn.util.introspect.scan.classpath.ClassPathScannerTypeReferenceCollector;
 import org.dockbox.hartshorn.component.ComponentContainer;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.ComponentType;
 import org.dockbox.hartshorn.component.processing.ComponentProcessor;
 import org.dockbox.hartshorn.component.processing.ServiceActivator;
+import org.dockbox.hartshorn.util.introspect.scan.PredefinedSetTypeReferenceCollector;
+import org.dockbox.hartshorn.util.introspect.scan.TypeReferenceCollectorContext;
+import org.dockbox.hartshorn.util.introspect.scan.classpath.ClassPathScannerTypeReferenceCollector;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -64,15 +63,8 @@ public class StandardApplicationContextConstructor implements ApplicationContext
 
     protected void registerHooks(final ApplicationContext applicationContext) {
         this.logger.debug("Registering shutdown hook for application context");
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            try {
-                if (!applicationContext.isClosed()) {
-                    applicationContext.close();
-                }
-            } catch (final Exception e) {
-                this.logger.error("Failed to close application context", e);
-            }
-        }, "ShutdownHook"));
+        final ApplicationContextShutdownHook shutdownHook = new ApplicationContextShutdownHook(this.logger, applicationContext);
+        Runtime.getRuntime().addShutdownHook(new Thread(shutdownHook, "ShutdownHook"));
     }
 
     protected ApplicationEnvironment createEnvironment(final InitializingContext context) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationContextConstructor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationContextConstructor.java
@@ -187,7 +187,7 @@ public class StandardApplicationContextConstructor implements ApplicationContext
         }
 
         prefixes.stream()
-                .map(prefix -> new ClassPathScannerTypeReferenceCollector(prefix))
+                .map(ClassPathScannerTypeReferenceCollector::new)
                 .forEach(collectorContext::register);
 
         if (!builder.standaloneComponents().isEmpty()) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationBindingFunction.java
@@ -60,8 +60,8 @@ public class DelegatingApplicationBindingFunction<T> implements BindingFunction<
     }
 
     @Override
-    public ApplicationContext singleton(final T t) {
-        this.delegate.singleton(t);
+    public ApplicationContext singleton(final T instance) {
+        this.delegate.singleton(instance);
         return this.applicationContext;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
@@ -39,7 +39,7 @@ import java.util.Properties;
 import java.util.Set;
 
 public abstract class DelegatingApplicationContext extends DefaultApplicationAwareContext implements
-        ApplicationContext, HierarchicalComponentProvider {
+        ApplicationContext {
 
     private final transient Properties environmentValues;
     private final transient ComponentProvider componentProvider;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
@@ -48,7 +48,7 @@ public abstract class DelegatingApplicationContext extends DefaultApplicationAwa
     private boolean isClosed = false;
     protected boolean isRunning = false;
 
-    public DelegatingApplicationContext(InitializingContext context) {
+    protected DelegatingApplicationContext(InitializingContext context) {
         super(null);
         context = new InitializingContext(context.environment(), this, context.builder());
         this.add(context);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
@@ -94,13 +94,13 @@ public abstract class DelegatingApplicationContext extends DefaultApplicationAwa
     @Override
     public <A> Option<A> activator(final Class<A> activator) {
         return this.first(ServiceActivatorContext.class)
-                .map(c -> c.activator(activator));
+                .map(context -> context.activator(activator));
     }
 
     @Override
     public boolean hasActivator(final Class<? extends Annotation> activator) {
         return this.first(ServiceActivatorContext.class)
-                .map(c -> c.hasActivator(activator))
+                .map(context -> context.hasActivator(activator))
                 .orElseGet(() -> false);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
@@ -18,6 +18,7 @@ package org.dockbox.hartshorn.application.context;
 
 import org.dockbox.hartshorn.application.ExceptionHandler;
 import org.dockbox.hartshorn.application.InitializingContext;
+import org.dockbox.hartshorn.application.InitializingContextBinderConfiguration;
 import org.dockbox.hartshorn.application.ServiceActivatorContext;
 import org.dockbox.hartshorn.application.environment.ApplicationEnvironment;
 import org.dockbox.hartshorn.application.lifecycle.LifecycleObserver;
@@ -63,7 +64,8 @@ public abstract class DelegatingApplicationContext extends DefaultApplicationAwa
         this.componentProvider = context.componentProvider();
         this.locator = context.componentLocator();
 
-        context.applyTo(this);
+        final InitializingContextBinderConfiguration configuration = new InitializingContextBinderConfiguration();
+        configuration.configureBindings(context, this);
     }
 
     protected abstract void prepareInitialization();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ApplicationEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ApplicationEnvironment.java
@@ -55,6 +55,7 @@ public interface ApplicationEnvironment extends
      * {@link Introspector}, but is typically the same.
      * @return The primary {@link Introspector}
      */
+    @Override
     Introspector introspector();
 
     /**

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/lifecycle/LifecycleObserverPreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/lifecycle/LifecycleObserverPreProcessor.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.application.lifecycle;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
+import org.dockbox.hartshorn.component.processing.ProcessingOrder;
 
 public class LifecycleObserverPreProcessor extends ComponentPreProcessor {
 
@@ -31,6 +32,6 @@ public class LifecycleObserverPreProcessor extends ComponentPreProcessor {
 
     @Override
     public Integer order() {
-        return (Integer.MIN_VALUE / 2) - 1024;
+        return (Integer.MIN_VALUE / 2) - (ProcessingOrder.LAST * 4);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentContainerImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentContainerImpl.java
@@ -16,11 +16,11 @@
 
 package org.dockbox.hartshorn.component;
 
-import java.util.Objects;
-
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
+
+import java.util.Objects;
 
 public class ComponentContainerImpl implements ComponentContainer {
 
@@ -96,11 +96,11 @@ public class ComponentContainerImpl implements ComponentContainer {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
-        final ComponentContainerImpl that = (ComponentContainerImpl) o;
-        return this.component.equals(that.component);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (other == null || this.getClass() != other.getClass()) return false;
+        final ComponentContainerImpl container = (ComponentContainerImpl) other;
+        return this.component.equals(container.component);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentContainerImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentContainerImpl.java
@@ -16,11 +16,11 @@
 
 package org.dockbox.hartshorn.component;
 
+import java.util.Objects;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.util.Objects;
 
 public class ComponentContainerImpl implements ComponentContainer {
 
@@ -54,14 +54,14 @@ public class ComponentContainerImpl implements ComponentContainer {
     @Override
     public String id() {
         final String id = this.annotation().id();
-        if ("".equals(id)) return ComponentUtilities.id(this.context, this.component, true);
+        if (id != null && id.isEmpty()) return ComponentUtilities.id(this.context, this.component, true);
         return id;
     }
 
     @Override
     public String name() {
         final String name = this.annotation().name();
-        if ("".equals(name)) return ComponentUtilities.name(this.context, this.component, true);
+        if (name != null && name.isEmpty()) return ComponentUtilities.name(this.context, this.component, true);
         return name;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentKey.java
@@ -60,14 +60,14 @@ public record ComponentKey<T>(Class<T> type, String name, Scope scope, boolean e
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
-        final ComponentKey<?> that = (ComponentKey<?>) o;
-        return this.enable == that.enable
-                && this.type.equals(that.type)
-                && Objects.equals(this.name, that.name)
-                && Objects.equals(this.scope, that.scope);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (other == null || this.getClass() != other.getClass()) return false;
+        final ComponentKey<?> otherComponentKey = (ComponentKey<?>) other;
+        return this.enable == otherComponentKey.enable
+                && this.type.equals(otherComponentKey.type)
+                && Objects.equals(this.name, otherComponentKey.name)
+                && Objects.equals(this.scope, otherComponentKey.scope);
     }
 
     @Override
@@ -136,11 +136,11 @@ public record ComponentKey<T>(Class<T> type, String name, Scope scope, boolean e
         }
 
         @Override
-        public boolean equals(final Object o) {
-            if (this == o) return true;
-            if (o == null || this.getClass() != o.getClass()) return false;
-            final ComponentKeyView<?> that = (ComponentKeyView<?>) o;
-            return Objects.equals(this.type, that.type) && Objects.equals(this.name, that.name);
+        public boolean equals(final Object other) {
+            if (this == other) return true;
+            if (other == null || this.getClass() != other.getClass()) return false;
+            final ComponentKeyView<?> otherKeyView = (ComponentKeyView<?>) other;
+            return Objects.equals(this.type, otherKeyView.type) && Objects.equals(this.name, otherKeyView.name);
         }
 
         @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentKey.java
@@ -75,7 +75,7 @@ public record ComponentKey<T>(Class<T> type, String name, Scope scope, boolean e
         return Objects.hash(this.type, this.name, this.scope, this.enable);
     }
 
-    public static class Builder<T> {
+    public static final class Builder<T> {
 
         private Class<T> type;
         private String name;
@@ -125,7 +125,7 @@ public record ComponentKey<T>(Class<T> type, String name, Scope scope, boolean e
         }
     }
 
-    public static class ComponentKeyView<T> {
+    public static final class ComponentKeyView<T> {
 
         private final Class<T> type;
         private final String name;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentUtilities.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentUtilities.java
@@ -40,7 +40,7 @@ public final class ComponentUtilities {
         return format(context, type, ignoreExisting, ' ', ComponentContainer::name);
     }
 
-    protected static String format(final ApplicationContext context, final Class<?> type, final boolean ignoreExisting, final char delimiter, final Function<ComponentContainer, String> attribute) {
+    public static String format(final ApplicationContext context, final Class<?> type, final boolean ignoreExisting, final char delimiter, final Function<ComponentContainer, String> attribute) {
         final Option<ComponentContainer> container = context.get(ComponentLocator.class).container(type);
         if (!ignoreExisting && container.present()) {
             final String name = attribute.apply(container.get());

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchyAwareComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchyAwareComponentProvider.java
@@ -17,7 +17,6 @@
 package org.dockbox.hartshorn.component;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.util.IllegalModificationException;
 import org.dockbox.hartshorn.component.ComponentKey.ComponentKeyView;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
 import org.dockbox.hartshorn.component.processing.ModifiableComponentProcessingContext;
@@ -43,6 +42,7 @@ import org.dockbox.hartshorn.proxy.ProxyFactory;
 import org.dockbox.hartshorn.proxy.StateAwareProxyFactory;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.ApplicationRuntimeException;
+import org.dockbox.hartshorn.util.IllegalModificationException;
 import org.dockbox.hartshorn.util.StringUtilities;
 import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.view.FieldView;
@@ -72,7 +72,7 @@ public class HierarchyAwareComponentProvider extends DefaultProvisionContext imp
             final Option<ObjectContainer<T>> objectContainer = this.provide(key);
             if (objectContainer.present()) return objectContainer;
 
-            return this.raw(key);
+            return this.createContextualInstanceContainer(key);
         }
         catch (final ApplicationException e) {
             throw new ComponentInitializationException("Failed to create component for key " + key, e);
@@ -207,7 +207,7 @@ public class HierarchyAwareComponentProvider extends DefaultProvisionContext imp
         }
     }
 
-    public <T> Option<ObjectContainer<T>> raw(final ComponentKey<T> key) throws ApplicationException {
+    public <T> Option<ObjectContainer<T>> createContextualInstanceContainer(final ComponentKey<T> key) throws ApplicationException {
         return new ContextDrivenProvider<>(key).provide(this.applicationContext());
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapter.java
@@ -35,11 +35,11 @@ public final class ScopeAdapter<T> implements Scope {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
-        final ScopeAdapter<?> that = (ScopeAdapter<?>) o;
-        return this.adaptee.equals(that.adaptee);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (other == null || this.getClass() != other.getClass()) return false;
+        final ScopeAdapter<?> adapter = (ScopeAdapter<?>) other;
+        return this.adaptee.equals(adapter.adaptee);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapter.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.component;
 
 import java.util.Objects;
 
-public class ScopeAdapter<T> implements Scope {
+public final class ScopeAdapter<T> implements Scope {
 
     private final T adaptee;
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ProvidedParameterContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ProvidedParameterContext.java
@@ -42,7 +42,11 @@ public final class ProvidedParameterContext extends DefaultProvisionContext {
             throw new IllegalArgumentException("Parameters and arguments must be of the same size");
         }
         final Map<ParameterView<?>, Object> argumentMap = IntStream.range(0, parameters.size()).boxed()
-                .collect(HashMap::new, (m, v) -> m.put(parameters.get(v), arguments.get(v)), Map::putAll);
+                .collect(
+                        HashMap::new,
+                        (parameterViews, index) -> parameterViews.put(parameters.get(index), arguments.get(index)),
+                        Map::putAll
+                );
         return new ProvidedParameterContext(argumentMap);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticBindingServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticBindingServicePreProcessor.java
@@ -25,6 +25,7 @@ import org.dockbox.hartshorn.component.condition.ConditionMatcher;
 import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.component.processing.ExitingComponentProcessor;
+import org.dockbox.hartshorn.component.processing.ProcessingOrder;
 import org.dockbox.hartshorn.introspect.ViewContextAdapter;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.ApplicationRuntimeException;
@@ -87,7 +88,7 @@ public class StaticBindingServicePreProcessor extends ComponentPreProcessor impl
 
     @Override
     public Integer order() {
-        return (Integer.MIN_VALUE / 2) - 512;
+        return (Integer.MIN_VALUE / 2) - (ProcessingOrder.LAST * 2);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentContainerReportable.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentContainerReportable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.component.contextual;
 
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentContainerReportable.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentContainerReportable.java
@@ -1,0 +1,19 @@
+package org.dockbox.hartshorn.component.contextual;
+
+import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
+import org.dockbox.hartshorn.reporting.Reportable;
+
+public class StaticComponentContainerReportable implements Reportable {
+    private final StaticComponentContainer<?> componentReference;
+
+    public StaticComponentContainerReportable(final StaticComponentContainer<?> componentReference) {
+        this.componentReference = componentReference;
+    }
+
+    @Override
+    public void report(final DiagnosticsPropertyCollector containerCollector) {
+        containerCollector.property("type").write(this.componentReference.type());
+        containerCollector.property("id").write(this.componentReference.id());
+        containerCollector.property("instance").write(this.componentReference.instance().toString());
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentContext.java
@@ -35,7 +35,7 @@ import jakarta.inject.Inject;
 @InstallIfAbsent
 public class StaticComponentContext extends DefaultApplicationAwareContext implements StaticComponentCollector, Reportable {
 
-    public static ContextKey<StaticComponentContext> CONTEXT_KEY = ContextKey.builder(StaticComponentContext.class)
+    public static final ContextKey<StaticComponentContext> CONTEXT_KEY = ContextKey.builder(StaticComponentContext.class)
             .fallback(StaticComponentContext::new)
             .build();
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentContext.java
@@ -76,11 +76,9 @@ public class StaticComponentContext extends DefaultApplicationAwareContext imple
 
     @Override
     public void report(final DiagnosticsPropertyCollector collector) {
-        final Reportable[] reporters = this.staticComponentContainers.stream().map(componentReference -> (Reportable) containerCollector -> {
-            containerCollector.property("type").write(componentReference.type());
-            containerCollector.property("id").write(componentReference.id());
-            containerCollector.property("instance").write(componentReference.instance().toString());
-        }).toArray(Reportable[]::new);
+        final Reportable[] reporters = this.staticComponentContainers.stream()
+                .map(StaticComponentContainerReportable::new)
+                .toArray(Reportable[]::new);
         collector.property("beans").write(reporters);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentContext.java
@@ -65,7 +65,7 @@ public class StaticComponentContext extends DefaultApplicationAwareContext imple
     @Override
     public <T> Set<StaticComponentContainer<T>> register(final Class<T> type, final Collection<T> components, final String id) {
         return components.stream()
-                .map(b -> this.register(b, type, id))
+                .map(component -> this.register(component, type, id))
                 .collect(Collectors.toSet());
     }
 
@@ -76,10 +76,10 @@ public class StaticComponentContext extends DefaultApplicationAwareContext imple
 
     @Override
     public void report(final DiagnosticsPropertyCollector collector) {
-        final Reportable[] reporters = this.staticComponentContainers.stream().map(componentReference -> (Reportable) c -> {
-            c.property("type").write(componentReference.type());
-            c.property("id").write(componentReference.id());
-            c.property("instance").write(componentReference.instance().toString());
+        final Reportable[] reporters = this.staticComponentContainers.stream().map(componentReference -> (Reportable) containerCollector -> {
+            containerCollector.property("type").write(componentReference.type());
+            containerCollector.property("id").write(componentReference.id());
+            containerCollector.property("instance").write(componentReference.instance().toString());
         }).toArray(Reportable[]::new);
         collector.property("beans").write(reporters);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentProviders.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/contextual/StaticComponentProviders.java
@@ -25,5 +25,5 @@ import org.dockbox.hartshorn.component.processing.Binds;
 public class StaticComponentProviders {
 
     @Binds
-    public Class<? extends StaticComponentProvider> staticComponentProvider = ContextStaticComponentProvider.class;
+    public final Class<? extends StaticComponentProvider> staticComponentProvider = ContextStaticComponentProvider.class;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryAbstractMethodInterceptor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryAbstractMethodInterceptor.java
@@ -1,0 +1,33 @@
+package org.dockbox.hartshorn.component.factory;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.proxy.MethodInterceptorContext;
+import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
+import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+
+public class ConstructorFactoryAbstractMethodInterceptor<T, R> extends ConstructorFactoryMethodInterceptor<T, R> {
+    private final ConstructorView<?> constructor;
+    private final ConversionService conversionService;
+    private final MethodView<T, R> method;
+    private final ApplicationContext context;
+    private final boolean enable;
+
+    public ConstructorFactoryAbstractMethodInterceptor(final ConstructorView<?> constructor,
+                                                       final ConversionService conversionService,
+                                                       final MethodView<T, R> method, final ApplicationContext context,
+                                                       final boolean enable) {
+        this.constructor = constructor;
+        this.conversionService = conversionService;
+        this.method = method;
+        this.context = context;
+        this.enable = enable;
+    }
+
+    @Override
+    public R intercept(final MethodInterceptorContext<T, R> interceptorContext) throws Throwable {
+        final Object instance = this.constructor.create(interceptorContext.args()).rethrow().orNull();
+        final R result = this.conversionService.convert(instance, this.method.returnType().type());
+        return this.processInstance(this.context, result, this.enable);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryAbstractMethodInterceptor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryAbstractMethodInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.component.factory;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryConcreteMethodInterceptor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryConcreteMethodInterceptor.java
@@ -1,0 +1,34 @@
+package org.dockbox.hartshorn.component.factory;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.component.processing.proxy.MethodProxyContext;
+import org.dockbox.hartshorn.proxy.MethodInterceptorContext;
+import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+
+public class ConstructorFactoryConcreteMethodInterceptor<T, R> extends ConstructorFactoryMethodInterceptor<T, R> {
+    private final MethodProxyContext<T> methodContext;
+    private final ConversionService conversionService;
+    private final MethodView<T, R> method;
+    private final ApplicationContext context;
+    private final boolean enable;
+
+    public ConstructorFactoryConcreteMethodInterceptor(final MethodProxyContext<T> methodContext,
+                                                       final ConversionService conversionService,
+                                                       final MethodView<T, R> method, final ApplicationContext context,
+                                                       final boolean enable) {
+        this.methodContext = methodContext;
+        this.conversionService = conversionService;
+        this.method = method;
+        this.context = context;
+        this.enable = enable;
+    }
+
+    @Override
+    public R intercept(final MethodInterceptorContext<T, R> interceptorContext) throws Throwable {
+        final T instance = interceptorContext.instance();
+        final Object result = this.methodContext.method().invoke(instance, interceptorContext.args()).orNull();
+        final R convertedResult = this.conversionService.convert(result, this.method.returnType().type());
+        return this.processInstance(this.context, convertedResult, this.enable);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryConcreteMethodInterceptor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryConcreteMethodInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.component.factory;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryMethodInterceptor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryMethodInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.component.factory;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryMethodInterceptor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/ConstructorFactoryMethodInterceptor.java
@@ -1,0 +1,19 @@
+package org.dockbox.hartshorn.component.factory;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.component.ComponentPopulator;
+import org.dockbox.hartshorn.component.ComponentPostConstructor;
+import org.dockbox.hartshorn.proxy.MethodInterceptor;
+import org.dockbox.hartshorn.util.ApplicationException;
+
+public abstract class ConstructorFactoryMethodInterceptor<T, R> implements MethodInterceptor<T, R> {
+
+    protected <U> U processInstance(final ApplicationContext context, final U instance, final boolean enable) throws ApplicationException {
+        U out = instance;
+        out = context.get(ComponentPopulator.class).populate(out);
+        if (enable) {
+            out = context.get(ComponentPostConstructor.class).doPostConstruct(out);
+        }
+        return out;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/FactoryServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/FactoryServicePreProcessor.java
@@ -16,23 +16,23 @@
 
 package org.dockbox.hartshorn.component.factory;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.component.processing.ExitingComponentProcessor;
 import org.dockbox.hartshorn.component.processing.ProcessingOrder;
+import org.dockbox.hartshorn.inject.ComponentInitializationException;
 import org.dockbox.hartshorn.inject.ContextDrivenProvider;
 import org.dockbox.hartshorn.inject.Provider;
 import org.dockbox.hartshorn.inject.binding.Bound;
 import org.dockbox.hartshorn.inject.processing.BindingProcessor;
-import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class FactoryServicePreProcessor extends ComponentPreProcessor implements ExitingComponentProcessor {
 
@@ -84,7 +84,7 @@ public class FactoryServicePreProcessor extends ComponentPreProcessor implements
     public void exit(final ApplicationContext context) {
         try {
             context.get(BindingProcessor.class).finalizeProxies(context);
-        } catch (final ApplicationException e) {
+        } catch (final ComponentInitializationException e) {
             context.handle(e);
         }
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/MissingFactoryConstructorException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/MissingFactoryConstructorException.java
@@ -18,13 +18,13 @@ package org.dockbox.hartshorn.component.factory;
 
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.util.ApplicationRuntimeException;
-import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
 public class MissingFactoryConstructorException extends ApplicationRuntimeException {
 
-    public MissingFactoryConstructorException(final ComponentKey<?> key, final MethodView<?, ?> method) {
+    public MissingFactoryConstructorException(final ComponentKey<?> key, final ExecutableElementView<?> elementView) {
         super("No matching bound constructor found for %s with parameters: %s"
-                .formatted(key, method.parameters().types().stream().map(TypeView::name).toList()));
+                .formatted(key, elementView.parameters().types().stream().map(TypeView::name).toList()));
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingOrder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingOrder.java
@@ -38,5 +38,5 @@ public class ProcessingOrder {
      */
     public static final ProcessingPhase MODIFYING = new ProcessingPhase("Modifying", i -> i >= 0, false);
 
-    public static final ProcessingPhase[] PHASES = new ProcessingPhase[] { INITIALIZING, MODIFYING };
+    public static final ProcessingPhase[] PHASES = { INITIALIZING, MODIFYING };
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingOrder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingOrder.java
@@ -29,14 +29,14 @@ public class ProcessingOrder {
      * processors are allowed to discard existing instances and return new ones. This can be used to
      * create proxy instances.
      */
-    public static final ProcessingPhase INITIALIZING = new ProcessingPhase("Initializing", i -> i < 0, true);
+    public static final ProcessingPhase INITIALIZING = new ProcessingPhase("Initializing", order -> order < 0, true);
 
     /**
      * Indicates which service orders can be performed during phase 2. During this phase, component
      * processors are not allowed to discard existing instances and return new ones. This limits the
      * behavior of these processors to only return the same instance, albeit with different state.
      */
-    public static final ProcessingPhase MODIFYING = new ProcessingPhase("Modifying", i -> i >= 0, false);
+    public static final ProcessingPhase MODIFYING = new ProcessingPhase("Modifying", order -> order >= 0, false);
 
     public static final ProcessingPhase[] PHASES = { INITIALIZING, MODIFYING };
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingPhase.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingPhase.java
@@ -45,11 +45,11 @@ public final class ProcessingPhase implements Predicate<Integer> {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
-        final ProcessingPhase that = (ProcessingPhase) o;
-        return this.name.equals(that.name);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (other == null || this.getClass() != other.getClass()) return false;
+        final ProcessingPhase phase = (ProcessingPhase) other;
+        return this.name.equals(phase.name);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ConcreteContextCarrier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ConcreteContextCarrier.java
@@ -30,6 +30,7 @@ public class ConcreteContextCarrier implements ContextCarrier {
     @Inject
     private ApplicationContext applicationContext;
 
+    @Override
     public ApplicationContext applicationContext() {
         return this.applicationContext;
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ContextKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ContextKey.java
@@ -197,11 +197,13 @@ public final class ContextKey<T extends Context> implements ContextIdentity<T> {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
-        final ContextKey<?> that = (ContextKey<?>) o;
-        return this.requiresApplicationContext == that.requiresApplicationContext && this.type.equals(that.type) && Objects.equals(this.name, that.name);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (other == null || this.getClass() != other.getClass()) return false;
+        final ContextKey<?> contextKey = (ContextKey<?>) other;
+        return this.requiresApplicationContext == contextKey.requiresApplicationContext
+                && this.type.equals(contextKey.type)
+                && Objects.equals(this.name, contextKey.name);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/CyclingConstructorAnalyzer.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/CyclingConstructorAnalyzer.java
@@ -72,15 +72,15 @@ public final class CyclingConstructorAnalyzer {
             if (!path.isEmpty()) return Attempt.of(new CyclicComponentException(type, path));
         }
 
-        return Attempt.<ConstructorView<C>, ApplicationException>of(optimalConstructor).peek(c -> {
+        return Attempt.<ConstructorView<C>, ApplicationException>of(optimalConstructor).peek(constructor -> {
             // Don't store if there may be a cycle in the dependency graph
-            if (checkForCycles) cache.put(type.type(), c);
+            if (checkForCycles) cache.put(type.type(), constructor);
         });
     }
 
     public static List<TypeView<?>> findCyclicPath(final TypeView<?> type) {
-        return findConstructor(type, false).map(c -> {
-            final List<TypeView<?>> path = findCyclicPath(c, type);
+        return findConstructor(type, false).map(constructor -> {
+            final List<TypeView<?>> path = findCyclicPath(constructor, type);
             return finalizeLookup(type, path);
         }).orElseGet(ArrayList::new);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingFunction.java
@@ -51,10 +51,10 @@ public interface BindingFunction<T> {
      * every time it is requested. This may not enhance the instance before it
      * is returned.
      *
-     * @param t The instance to bind to
+     * @param instance The instance to bind to
      * @return The binder
      */
-    Binder singleton(T t);
+    Binder singleton(T instance);
 
     /**
      * Binds to a supplier that will provide a lazy instance of the given type

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
@@ -117,10 +117,10 @@ public class HierarchyBindingFunction<T> implements BindingFunction<T> {
     }
 
     @Override
-    public Binder singleton(final T t) {
+    public Binder singleton(final T instance) {
         // Set 'processed' to false to ensure that the singleton is processed the first time it is requested. As the object
         // container is reused, this will only happen once.
-        return this.add(new SingletonProvider<>(t, false));
+        return this.add(new SingletonProvider<>(instance, false));
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/BindingProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/BindingProcessor.java
@@ -106,11 +106,11 @@ public class BindingProcessor {
         else function.to(supplier);
     }
 
-    private <R, C extends Class<R>, E extends AnnotatedElementView & GenericTypeView<C>> void processClassBinding(final ApplicationContext context,
+    private <R, E extends AnnotatedElementView & GenericTypeView<Class<R>>> void processClassBinding(final ApplicationContext context,
                                                              final E element, final ComponentKey<R> key, boolean singleton,
                                                              final Binds annotation) throws ApplicationException {
         final ViewContextAdapter contextAdapter = new IntrospectionViewContextAdapter(context);
-        final C targetType = contextAdapter.load(element)
+        final Class<R> targetType = contextAdapter.load(element)
                 .mapError(error -> new ComponentInitializationException("Failed to obtain class type for " + element.qualifiedName(), error))
                 .rethrow()
                 .orElseThrow(() -> new ComponentInitializationException("Failed to obtain class type for " + element.qualifiedName()));
@@ -140,7 +140,7 @@ public class BindingProcessor {
         else function.to(targetType);
     }
 
-    public void finalizeProxies(final ApplicationContext applicationContext) throws ApplicationException {
+    public void finalizeProxies(final ApplicationContext applicationContext) throws ComponentInitializationException {
         if (this.proxiesToInitialize.isEmpty()) return;
 
         for (final LateSingletonContext<?> proxyContext : new ArrayList<>(this.proxiesToInitialize)) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/BindingProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/BindingProcessor.java
@@ -16,10 +16,6 @@
 
 package org.dockbox.hartshorn.inject.processing;
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentContainer;
 import org.dockbox.hartshorn.component.ComponentKey;
@@ -42,6 +38,10 @@ import org.dockbox.hartshorn.util.introspect.view.FieldView;
 import org.dockbox.hartshorn.util.introspect.view.GenericTypeView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.View;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.inject.Singleton;
 
@@ -92,7 +92,7 @@ public class BindingProcessor {
                                             final E element, final ComponentKey<R> key,
                                             final boolean singleton, final Binds annotation) throws ApplicationException {
         final BindingFunction<R> function = context.bind(key).priority(annotation.priority());
-        element.annotations().get(InstallTo.class).peek(a -> function.installTo(a.value()));
+        element.annotations().get(InstallTo.class).peek(installTo -> function.installTo(installTo.value()));
 
         final ViewContextAdapter contextAdapter = new IntrospectionViewContextAdapter(context);
         final CheckedSupplier<R> supplier = () -> contextAdapter.load(element)
@@ -119,7 +119,7 @@ public class BindingProcessor {
 
         singleton = singleton || context.environment().singleton(targetType);
         final BindingFunction<R> function = context.bind(key).priority(annotation.priority());
-        element.annotations().get(InstallTo.class).peek(a -> function.installTo(a.value()));
+        element.annotations().get(InstallTo.class).peek(installTo -> function.installTo(installTo.value()));
 
         if (singleton) {
             final boolean lazy = annotation.lazy() || Boolean.TRUE.equals(context.get(ComponentLocator.class)

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ComponentContextInjectionPreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ComponentContextInjectionPreProcessor.java
@@ -40,11 +40,11 @@ public class ComponentContextInjectionPreProcessor extends ComponentPreProcessor
             this.validate(field, processingContext);
 
         final List<ExecutableElementView<T>> constructors = processingContext.type().constructors().injectable()
-                .stream().map(c -> (ExecutableElementView<T>) c)
+                .stream().map(constructor -> (ExecutableElementView<T>) constructor)
                 .collect(Collectors.toList());
 
         final List<ExecutableElementView<T>> methods = processingContext.type().methods().all().stream()
-                .map(m -> (ExecutableElementView<T>) m)
+                .map(method -> (ExecutableElementView<T>) method)
                 .collect(Collectors.toList());
 
         final Collection<ExecutableElementView<T>> executables = CollectionUtilities.merge(constructors, methods);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContextList.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContextList.java
@@ -59,20 +59,20 @@ public class ProviderContextList extends DefaultProvisionContext implements Repo
 
     @Override
     public void report(final DiagnosticsPropertyCollector collector) {
-        final Reportable[] reporters = this.elements.allValues().stream().map(context -> (Reportable) c -> {
-            c.property("key").write(keyCollector -> {
+        final Reportable[] reporters = this.elements.allValues().stream().map(context -> (Reportable) elementCollector -> {
+            elementCollector.property("key").write(keyCollector -> {
                 keyCollector.property("type").write(context.key().type().getCanonicalName());
                 if (context.key().name() != null) {
                     keyCollector.property("name").write(context.key().name());
                 }
             });
-            c.property("phase").write(context.provider().phase());
-            c.property("lazy").write(context.provider().lazy());
-            c.property("priority").write(context.provider().priority());
+            elementCollector.property("phase").write(context.provider().phase());
+            elementCollector.property("lazy").write(context.provider().lazy());
+            elementCollector.property("priority").write(context.provider().priority());
             if (StringUtilities.notEmpty(context.provider().value())) {
-                c.property("name").write(context.provider().value());
+                elementCollector.property("name").write(context.provider().value());
             }
-            c.property("element").write(context.element());
+            elementCollector.property("element").write(context.element());
         }).toArray(Reportable[]::new);
         collector.property("providers").write(reporters);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContextList.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContextList.java
@@ -21,7 +21,6 @@ import org.dockbox.hartshorn.context.DefaultProvisionContext;
 import org.dockbox.hartshorn.context.InstallIfAbsent;
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
 import org.dockbox.hartshorn.reporting.Reportable;
-import org.dockbox.hartshorn.util.StringUtilities;
 import org.dockbox.hartshorn.util.collections.MultiMap;
 
 import java.util.Collection;
@@ -59,21 +58,9 @@ public class ProviderContextList extends DefaultProvisionContext implements Repo
 
     @Override
     public void report(final DiagnosticsPropertyCollector collector) {
-        final Reportable[] reporters = this.elements.allValues().stream().map(context -> (Reportable) elementCollector -> {
-            elementCollector.property("key").write(keyCollector -> {
-                keyCollector.property("type").write(context.key().type().getCanonicalName());
-                if (context.key().name() != null) {
-                    keyCollector.property("name").write(context.key().name());
-                }
-            });
-            elementCollector.property("phase").write(context.provider().phase());
-            elementCollector.property("lazy").write(context.provider().lazy());
-            elementCollector.property("priority").write(context.provider().priority());
-            if (StringUtilities.notEmpty(context.provider().value())) {
-                elementCollector.property("name").write(context.provider().value());
-            }
-            elementCollector.property("element").write(context.element());
-        }).toArray(Reportable[]::new);
+        final Reportable[] reporters = this.elements.allValues().stream()
+                .map(ProviderContextReportable::new)
+                .toArray(Reportable[]::new);
         collector.property("providers").write(reporters);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContextReportable.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContextReportable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.inject.processing;
 
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContextReportable.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderContextReportable.java
@@ -1,0 +1,30 @@
+package org.dockbox.hartshorn.inject.processing;
+
+import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
+import org.dockbox.hartshorn.reporting.Reportable;
+import org.dockbox.hartshorn.util.StringUtilities;
+
+public class ProviderContextReportable implements Reportable {
+    private final ProviderContext context;
+
+    public ProviderContextReportable(final ProviderContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void report(final DiagnosticsPropertyCollector elementCollector) {
+        elementCollector.property("key").write(keyCollector -> {
+            keyCollector.property("type").write(this.context.key().type().getCanonicalName());
+            if (this.context.key().name() != null) {
+                keyCollector.property("name").write(this.context.key().name());
+            }
+        });
+        elementCollector.property("phase").write(this.context.provider().phase());
+        elementCollector.property("lazy").write(this.context.provider().lazy());
+        elementCollector.property("priority").write(this.context.provider().priority());
+        if (StringUtilities.notEmpty(this.context.provider().value())) {
+            elementCollector.property("name").write(this.context.provider().value());
+        }
+        elementCollector.property("element").write(this.context.element());
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/logging/logback/LogbackPIDConverter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/logging/logback/LogbackPIDConverter.java
@@ -35,6 +35,6 @@ public class LogbackPIDConverter extends ClassicConverter {
 
     @Override
     public String convert(final ILoggingEvent event) {
-        return "" + PROCESS_ID;
+        return String.valueOf(PROCESS_ID);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
@@ -47,7 +47,7 @@ public class ApplicationBoundParameterLoaderContext extends ParameterLoaderConte
         this(executable, instance, applicationContext, applicationContext, scope);
     }
 
-    public ApplicationBoundParameterLoaderContext(ExecutableElementView<?> executable, Object instance, ApplicationContext applicationContext, ComponentProvider provider, Scope scope) {
+    public ApplicationBoundParameterLoaderContext(final ExecutableElementView<?> executable, final Object instance, final ApplicationContext applicationContext, final ComponentProvider provider, final Scope scope) {
         super(executable, instance);
         this.applicationContext = applicationContext;
         this.provider = provider;
@@ -73,12 +73,12 @@ public class ApplicationBoundParameterLoaderContext extends ParameterLoaderConte
     }
 
     @Override
-    public <C extends Context> void add(C context) {
+    public <C extends Context> void add(final C context) {
         this.context.add(context);
     }
 
     @Override
-    public <C extends Context> void add(String name, C context) {
+    public <C extends Context> void add(final String name, final C context) {
         this.context.add(name, context);
     }
 
@@ -88,12 +88,12 @@ public class ApplicationBoundParameterLoaderContext extends ParameterLoaderConte
     }
 
     @Override
-    public <C extends Context> Option<C> first(ContextIdentity<C> key) {
+    public <C extends Context> Option<C> first(final ContextIdentity<C> key) {
         return this.context.first(key);
     }
 
     @Override
-    public <C extends Context> List<C> all(ContextIdentity<C> key) {
+    public <C extends Context> List<C> all(final ContextIdentity<C> key) {
         return this.context.all(key);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/Lazy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/Lazy.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.util;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 
-public class Lazy<T> {
+public final class Lazy<T> {
 
     private final ApplicationContext applicationContext;
     private final ComponentKey<T> type;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ClassPathResourceLookupStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/resources/ClassPathResourceLookupStrategy.java
@@ -33,6 +33,7 @@ public class ClassPathResourceLookupStrategy implements ResourceLookupStrategy {
 
     public static final String NAME = "classpath";
 
+    @Override
     public String name() {
         return NAME;
     }

--- a/hartshorn-core/src/test/groovy/test/org/dockbox/hartshorn/core/groovy/GroovyClassComponent.groovy
+++ b/hartshorn-core/src/test/groovy/test/org/dockbox/hartshorn/core/groovy/GroovyClassComponent.groovy
@@ -25,7 +25,7 @@ import org.dockbox.hartshorn.component.Component
 class GroovyClassComponent {
 
     @Inject
-    private ApplicationContext applicationContext;
+    private ApplicationContext applicationContext
     private ApplicationEnvironment environment
 
     @Inject

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/BindingHierarchyTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/BindingHierarchyTests.java
@@ -92,17 +92,17 @@ public class BindingHierarchyTests {
         final Option<Provider<Contract>> priorityZero = hierarchy.get(0);
         Assertions.assertTrue(priorityZero.present());
         Assertions.assertTrue(priorityZero.get() instanceof ContextDrivenProvider);
-        Assertions.assertEquals(((ContextDrivenProvider<Contract>) priorityZero.get()).type(), ImplementationA.class);
+        Assertions.assertSame(((ContextDrivenProvider<Contract>) priorityZero.get()).type(), ImplementationA.class);
 
         final Option<Provider<Contract>> priorityOne = hierarchy.get(1);
         Assertions.assertTrue(priorityOne.present());
         Assertions.assertTrue(priorityOne.get() instanceof ContextDrivenProvider);
-        Assertions.assertEquals(((ContextDrivenProvider<Contract>) priorityOne.get()).type(), ImplementationB.class);
+        Assertions.assertSame(((ContextDrivenProvider<Contract>) priorityOne.get()).type(), ImplementationB.class);
 
         final Option<Provider<Contract>> priorityTwo = hierarchy.get(2);
         Assertions.assertTrue(priorityTwo.present());
         Assertions.assertTrue(priorityTwo.get() instanceof ContextDrivenProvider);
-        Assertions.assertEquals(((ContextDrivenProvider<Contract>) priorityTwo.get()).type(), ImplementationC.class);
+        Assertions.assertSame(((ContextDrivenProvider<Contract>) priorityTwo.get()).type(), ImplementationC.class);
     }
 
     @Test
@@ -116,7 +116,7 @@ public class BindingHierarchyTests {
         final Option<Provider<LocalContract>> provider = hierarchy.get(-1);
         Assertions.assertTrue(provider.present());
         Assertions.assertTrue(provider.get() instanceof ContextDrivenProvider);
-        Assertions.assertEquals(((ContextDrivenProvider<LocalContract>) provider.get()).type(), LocalImpl.class);
+        Assertions.assertSame(((ContextDrivenProvider<LocalContract>) provider.get()).type(), LocalImpl.class);
     }
 
     interface LocalContract {

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/CircularConstructorA.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/CircularConstructorA.java
@@ -22,14 +22,14 @@ import jakarta.inject.Singleton;
 @Singleton
 public class CircularConstructorA {
 
-    private final CircularConstructorB b;
+    private final CircularConstructorB constructorB;
 
     @Inject
-    public CircularConstructorA(final CircularConstructorB b) {
-        this.b = b;
+    public CircularConstructorA(final CircularConstructorB constructorB) {
+        this.constructorB = constructorB;
     }
 
-    public CircularConstructorB b() {
-        return this.b;
+    public CircularConstructorB constructorB() {
+        return this.constructorB;
     }
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/CircularConstructorB.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/CircularConstructorB.java
@@ -22,14 +22,14 @@ import jakarta.inject.Singleton;
 @Singleton
 public class CircularConstructorB {
 
-    private final CircularConstructorA a;
+    private final CircularConstructorA constructorA;
 
     @Inject
-    public CircularConstructorB(final CircularConstructorA a) {
-        this.a = a;
+    public CircularConstructorB(final CircularConstructorA constructorA) {
+        this.constructorA = constructorA;
     }
 
-    public CircularConstructorA a() {
-        return this.a;
+    public CircularConstructorA constructorA() {
+        return this.constructorA;
     }
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/LongCycles.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/LongCycles.java
@@ -24,24 +24,24 @@ public class LongCycles {
     @Singleton
     public static class LongCycleA {
         @Inject
-        public LongCycleA(final LongCycleB b) {}
+        public LongCycleA(final LongCycleB cycle) {}
     }
 
     @Singleton
     public static class LongCycleB {
         @Inject
-        public LongCycleB(final LongCycleC c) {}
+        public LongCycleB(final LongCycleC cycle) {}
     }
 
     @Singleton
     public static class LongCycleC {
         @Inject
-        public LongCycleC(final LongCycleD d) {}
+        public LongCycleC(final LongCycleD cycle) {}
     }
 
     @Singleton
     public static class LongCycleD {
         @Inject
-        public LongCycleD(final LongCycleA a) {}
+        public LongCycleD(final LongCycleA cycle) {}
     }
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/contextual/StaticBindsTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/contextual/StaticBindsTests.java
@@ -57,7 +57,7 @@ public class StaticBindsTests {
 
         Assertions.assertEquals("John Doe", reference.instance());
         Assertions.assertEquals("names", reference.id());
-        Assertions.assertEquals(String.class, reference.type().type());
+        Assertions.assertSame(String.class, reference.type().type());
     }
 
     @Test

--- a/hartshorn-discovery/hartshorn-discovery.gradle.kts
+++ b/hartshorn-discovery/hartshorn-discovery.gradle.kts
@@ -19,10 +19,10 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-util")
+    api("org.dockbox.hartshorn:hartshorn-util")
 
-    compileOnly("com.google.auto.service:auto-service:1.0-rc7")
-    annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
+    compileOnly(libs.autoService)
+    annotationProcessor(libs.autoService)
 
     testAnnotationProcessor("org.dockbox.hartshorn:hartshorn-discovery")
 }

--- a/hartshorn-events/hartshorn-events.gradle.kts
+++ b/hartshorn-events/hartshorn-events.gradle.kts
@@ -19,10 +19,7 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
+    api("org.dockbox.hartshorn:hartshorn-core")
 
     testImplementation("org.dockbox.hartshorn:hartshorn-hsl") // For expression evaluation
     testImplementation("org.dockbox.hartshorn:hartshorn-introspect-reflection")

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/AbstractTargetEvent.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/AbstractTargetEvent.java
@@ -24,7 +24,7 @@ public abstract class AbstractTargetEvent extends ContextCarrierEvent implements
 
     private Subject subject;
 
-    public AbstractTargetEvent(final Subject subject) {
+    protected AbstractTargetEvent(final Subject subject) {
         this.subject = subject;
     }
 

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterContext.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterContext.java
@@ -30,19 +30,19 @@ public class EventExecutionFilterContext extends DefaultProvisionContext {
     private final Set<EventExecutionFilter> executionFilters = ConcurrentHashMap.newKeySet();
 
     public boolean contains(final EventExecutionFilter o) {
-        return executionFilters.contains(o);
+        return this.executionFilters.contains(o);
     }
 
     public boolean add(final EventExecutionFilter eventExecutionFilter) {
-        return executionFilters.add(eventExecutionFilter);
+        return this.executionFilters.add(eventExecutionFilter);
     }
 
     public boolean remove(final EventExecutionFilter o) {
-        return executionFilters.remove(o);
+        return this.executionFilters.remove(o);
     }
 
     public boolean addAll(final Collection<? extends EventExecutionFilter> c) {
-        return executionFilters.addAll(c);
+        return this.executionFilters.addAll(c);
     }
 
     public Set<EventExecutionFilter> filters() {

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterContext.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventExecutionFilterContext.java
@@ -29,20 +29,20 @@ public class EventExecutionFilterContext extends DefaultProvisionContext {
 
     private final Set<EventExecutionFilter> executionFilters = ConcurrentHashMap.newKeySet();
 
-    public boolean contains(final EventExecutionFilter o) {
-        return this.executionFilters.contains(o);
+    public boolean contains(final EventExecutionFilter filter) {
+        return this.executionFilters.contains(filter);
     }
 
     public boolean add(final EventExecutionFilter eventExecutionFilter) {
         return this.executionFilters.add(eventExecutionFilter);
     }
 
-    public boolean remove(final EventExecutionFilter o) {
-        return this.executionFilters.remove(o);
+    public boolean remove(final EventExecutionFilter filter) {
+        return this.executionFilters.remove(filter);
     }
 
-    public boolean addAll(final Collection<? extends EventExecutionFilter> c) {
-        return this.executionFilters.addAll(c);
+    public boolean addAll(final Collection<? extends EventExecutionFilter> filters) {
+        return this.executionFilters.addAll(filters);
     }
 
     public Set<EventExecutionFilter> filters() {

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandler.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandler.java
@@ -132,10 +132,10 @@ public class EventHandler {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof EventHandler)) return false;
-        return Objects.equals(this.eventType, ((EventHandler) o).eventType);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (!(other instanceof EventHandler)) return false;
+        return Objects.equals(this.eventType, ((EventHandler) other).eventType);
     }
 
     @Override

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandler.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandler.java
@@ -65,8 +65,9 @@ public class EventHandler {
         EventWrapperImpl<?>[] cache = this.computedInvokerCache;
         if (null == cache) {
             synchronized (this) {
-                if (null == (cache = this.computedInvokerCache)) {
-                    cache = this.computedInvokerCache = this.computeInvokerCache();
+                if (null == this.computedInvokerCache) {
+                    cache = this.computeInvokerCache();
+                    this.computedInvokerCache = cache;
                 }
             }
         }

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandlerRegistry.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandlerRegistry.java
@@ -33,7 +33,8 @@ public final class EventHandlerRegistry {
     public EventHandler handler(final TypeView<? extends Event> type) {
         EventHandler handler = this.handlers.get(type.type());
         if (null == handler) {
-            this.computeHierarchy(handler = new EventHandler(type));
+            handler = new EventHandler(type);
+            this.computeHierarchy(handler);
             this.handlers.put(type.type(), handler);
         }
         return handler;

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterLoaderContext.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterLoaderContext.java
@@ -19,16 +19,15 @@ package org.dockbox.hartshorn.events.handle;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.events.parents.Event;
 import org.dockbox.hartshorn.util.ApplicationBoundParameterLoaderContext;
-import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 
 public class EventParameterLoaderContext extends ApplicationBoundParameterLoaderContext {
 
     private final Event event;
 
-    public EventParameterLoaderContext(final MethodView<?, ?> method, final TypeView<?> type, final Object instance,
+    public EventParameterLoaderContext(final ExecutableElementView<?> element, final Object instance,
                                        final ApplicationContext applicationContext, final Event event) {
-        super(method, instance, applicationContext);
+        super(element, instance, applicationContext);
         this.event = event;
     }
 

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventWrapperImpl.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventWrapperImpl.java
@@ -148,9 +148,7 @@ public final class EventWrapperImpl<T> implements Comparable<EventWrapperImpl<T>
             // Lazy initialisation to allow processors to register first
             if (this.listener == null) this.listener = event.applicationContext().get(this.listenerType);
 
-            final TypeView<T> listenerType = event.applicationContext().environment().introspect(this.listenerType.type());
-            final EventParameterLoaderContext loaderContext = new EventParameterLoaderContext(this.method, listenerType, this.listener, this.context, event);
-
+            final EventParameterLoaderContext loaderContext = new EventParameterLoaderContext(this.method, this.listener, this.context, event);
             final List<Object> arguments = this.parameterLoader().loadArguments(loaderContext);
             final Attempt<?, Throwable> result = this.method.invoke(this.listener, arguments);
 

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventWrapperImpl.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventWrapperImpl.java
@@ -176,8 +176,8 @@ public final class EventWrapperImpl<T> implements Comparable<EventWrapperImpl<T>
     }
 
     @Override
-    public int compareTo(@NonNull final EventWrapperImpl o) {
-        return COMPARATOR.compare(this, o);
+    public int compareTo(@NonNull final EventWrapperImpl other) {
+        return COMPARATOR.compare(this, other);
     }
 
     @Override
@@ -190,10 +190,10 @@ public final class EventWrapperImpl<T> implements Comparable<EventWrapperImpl<T>
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof EventWrapperImpl)) return false;
-        return fastEqual(this, (EventWrapperImpl<?>) o);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (!(other instanceof EventWrapperImpl)) return false;
+        return fastEqual(this, (EventWrapperImpl<?>) other);
     }
 
     private static boolean fastEqual(final EventWrapperImpl<?> o1, final EventWrapperImpl<?> o2) {

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/parents/ContextCarrierEvent.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/parents/ContextCarrierEvent.java
@@ -27,7 +27,7 @@ public abstract class ContextCarrierEvent extends DefaultApplicationAwareContext
 
     private ApplicationContext context;
 
-    public ContextCarrierEvent() {
+    protected ContextCarrierEvent() {
         super(null);
     }
 

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/parents/Event.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/parents/Event.java
@@ -18,11 +18,10 @@ package org.dockbox.hartshorn.events.parents;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.context.ApplicationAwareContext;
-import org.dockbox.hartshorn.context.ContextCarrier;
 import org.dockbox.hartshorn.events.EventBus;
 
 /** A low level type which is used when subscribing to, posting, or modifying events. */
-public interface Event extends ApplicationAwareContext, ContextCarrier {
+public interface Event extends ApplicationAwareContext {
 
     /**
      * Posts the event directly to the implementation of {@link EventBus}, obtained through

--- a/hartshorn-events/src/test/java/test/org/dockbox/hartshorn/events/GenericEvent.java
+++ b/hartshorn-events/src/test/java/test/org/dockbox/hartshorn/events/GenericEvent.java
@@ -22,7 +22,7 @@ public abstract class GenericEvent<T> extends ContextCarrierEvent {
 
     private final T value;
 
-    public GenericEvent(final T value) {
+    protected GenericEvent(final T value) {
         this.value = value;
     }
 

--- a/hartshorn-events/src/test/java/test/org/dockbox/hartshorn/events/listeners/BasicEventListener.java
+++ b/hartshorn-events/src/test/java/test/org/dockbox/hartshorn/events/listeners/BasicEventListener.java
@@ -16,11 +16,13 @@
 
 package test.org.dockbox.hartshorn.events.listeners;
 
-import test.org.dockbox.hartshorn.events.SampleEvent;
 import org.dockbox.hartshorn.events.annotations.Listener;
+
+import test.org.dockbox.hartshorn.events.SampleEvent;
 
 public class BasicEventListener {
 
+    @SuppressWarnings({ "PublicField", "StaticNonFinalField" })
     public static boolean fired;
 
     @Listener

--- a/hartshorn-events/src/test/java/test/org/dockbox/hartshorn/events/listeners/ConditionalEventListener.java
+++ b/hartshorn-events/src/test/java/test/org/dockbox/hartshorn/events/listeners/ConditionalEventListener.java
@@ -17,13 +17,15 @@
 package test.org.dockbox.hartshorn.events.listeners;
 
 import org.dockbox.hartshorn.component.Service;
-import test.org.dockbox.hartshorn.events.SampleNamedEvent;
 import org.dockbox.hartshorn.events.annotations.Listener;
 import org.dockbox.hartshorn.hsl.condition.RequiresExpression;
+
+import test.org.dockbox.hartshorn.events.SampleNamedEvent;
 
 @Service
 public class ConditionalEventListener {
 
+    @SuppressWarnings({ "PublicField", "StaticNonFinalField" })
     public static boolean fired;
 
     @Listener

--- a/hartshorn-events/src/test/java/test/org/dockbox/hartshorn/events/listeners/StaticEventListener.java
+++ b/hartshorn-events/src/test/java/test/org/dockbox/hartshorn/events/listeners/StaticEventListener.java
@@ -16,11 +16,13 @@
 
 package test.org.dockbox.hartshorn.events.listeners;
 
-import test.org.dockbox.hartshorn.events.SampleEvent;
 import org.dockbox.hartshorn.events.annotations.Listener;
+
+import test.org.dockbox.hartshorn.events.SampleEvent;
 
 public final class StaticEventListener {
 
+    @SuppressWarnings({ "PublicField", "StaticNonFinalField" })
     public static boolean fired;
 
     private StaticEventListener() {}

--- a/hartshorn-hsl/hartshorn-hsl.gradle.kts
+++ b/hartshorn-hsl/hartshorn-hsl.gradle.kts
@@ -19,10 +19,7 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
+    api("org.dockbox.hartshorn:hartshorn-core")
 
     testImplementation("org.dockbox.hartshorn:hartshorn-introspect-reflection")
     testImplementation("org.dockbox.hartshorn:hartshorn-proxy-javassist")

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/customizer/ScriptContext.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/customizer/ScriptContext.java
@@ -150,6 +150,7 @@ public class ScriptContext extends DefaultApplicationAwareContext implements Res
                 .map(result -> (T) result);
     }
 
+    @Override
     public void clear() {
         this.results.clear();
     }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Interpreter.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Interpreter.java
@@ -881,7 +881,8 @@ public class Interpreter implements ExpressionVisitor<Object>, StatementVisitor<
                 constructor = new VirtualFunction(statement.constructor(), this.variableScope(), true);
             }
 
-            final Map<String, FieldStatement> fields = statement.fields().stream().collect(Collectors.toUnmodifiableMap(field -> field.name().lexeme(), f -> f));
+            final Map<String, FieldStatement> fields = statement.fields().stream()
+                    .collect(Collectors.toUnmodifiableMap(field -> field.name().lexeme(), field -> field));
 
             final VirtualClass virtualClass = new VirtualClass(statement.name().lexeme(),
                     superClassReference, constructor, this.variableScope(),

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Interpreter.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Interpreter.java
@@ -1048,15 +1048,15 @@ public class Interpreter implements ExpressionVisitor<Object>, StatementVisitor<
         return true;
     }
 
-    private boolean isEqual(final Object a, final Object b) {
-        if (a == null && b == null) return true;
-        if (a == null) return false;
-        if (a instanceof Number na && b instanceof Number nb) {
-            final BigDecimal ba = BigDecimal.valueOf(na.doubleValue());
-            final BigDecimal bb = BigDecimal.valueOf(nb.doubleValue());
-            return ba.compareTo(bb) == 0;
+    private boolean isEqual(final Object left, final Object right) {
+        if (left == null && right == null) return true;
+        if (left == null) return false;
+        if (left instanceof Number numberLeft && right instanceof Number numberRight) {
+            final BigDecimal decimalLeft = BigDecimal.valueOf(numberLeft.doubleValue());
+            final BigDecimal decimalRight = BigDecimal.valueOf(numberRight.doubleValue());
+            return decimalLeft.compareTo(decimalRight) == 0;
         }
-        return a.equals(b);
+        return left.equals(right);
     }
 
     private Object unwrap(final Object object) {

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/lexer/Lexer.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/lexer/Lexer.java
@@ -361,8 +361,8 @@ public class Lexer {
         return this.current >= this.source.length();
     }
 
-    private boolean isDigit(final char c) {
-        return c >= '0' && c <= '9';
+    private boolean isDigit(final char character) {
+        return character >= '0' && character <= '9';
     }
 
     private boolean match(final char expected) {
@@ -383,14 +383,14 @@ public class Lexer {
         return this.source.charAt(this.current + 1);
     }
 
-    private boolean isAlpha(final char c) {
-        return (c >= 'a' && c <= 'z') ||
-                (c >= 'A' && c <= 'Z') ||
-                c == '_';
+    private boolean isAlpha(final char character) {
+        return (character >= 'a' && character <= 'z') ||
+                (character >= 'A' && character <= 'Z') ||
+                character == '_';
     }
 
-    private boolean isAlphaNumeric(final char c) {
-        return this.isAlpha(c) || this.isDigit(c);
+    private boolean isAlphaNumeric(final char character) {
+        return this.isAlpha(character) || this.isDigit(character);
     }
 
     private void nextLine() {

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AmbiguousLibraryFunction.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AmbiguousLibraryFunction.java
@@ -22,54 +22,28 @@ import org.dockbox.hartshorn.hsl.objects.InstanceReference;
 import org.dockbox.hartshorn.hsl.runtime.RuntimeError;
 import org.dockbox.hartshorn.hsl.token.Token;
 import org.dockbox.hartshorn.util.ApplicationException;
-import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
 import java.util.List;
 import java.util.Set;
 
-public class AmbiguousLibraryFunction implements CallableNode {
-
-    private final Set<HslLibrary> libraries;
-
-    public AmbiguousLibraryFunction(final Set<HslLibrary> libraries) {
-        this.libraries = libraries;
-    }
-
-    public Set<HslLibrary> libraries() {
-        return this.libraries;
-    }
+public record AmbiguousLibraryFunction(Set<HslLibrary> libraries) implements CallableNode {
 
     @Override
-    public Object call(final Token at, final Interpreter interpreter, final InstanceReference instance, final List<Object> arguments) throws ApplicationException {
+    public Object call(final Token at, final Interpreter interpreter, final InstanceReference instance, final List<Object> arguments)
+            throws ApplicationException {
         final List<HslLibrary> applicableLibraries = this.libraries.stream()
                 .filter(library -> library.declaration().params().size() == arguments.size())
                 .toList();
 
-        if (applicableLibraries.isEmpty()) {
+        if(applicableLibraries.isEmpty()) {
             throw new RuntimeError(at, "No applicable library found for " + arguments.size() + " arguments");
         }
-        else if (applicableLibraries.size() > 1) {
+        else if(applicableLibraries.size() > 1) {
             throw new RuntimeError(at, "Multiple applicable libraries found for " + arguments.size() + " arguments");
         }
         else {
             final HslLibrary library = applicableLibraries.get(0);
             return library.call(at, interpreter, instance, arguments);
         }
-    }
-
-    private boolean isApplicableFor(final HslLibrary library, final List<Object> arguments) {
-        if (library.declaration().params().size() != arguments.size()) {
-            return false;
-        }
-        final MethodView<?, ?> method = library.declaration().method();
-        final List<TypeView<?>> parameters = method.parameters().types();
-        for (int i = 0; i < parameters.size(); i++) {
-            final TypeView<?> parameter = parameters.get(i);
-            final Object argument = arguments.get(i);
-            if (argument == null && !parameter.isPrimitive()) continue;
-            if (!parameter.isParentOf(argument.getClass())) return false;
-        }
-        return true;
     }
 }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/NativeExecutionException.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/NativeExecutionException.java
@@ -27,8 +27,8 @@ import org.dockbox.hartshorn.util.ApplicationException;
  * @since 22.4
  */
 public class NativeExecutionException extends ApplicationException {
-    public NativeExecutionException(final String message, final Throwable e) {
-        super(message, e);
+    public NativeExecutionException(final String message, final Throwable cause) {
+        super(message, cause);
     }
 
     public NativeExecutionException(final String message) {

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExecutableLookup.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExecutableLookup.java
@@ -53,8 +53,8 @@ public class ExecutableLookup {
             return zeroParameterMethod.get();
         }
         final List<MethodView<T, ?>> methods = declaring.methods().all().stream()
-                .filter(m -> m.name().equals(function))
-                .filter(m -> m.parameters().count() == arguments.size())
+                .filter(method -> method.name().equals(function))
+                .filter(method -> method.parameters().count() == arguments.size())
                 .toList();
         if (methods.isEmpty()) {
             throw new RuntimeError(at, "Method '" + function + "' with " + arguments.size() + " parameters does not exist on external instance of type " + declaring.name());

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExternalFunction.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/objects/external/ExternalFunction.java
@@ -79,8 +79,8 @@ public class ExternalFunction extends AbstractFinalizable implements MethodRefer
             return zeroParameterMethod.get();
         }
         final List<MethodView<Object, ?>> methods = this.type.methods().all().stream()
-                .filter(m -> m.name().equals(this.methodName))
-                .filter(m -> m.parameters().count() == arguments.size())
+                .filter(method -> method.name().equals(this.methodName))
+                .filter(method -> method.parameters().count() == arguments.size())
                 .toList();
         if (methods.isEmpty()) {
             throw new RuntimeError(at, "Method '" + this.methodName + "' with " + arguments.size() + " parameters does not exist on external instance of type " + this.type.name());
@@ -106,7 +106,7 @@ public class ExternalFunction extends AbstractFinalizable implements MethodRefer
                 .mapError(error -> {
                     if (error instanceof ApplicationException ae) return ae;
                     return new ApplicationException(error);
-                }).map(o -> new ExternalInstance(o, interpreter.applicationContext().environment().introspect(o)))
+                }).map(object -> new ExternalInstance(object, interpreter.applicationContext().environment().introspect(object)))
                 .orNull();
     }
 

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/expression/ComplexExpressionParser.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/expression/ComplexExpressionParser.java
@@ -83,16 +83,16 @@ public class ComplexExpressionParser {
             final Token equals = this.parser.previous();
             final Expression value = this.parse();
 
-            if (expr instanceof VariableExpression) {
-                final Token name = ((VariableExpression) expr).name();
+            if (expr instanceof VariableExpression variableExpression) {
+                final Token name = variableExpression.name();
                 return new AssignExpression(name, value);
             }
             else if (expr instanceof final ArrayGetExpression arrayGetExpression) {
                 final Token name = arrayGetExpression.name();
                 return new ArraySetExpression(name, arrayGetExpression.index(), value);
             }
-            else if (expr instanceof final GetExpression get) {
-                return new SetExpression(get.object(), get.name(), value);
+            else if (expr instanceof final GetExpression getExpression) {
+                return new SetExpression(getExpression.object(), getExpression.name(), value);
             }
             throw new ScriptEvaluationError("Invalid assignment target.", Phase.PARSING, equals);
         }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/expression/ComplexExpressionParser.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/expression/ComplexExpressionParser.java
@@ -63,7 +63,7 @@ public class ComplexExpressionParser {
     private final TokenStepValidator validator;
 
     private static final int MAX_NUM_OF_ARGUMENTS = 8;
-    private static final TokenType[] ASSIGNMENT_TOKENS = allTokensMatching(t -> t.assignsWith() != null);
+    private static final TokenType[] ASSIGNMENT_TOKENS = allTokensMatching(token -> token.assignsWith() != null);
 
     public ComplexExpressionParser(final TokenParser parser, final TokenStepValidator validator) {
         this.parser = parser;

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/ClassStatementParser.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/ClassStatementParser.java
@@ -105,7 +105,7 @@ public class ClassStatementParser implements ASTNodeParser<ClassStatement> {
     private <T extends Statement> T handleDelegate(final TokenParser parser, final TokenStepValidator validator,
                                                    final Option<ASTNodeParser<T>> statement) {
         return statement
-                .flatMap(p -> p.parse(parser, validator))
+                .flatMap(nodeParser -> nodeParser.parse(parser, validator))
                 .attempt(ScriptEvaluationError.class)
                 .rethrow()
                 .orNull();

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/runtime/AbstractScriptRuntime.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/runtime/AbstractScriptRuntime.java
@@ -35,6 +35,7 @@ import org.dockbox.hartshorn.hsl.token.Token;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -154,21 +155,21 @@ public class AbstractScriptRuntime extends ExpressionConditionContext implements
         }
     }
 
-    protected void handleScriptEvaluationError(final ScriptContext context, final ScriptEvaluationError e) {
+    protected void handleScriptEvaluationError(final ScriptContext context, final ScriptEvaluationError error) {
         final String source = context.source();
-        final Phase phase = e.phase();
-        final int line = e.line();
-        final int column = e.column();
+        final Phase phase = error.phase();
+        final int line = error.line();
+        final int column = error.column();
 
         final StringBuilder sb = new StringBuilder();
-        sb.append(e.getMessage());
-        if (e.getMessage().trim().endsWith(".")) {
+        sb.append(error.getMessage());
+        if (error.getMessage().trim().endsWith(".")) {
             sb.append(" While ");
         }
         else {
             sb.append(" while ");
         }
-        sb.append(phase.name().toLowerCase());
+        sb.append(phase.name().toLowerCase(Locale.ROOT));
         if (line <= -1 || column <= -1) {
             sb.append(" (outside source).");
         }
@@ -192,10 +193,10 @@ public class AbstractScriptRuntime extends ExpressionConditionContext implements
             message = "%s\n%s\n%s".formatted(message, lineText, marker);
         }
 
-        final ScriptEvaluationError error = new ScriptEvaluationError(e.getCause(), message, phase, e.at(), line, column);
+        final ScriptEvaluationError evaluationError = new ScriptEvaluationError(error.getCause(), message, phase, error.at(), line, column);
         // We only want to customize the error message, not the stack trace, so we
         // keep the original stack trace.
-        error.setStackTrace(e.getStackTrace());
-        throw error;
+        evaluationError.setStackTrace(evaluationError.getStackTrace());
+        throw evaluationError;
     }
 }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/visitors/StatementVisitor.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/visitors/StatementVisitor.java
@@ -16,7 +16,29 @@
 
 package org.dockbox.hartshorn.hsl.visitors;
 
-import org.dockbox.hartshorn.hsl.ast.statement.*;
+import org.dockbox.hartshorn.hsl.ast.statement.BlockStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.BreakStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ClassStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ConstructorStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ContinueStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.DoWhileStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ExpressionStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ExtensionStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.FieldStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ForEachStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ForStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.FunctionStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.IfStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ModuleStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.NativeFunctionStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.PrintStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.RepeatStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.ReturnStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.SwitchCase;
+import org.dockbox.hartshorn.hsl.ast.statement.SwitchStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.TestStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.VariableStatement;
+import org.dockbox.hartshorn.hsl.ast.statement.WhileStatement;
 
 /**
  * Visitor interface for all supported {@link org.dockbox.hartshorn.hsl.ast.statement.Statement}s.

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/LexerTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/LexerTests.java
@@ -96,7 +96,7 @@ public class LexerTests {
         final Field field = TokenConstants.class.getField(name);
         // Should be static and public
         final char constant = (char) field.get(null);
-        Assertions.assertEquals("" + constant, type.representation());
+        Assertions.assertEquals(String.valueOf(constant), type.representation());
     }
 
     @ParameterizedTest

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ScriptRuntimeTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ScriptRuntimeTests.java
@@ -55,7 +55,7 @@ public class ScriptRuntimeTests {
 
     public static Stream<Arguments> scripts() throws IOException {
         final Path resources = Paths.get("src", "test", "resources");
-        return Files.find(resources, 5, (p, bfa) -> bfa.isRegularFile() && p.getFileName().toString().endsWith(".hsl")).map(Arguments::of);
+        return Files.find(resources, 5, (path, attributes) -> attributes.isRegularFile() && path.getFileName().toString().endsWith(".hsl")).map(Arguments::of);
     }
 
     public static Stream<Arguments> phases() {

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ScriptRuntimeTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ScriptRuntimeTests.java
@@ -165,9 +165,9 @@ public class ScriptRuntimeTests {
 
         final Map<String, Object> results = context.interpreter().global();
         Assertions.assertFalse(results.isEmpty());
-        Assertions.assertEquals(12d, results.get("a"));
-        Assertions.assertEquals(13d, results.get("b"));
-        Assertions.assertEquals(25d, results.get("c"));
+        Assertions.assertEquals(12.0d, results.get("a"));
+        Assertions.assertEquals(13.0d, results.get("b"));
+        Assertions.assertEquals(25.0d, results.get("c"));
     }
 
     @ParameterizedTest

--- a/hartshorn-i18n/hartshorn-i18n.gradle.kts
+++ b/hartshorn-i18n/hartshorn-i18n.gradle.kts
@@ -19,11 +19,7 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-config")
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
+    api("org.dockbox.hartshorn:hartshorn-config")
 
     testImplementation("org.dockbox.hartshorn:hartshorn-config-jackson")
     testImplementation("org.dockbox.hartshorn:hartshorn-introspect-reflection")

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
@@ -112,7 +112,7 @@ public class DefaultTranslationBundle implements TranslationBundle {
         final ObjectMapper objectMapper = this.applicationContext.get(ObjectMapper.class).fileType(fileFormat);
         final Map<String, String> result = objectMapper.flat(source).entrySet()
                 .stream()
-                .collect(Collectors.toMap(Entry::getKey, e -> String.valueOf(e.getValue())));
+                .collect(Collectors.toMap(Entry::getKey, value -> String.valueOf(value.getValue())));
         return this.register(result, locale);
     }
 

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
@@ -43,10 +43,12 @@ public class DefaultTranslationBundle implements TranslationBundle {
     private ApplicationContext applicationContext;
     private Locale primaryLanguage = Locale.getDefault();
 
+    @Override
     public Locale primaryLanguage() {
         return this.primaryLanguage;
     }
 
+    @Override
     public DefaultTranslationBundle primaryLanguage(final Locale primaryLanguage) {
         this.primaryLanguage = primaryLanguage;
         return this;

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectMethodInterceptor.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectMethodInterceptor.java
@@ -1,0 +1,39 @@
+package org.dockbox.hartshorn.i18n.services;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.component.processing.proxy.MethodProxyContext;
+import org.dockbox.hartshorn.i18n.Message;
+import org.dockbox.hartshorn.i18n.TranslationService;
+import org.dockbox.hartshorn.i18n.annotations.InjectTranslation;
+import org.dockbox.hartshorn.proxy.MethodInterceptor;
+import org.dockbox.hartshorn.proxy.MethodInterceptorContext;
+import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
+
+public class TranslationInjectMethodInterceptor<T, R> implements MethodInterceptor<T, R> {
+    private final ApplicationContext context;
+    private final String key;
+    private final InjectTranslation annotation;
+    private final ConversionService conversionService;
+    private final MethodProxyContext<T> methodContext;
+
+    public TranslationInjectMethodInterceptor(final ApplicationContext context, final String key,
+                                              final InjectTranslation annotation, final ConversionService conversionService,
+                                              final MethodProxyContext<T> methodContext) {
+        this.context = context;
+        this.key = key;
+        this.annotation = annotation;
+        this.conversionService = conversionService;
+        this.methodContext = methodContext;
+    }
+
+    @Override
+    public R intercept(final MethodInterceptorContext<T, R> interceptorContext) {
+        // Prevents NPE when formatting cached resources without arguments
+        final Object[] args = interceptorContext.args();
+        final Object[] objects = null == args ? TranslationInjectPostProcessor.EMPTY_ARGS : args;
+        final Message message = this.context.get(TranslationService.class).getOrCreate(this.key, this.annotation.value()).format(objects);
+
+        //noinspection unchecked
+        return (R) this.conversionService.convert(message, this.methodContext.method().returnType().type());
+    }
+}

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectMethodInterceptor.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectMethodInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.i18n.services;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectPostProcessor.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectPostProcessor.java
@@ -19,7 +19,6 @@ package org.dockbox.hartshorn.i18n.services;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.i18n.Message;
-import org.dockbox.hartshorn.i18n.TranslationService;
 import org.dockbox.hartshorn.i18n.annotations.InjectTranslation;
 import org.dockbox.hartshorn.proxy.MethodInterceptor;
 import org.dockbox.hartshorn.component.processing.proxy.MethodProxyContext;
@@ -38,15 +37,7 @@ public class TranslationInjectPostProcessor extends ServiceAnnotatedMethodInterc
         final InjectTranslation annotation = methodContext.method().annotations().get(InjectTranslation.class).get();
         final ConversionService conversionService = context.get(ConversionService.class);
 
-        return interceptorContext -> {
-            // Prevents NPE when formatting cached resources without arguments
-            final Object[] args = interceptorContext.args();
-            final Object[] objects = null == args ? EMPTY_ARGS : args;
-            final Message message = context.get(TranslationService.class).getOrCreate(key, annotation.value()).format(objects);
-
-            //noinspection unchecked
-            return (R) conversionService.convert(message, methodContext.method().returnType().type());
-        };
+        return new TranslationInjectMethodInterceptor<>(context, key, annotation, conversionService, methodContext);
     }
 
     @Override

--- a/hartshorn-i18n/src/test/java/test/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
+++ b/hartshorn-i18n/src/test/java/test/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
@@ -168,7 +168,7 @@ public final class TranslationBatchGenerator {
         final File batch = TranslationBatchGenerator.existingBatch();
         if (batch.exists() && batch.isDirectory()) {
             return Stream.of(batch.listFiles())
-                    .filter(f -> !f.isDirectory())
+                    .filter(file -> !file.isDirectory())
                     .toList();
         }
         else {

--- a/hartshorn-introspect/hartshorn-introspect-reflection/hartshorn-introspect-reflection.gradle.kts
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/hartshorn-introspect-reflection.gradle.kts
@@ -19,9 +19,8 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    implementation("org.dockbox.hartshorn:hartshorn-discovery")
+    api("org.dockbox.hartshorn:hartshorn-introspect")
+    api("org.dockbox.hartshorn:hartshorn-discovery")
 
     testImplementation(testFixtures(project(":hartshorn-introspect")))
     testImplementation("org.dockbox.hartshorn:hartshorn-proxy")

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionElementAnnotationsIntrospector.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionElementAnnotationsIntrospector.java
@@ -63,7 +63,7 @@ public class ReflectionElementAnnotationsIntrospector implements ElementAnnotati
     @Override
     public Set<Annotation> annotedWith(final Class<? extends Annotation> annotation) {
         return this.all().stream()
-                .filter(a -> this.introspector.introspect(a.annotationType()).annotations().has(annotation))
+                .filter(presentAnnotation -> this.introspector.introspect(presentAnnotation.annotationType()).annotations().has(annotation))
                 .collect(Collectors.toSet());
     }
 

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionElementModifiersIntrospector.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionElementModifiersIntrospector.java
@@ -141,6 +141,6 @@ public class ReflectionElementModifiersIntrospector implements ElementModifiersI
 
     @Override
     public boolean isDefault() {
-        return member instanceof Method method && method.isDefault();
+        return this.member instanceof Method method && method.isDefault();
     }
 }

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionIntrospector.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionIntrospector.java
@@ -121,12 +121,12 @@ public class ReflectionIntrospector implements Introspector {
 
     @Override
     public MethodView<?, ?> introspect(final Method method) {
-        return this.methodViewCache.computeIfAbsent(method, _0 -> new ReflectionMethodView<>(this, method));
+        return this.methodViewCache.computeIfAbsent(method, key0 -> new ReflectionMethodView<>(this, method));
     }
 
     @Override
     public <T> ConstructorView<T> introspect(final Constructor<T> method) {
-        return (ConstructorView<T>) this.constructorViewCache.computeIfAbsent(method, _0 -> new ReflectionConstructorView<>(this, method));
+        return (ConstructorView<T>) this.constructorViewCache.computeIfAbsent(method, key0 -> new ReflectionConstructorView<>(this, method));
     }
 
     @Override

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionTypeMethodsIntrospector.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionTypeMethodsIntrospector.java
@@ -53,8 +53,8 @@ public class ReflectionTypeMethodsIntrospector<T> implements TypeMethodsIntrospe
         final List<Method> methods = List.of(this.type.type().getMethods());
         if (!this.type.superClass().isVoid()) {
             final List<Method> superClassMethods = this.type.superClass().methods().all().stream()
-                    .filter(m -> m.isPublic() || m.isProtected())
-                    .flatMap(m -> m.method().stream())
+                    .filter(method -> method.modifiers().isPublic() || method.modifiers().isProtected())
+                    .flatMap(method -> method.method().stream())
                     .toList();
             allMethods.addAll(superClassMethods);
         }

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionExecutableElementView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionExecutableElementView.java
@@ -40,7 +40,7 @@ public abstract class ReflectionExecutableElementView<Parent> extends Reflection
     private ExecutableParametersIntrospector parametersIntrospector;
     private TypeVariablesIntrospector typeVariablesIntrospector;
 
-    public ReflectionExecutableElementView(final ReflectionIntrospector introspector, final Executable executable) {
+    protected ReflectionExecutableElementView(final ReflectionIntrospector introspector, final Executable executable) {
         super(introspector);
         this.executable = executable;
         this.introspector = introspector;

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionFieldView.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionFieldView.java
@@ -16,12 +16,6 @@
 
 package org.dockbox.hartshorn.util.introspect.reflect.view;
 
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
 import org.dockbox.hartshorn.util.introspect.ElementModifiersIntrospector;
 import org.dockbox.hartshorn.util.introspect.IllegalIntrospectionException;
@@ -35,6 +29,12 @@ import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Attempt;
 import org.dockbox.hartshorn.util.option.Option;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 public class ReflectionFieldView<Parent, FieldType> extends ReflectionAnnotatedElementView implements FieldView<Parent, FieldType>, ReflectionModifierCarrierView {
 
@@ -96,7 +96,7 @@ public class ReflectionFieldView<Parent, FieldType> extends ReflectionAnnotatedE
                 final Option<MethodView<Parent, ?>> method = this.declaredBy().methods().named(getter);
                 final MethodView<Parent, ?> methodContext = method.orElseThrow(() -> new IllegalIntrospectionException(this, "Getter for field '" + this.name() + "' (" + getter + ") does not exist!"));
                 this.getter = object -> methodContext.invoke(instance)
-                        .map(o -> this.type().cast(o));
+                        .map(result -> this.type().cast(result));
             } else {
                 this.getter = object -> Attempt.of(() -> {
                     try {

--- a/hartshorn-introspect/hartshorn-introspect.gradle.kts
+++ b/hartshorn-introspect/hartshorn-introspect.gradle.kts
@@ -23,6 +23,6 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-util")
+    api("org.dockbox.hartshorn:hartshorn-util")
     testImplementation("org.dockbox.hartshorn:hartshorn-proxy-javassist")
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/annotations/CompositeAnnotationInvocationException.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/annotations/CompositeAnnotationInvocationException.java
@@ -26,7 +26,7 @@ public class CompositeAnnotationInvocationException extends ApplicationRuntimeEx
         super("Can't invoke " + type.getName() + "." + method.getName() + "() on composite annotation " + annotation);
     }
 
-    public CompositeAnnotationInvocationException(final Class<?> type, final Method method, final Annotation annotation, final Throwable e) {
-        super("Can't invoke " + type.getName() + "." + method.getName() + "() on composite annotation " + annotation, e);
+    public CompositeAnnotationInvocationException(final Class<?> type, final Method method, final Annotation annotation, final Throwable cause) {
+        super("Can't invoke " + type.getName() + "." + method.getName() + "() on composite annotation " + annotation, cause);
     }
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/annotations/VirtualHierarchyAnnotationLookup.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/annotations/VirtualHierarchyAnnotationLookup.java
@@ -111,11 +111,11 @@ public class VirtualHierarchyAnnotationLookup implements AnnotationLookup {
     private record HierarchyKey(AnnotatedElement element, Class<? extends Annotation> annotationType) {
 
         @Override
-            public boolean equals(final Object o) {
-                if (this == o) return true;
-                if (o == null || this.getClass() != o.getClass()) return false;
-                final HierarchyKey that = (HierarchyKey) o;
-                return Objects.equals(this.element, that.element) && Objects.equals(this.annotationType, that.annotationType);
+            public boolean equals(final Object other) {
+                if (this == other) return true;
+                if (other == null || this.getClass() != other.getClass()) return false;
+                final HierarchyKey key = (HierarchyKey) other;
+                return Objects.equals(this.element, key.element) && Objects.equals(this.annotationType, key.annotationType);
             }
 
     }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/Converter.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/Converter.java
@@ -55,8 +55,8 @@ public interface Converter<I, O> {
      * @param <T> the type of output of the {@code after} converter, and of the composed converter
      */
     default <T> Converter<I, T> andThen(final Converter<O, T> after) {
-        return (final I i) -> {
-            final O result = this.convert(i);
+        return (final I input) -> {
+            final O result = this.convert(input);
             return result != null ? after.convert(result) : null;
         };
     }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/ArrayToCollectionConverterFactory.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/ArrayToCollectionConverterFactory.java
@@ -25,6 +25,7 @@ import org.dockbox.hartshorn.util.introspect.convert.DefaultValueProviderFactory
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 
 public class ArrayToCollectionConverterFactory implements ConverterFactory<Object[], Collection<?>> {
 
@@ -39,21 +40,16 @@ public class ArrayToCollectionConverterFactory implements ConverterFactory<Objec
         return new ArrayToCollectionConverter<>(this.collectionFactory.create(targetType));
     }
 
-    private static class ArrayToCollectionConverter<O extends Collection<?>> implements Converter<Object[], O> {
-
-        private final DefaultValueProvider<O> helperProvider;
-
-        private ArrayToCollectionConverter(final DefaultValueProvider<O> helperProvider) {
-            this.helperProvider = helperProvider;
-        }
+    private record ArrayToCollectionConverter<O extends Collection<?>>(DefaultValueProvider<O> helperProvider)
+            implements Converter<Object[], O> {
 
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        @Override
-        public O convert(final Object @Nullable [] source) {
-            assert source != null;
-            final Collection collection = this.helperProvider.defaultValue();
-            collection.addAll(Arrays.asList(source));
-            return (O) collection;
+            @Override
+            public O convert(final Object @Nullable [] source) {
+                assert source != null;
+                final Collection collection = this.helperProvider.defaultValue();
+                Objects.requireNonNull(collection).addAll(Arrays.asList(source));
+                return (O) collection;
+            }
         }
-    }
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/CollectionToCollectionConverterFactory.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/CollectionToCollectionConverterFactory.java
@@ -16,13 +16,14 @@
 
 package org.dockbox.hartshorn.util.introspect.convert.support;
 
+import java.util.Collection;
+import java.util.Objects;
+
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.ConverterFactory;
 import org.dockbox.hartshorn.util.introspect.convert.DefaultValueProvider;
 import org.dockbox.hartshorn.util.introspect.convert.DefaultValueProviderFactory;
-
-import java.util.Collection;
 
 public class CollectionToCollectionConverterFactory implements ConverterFactory<Collection<?>, Collection<?>> {
 
@@ -55,7 +56,7 @@ public class CollectionToCollectionConverterFactory implements ConverterFactory<
         public O convert(final Collection<?> source) {
             //noinspection unchecked
             final Collection<Object> collection = (Collection<Object>) this.defaultValueProvider.defaultValue();
-            collection.addAll(source);
+            Objects.requireNonNull(collection).addAll(source);
             return this.targetType.cast(collection);
         }
     }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/ObjectToCollectionConverterFactory.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/ObjectToCollectionConverterFactory.java
@@ -42,20 +42,15 @@ public class ObjectToCollectionConverterFactory implements ConverterFactory<Obje
         return new ObjectToCollectionConverter<>(converter);
     }
 
-    private static class ObjectToCollectionConverter<O extends Collection<?>> implements Converter<Object, O> {
-
-        private final Converter<Object[], O> helperConverter;
-
-        public ObjectToCollectionConverter(final Converter<Object[], O> helperConverter) {
-            this.helperConverter = helperConverter;
-        }
+    private record ObjectToCollectionConverter<O extends Collection<?>>(Converter<Object[], O> helperConverter)
+            implements Converter<Object, O> {
 
         @Override
-        public O convert(final @Nullable Object source) {
-            assert source != null;
-            final Object[] array = (Object[]) Array.newInstance(source.getClass(), 1);
-            array[0] = source;
-            return this.helperConverter.convert(array);
+            public O convert(final @Nullable Object source) {
+                assert source != null;
+                final Object[] array = (Object[]) Array.newInstance(source.getClass(), 1);
+                array[0] = source;
+                return this.helperConverter.convert(array);
+            }
         }
-    }
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/OptionToObjectConverterFactory.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/OptionToObjectConverterFactory.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.util.introspect.convert.support;
 
+import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.convert.ConditionalConverter;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.ConverterFactory;
@@ -25,13 +26,17 @@ public class OptionToObjectConverterFactory implements ConverterFactory<Option<?
 
     @Override
     public <O> Converter<Option<?>, O> create(final Class<O> targetType) {
-        return input -> input.map(targetType::cast).orNull();
+        return input -> input.map(result -> (O) result).orNull();
     }
 
     @Override
     public boolean canConvert(final Object source, final Class<?> targetType) {
-        final Option<?> option = (Option<?>) source;
-        final Object value = option.orNull();
-        return value == null || targetType.isAssignableFrom(value.getClass());
+        if (source instanceof Option<?> option) {
+            final Object value = option.orNull();
+
+            if (value == null) return true;
+            return TypeUtils.isAssignable(value.getClass(), targetType);
+        }
+        return false;
     }
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/OptionalToObjectConverter.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/OptionalToObjectConverter.java
@@ -17,15 +17,28 @@
 package org.dockbox.hartshorn.util.introspect.convert.support;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.util.TypeUtils;
+import org.dockbox.hartshorn.util.introspect.convert.ConditionalConverter;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 
 import java.util.Optional;
 
-public class OptionalToObjectConverter implements Converter<Optional<?>, Object> {
+public class OptionalToObjectConverter implements Converter<Optional<?>, Object>, ConditionalConverter {
 
     @Override
     public @Nullable Object convert(final @Nullable Optional<?> input) {
         assert input != null;
         return input.orElse(null);
+    }
+
+    @Override
+    public boolean canConvert(final Object source, final Class<?> targetType) {
+        if (source instanceof Optional<?> optional) {
+            final Object value = optional.orElse(null);
+
+            if (value == null) return true;
+            return TypeUtils.isAssignable(value.getClass(), targetType);
+        }
+        return false;
     }
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/StringToEnumConverterFactory.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/StringToEnumConverterFactory.java
@@ -29,25 +29,19 @@ public class StringToEnumConverterFactory implements ConverterFactory<String, En
     }
 
     @SuppressWarnings("unchecked")
-    private static class StringToEnumConverter<T extends Enum> implements Converter<String, T> {
-
-        private final Class<T> enumType;
-
-        private StringToEnumConverter(final Class<T> enumType) {
-            this.enumType = enumType;
-        }
+    private record StringToEnumConverter<T extends Enum>(Class<T> enumType) implements Converter<String, T> {
 
         @Override
         public @Nullable T convert(final @Nullable String source) {
             assert source != null;
-            if (source.isEmpty()) {
+            if(source.isEmpty()) {
                 return null;
             }
             try {
                 final Enum value = Enum.valueOf(this.enumType, source.trim());
                 return this.enumType.cast(value);
             }
-            catch (final IllegalArgumentException e) {
+            catch(final IllegalArgumentException e) {
                 return null;
             }
         }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/StringToNumberConverterFactory.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/StringToNumberConverterFactory.java
@@ -52,33 +52,26 @@ public class StringToNumberConverterFactory implements ConverterFactory<String, 
         return (Converter<String, O>) converter;
     }
 
-    private static class StringToNumberConverter<T extends Number> implements Converter<String, T> {
-
-        private final Function<String, T> parseFunction;
-        private final Function<String, T> decodeFunction;
-
-        public StringToNumberConverter(final Function<String, T> parseFunction, final Function<String, T> decodeFunction) {
-            this.parseFunction = parseFunction;
-            this.decodeFunction = decodeFunction;
-        }
+    private record StringToNumberConverter<T extends Number>(Function<String, T> parseFunction, Function<String, T> decodeFunction)
+            implements Converter<String, T> {
 
         @Override
-        public @Nullable T convert(final @Nullable String input) {
-            assert input != null;
-            try {
-                if (isHexNumber(input)) {
-                    return this.decodeFunction.apply(input);
+            public @Nullable T convert(final @Nullable String input) {
+                assert input != null;
+                try {
+                    if(isHexNumber(input)) {
+                        return this.decodeFunction.apply(input);
+                    }
+                    else {
+                        return this.parseFunction.apply(input);
+                    }
                 }
-                else {
-                    return this.parseFunction.apply(input);
+                catch(final NumberFormatException e) {
+                    // If primitive, the conversion service will default to zero
+                    return null;
                 }
-            }
-            catch (final NumberFormatException e) {
-                // If primitive, the conversion service will default to zero
-                return null;
             }
         }
-    }
 
     public static boolean isHexNumber(final String value) {
         final int index = value.startsWith("-") ? 1 : 0;

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/ClassNameReference.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/ClassNameReference.java
@@ -51,10 +51,10 @@ public class ClassNameReference implements TypeReference {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof final ClassNameReference that)) return false;
-        return this.name.equals(that.name);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (!(other instanceof final ClassNameReference reference)) return false;
+        return this.name.equals(reference.name);
     }
 
     @Override

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/PredefinedSetTypeReferenceCollector.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/PredefinedSetTypeReferenceCollector.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class PredefinedSetTypeReferenceCollector implements TypeReferenceCollector {
+public final class PredefinedSetTypeReferenceCollector implements TypeReferenceCollector {
 
     private final Set<TypeReference> references;
 

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/TypeReferenceCollectorContext.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/TypeReferenceCollectorContext.java
@@ -16,14 +16,11 @@
 
 package org.dockbox.hartshorn.util.introspect.scan;
 
-import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.context.DefaultContext;
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
 import org.dockbox.hartshorn.reporting.Reportable;
-import org.dockbox.hartshorn.util.option.Option;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ClassPathScanner {
+public final class ClassPathScanner {
 
     private final Set<String> classNames = new HashSet<>();
     private final Set<ClassLoader> classLoaders = new HashSet<>();

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
@@ -56,7 +56,7 @@ public class ClassPathScanner {
             return this;
         }
 
-        for (final String path : value.split("" + File.pathSeparatorChar, -1)) {
+        for (final String path : value.split(String.valueOf(File.pathSeparatorChar), -1)) {
             if (path == null || path.trim().isEmpty()) continue;
             final File file = new File(path);
             if (!file.exists()) continue;

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
@@ -20,6 +20,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.FileSystem;
@@ -69,7 +71,7 @@ public final class ClassPathScanner {
                     }
                 });
             }
-            catch (final Exception e) {
+            catch (final MalformedURLException e) {
                 // Ignore
             }
         }
@@ -123,19 +125,19 @@ public final class ClassPathScanner {
             final FileSystem fileSystem = FileSystems.newFileSystem(Paths.get(url.toURI()), (ClassLoader) null);
             Files.walkFileTree(fileSystem.getRootDirectories().iterator().next(), new JarFileWalker(this, handler, classLoader));
         }
-        catch (final Exception e) {
+        catch (final IOException | URISyntaxException e) {
             throw new ClassPathWalkingException("Error while scanning jar file " + jarFile, e);
         }
     }
 
-    private void processDirectoryResource(final ResourceHandler handler, final URLClassLoader classLoader, final File directory) {
+    private void processDirectoryResource(final ResourceHandler handler, final URLClassLoader classLoader, final File directory) throws ClassPathWalkingException {
         try {
             final File rootDir = directory.getCanonicalFile();
             final int rootDirNameLen = rootDir.getCanonicalPath().length();
             Files.walkFileTree(rootDir.toPath(), new DirectoryFileTreeWalker(this, rootDirNameLen, handler, classLoader));
         }
         catch (final IOException e) {
-            throw new RuntimeException(e);
+            throw new ClassPathWalkingException("Could not process directory resource " + directory.getPath(), e);
         }
     }
 

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClasspathTypeReferenceCollector.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClasspathTypeReferenceCollector.java
@@ -33,7 +33,7 @@ public abstract class ClasspathTypeReferenceCollector implements TypeReferenceCo
     private final String packageName;
     private final Set<TypeReference> cache = ConcurrentHashMap.newKeySet();
 
-    public ClasspathTypeReferenceCollector(final String packageName) {
+    protected ClasspathTypeReferenceCollector(final String packageName) {
         this.packageName = packageName;
     }
 

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClasspathTypeReferenceCollector.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClasspathTypeReferenceCollector.java
@@ -53,10 +53,10 @@ public abstract class ClasspathTypeReferenceCollector implements TypeReferenceCo
     protected abstract Set<TypeReference> createCache() throws TypeCollectionException;
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof final ClasspathTypeReferenceCollector that)) return false;
-        return this.packageName.equals(that.packageName);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (!(other instanceof final ClasspathTypeReferenceCollector collector)) return false;
+        return this.packageName.equals(collector.packageName);
     }
 
     @Override

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/AnnotatedElementView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/AnnotatedElementView.java
@@ -35,20 +35,4 @@ public interface AnnotatedElementView extends View {
      */
     ElementAnnotationsIntrospector annotations();
 
-    /**
-     * Returns the simple name of the element. For example, if the element is a field, this
-     * method will return the field's name, without further qualification.
-     *
-     * @return the simple name of the element
-     */
-    String name();
-
-    /**
-     * Returns the qualified name of the element. For example, if the element is a field,
-     * this method will return the field's name, qualified by the declaring class.
-     *
-     * @return the qualified name of the element
-     */
-    String qualifiedName();
-
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/ModifierCarrierView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/ModifierCarrierView.java
@@ -27,7 +27,7 @@ public interface ModifierCarrierView extends View {
      */
     @Deprecated(forRemoval = true, since = "23.1")
     default boolean isPublic() {
-        return this.has(AccessModifier.PUBLIC);
+        return this.modifiers().isPublic();
     }
 
     /**
@@ -36,7 +36,7 @@ public interface ModifierCarrierView extends View {
      */
     @Deprecated(forRemoval = true, since = "23.1")
     default boolean isProtected() {
-        return this.has(AccessModifier.PROTECTED);
+        return this.modifiers().isProtected();
     }
 
     /**
@@ -45,7 +45,7 @@ public interface ModifierCarrierView extends View {
      */
     @Deprecated(forRemoval = true, since = "23.1")
     default boolean isPrivate() {
-        return this.has(AccessModifier.PRIVATE);
+        return this.modifiers().isPrivate();
     }
 
     /**

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/PackageView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/PackageView.java
@@ -17,5 +17,6 @@
 package org.dockbox.hartshorn.util.introspect.view;
 
 public interface PackageView extends View {
+    @Override
     String name();
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/View.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/View.java
@@ -21,6 +21,12 @@ import org.dockbox.hartshorn.util.Named;
 
 public interface View extends Named, Reportable {
 
+    /**
+     * Returns the qualified name of the element. For example, if the element is a field,
+     * this method will return the field's name, qualified by the declaring class.
+     *
+     * @return the qualified name of the element
+     */
     String qualifiedName();
 
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/WildcardIntrospectorTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/WildcardIntrospectorTests.java
@@ -27,7 +27,7 @@ public class WildcardIntrospectorTests {
 
     @Test
     void testWildcardIsParentChildAndEqual() {
-        final WildcardTypeView view = new WildcardTypeView();
+        final TypeView<Object> view = new WildcardTypeView();
 
         Assertions.assertTrue(view.isParentOf(Object.class));
         Assertions.assertTrue(view.isChildOf(Object.class));

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
@@ -66,7 +66,7 @@ public class CollectionFactoryTests {
 
     @Test
     public void testCreateCollectionWithEnumSet() {
-        CollectionFactory factory = this.createFactory(EnumSet.class, () -> null);
+        final CollectionFactory factory = this.createFactory(EnumSet.class, () -> null);
         final EnumSet<Color> enumSet = factory.createCollection(EnumSet.class, Color.class, 2);
         Assertions.assertTrue(enumSet instanceof EnumSet);
         Assertions.assertEquals(enumSet.size(), 0);
@@ -74,7 +74,7 @@ public class CollectionFactoryTests {
 
     @Test
     public void testCreateCollectionWithUnsupportedInterface() {
-        CollectionFactory factory = this.createFactory(BeanContext.class, () -> null);
+        final CollectionFactory factory = this.createFactory(BeanContext.class, () -> null);
         Assertions.assertThrows(IllegalArgumentException.class, () -> factory.createCollection(BeanContext.class, Integer.class, 0));
     }
 

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
@@ -38,28 +38,28 @@ public class CollectionFactoryTests {
 
     @Test
     public void testCreateCollectionWithArrayList() {
-        final List<Integer> list = createDefaultFactory().createCollection(List.class, Integer.class, 10);
+        final List<Integer> list = this.createDefaultFactory().createCollection(List.class, Integer.class, 10);
         Assertions.assertTrue(list instanceof ArrayList);
         Assertions.assertEquals(list.size(), 0);
     }
 
     @Test
     public void testCreateCollectionWithHashSet() {
-        final Set<String> set = createDefaultFactory().createCollection(Set.class, String.class, 5);
+        final Set<String> set = this.createDefaultFactory().createCollection(Set.class, String.class, 5);
         Assertions.assertTrue(set instanceof HashSet);
         Assertions.assertEquals(set.size(), 0);
     }
 
     @Test
     public void testCreateCollectionWithTreeSet() {
-        final SortedSet<Double> sortedSet = createDefaultFactory().createCollection(SortedSet.class, Double.class, 3);
+        final SortedSet<Double> sortedSet = this.createDefaultFactory().createCollection(SortedSet.class, Double.class, 3);
         Assertions.assertTrue(sortedSet instanceof TreeSet);
         Assertions.assertEquals(sortedSet.size(), 0);
     }
 
     @Test
     public void testCreateCollectionWithLinkedList() {
-        final Queue<Boolean> queue = createDefaultFactory().createCollection(Queue.class, Boolean.class, 7);
+        final Queue<Boolean> queue = this.createDefaultFactory().createCollection(Queue.class, Boolean.class, 7);
         Assertions.assertTrue(queue instanceof LinkedList);
         Assertions.assertEquals(queue.size(), 0);
     }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToCollectionConverterFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToCollectionConverterFactoryTests.java
@@ -36,8 +36,8 @@ public class ObjectToCollectionConverterFactoryTests {
         final Object converted = converter.convert(element);
         Assertions.assertNotNull(converted);
         Assertions.assertTrue(converted instanceof Set);
-        Assertions.assertEquals(1, ((Set) converted).size());
-        Assertions.assertEquals(element, ((Set) converted).iterator().next());
+        Assertions.assertEquals(1, ((Collection) converted).size());
+        Assertions.assertEquals(element, ((Iterable) converted).iterator().next());
     }
 
     @Test
@@ -47,8 +47,8 @@ public class ObjectToCollectionConverterFactoryTests {
         final Object converted = converter.convert(element);
         Assertions.assertNotNull(converted);
         Assertions.assertTrue(converted instanceof Set);
-        Assertions.assertEquals(1, ((Set) converted).size());
-        Assertions.assertEquals(element, ((Set) converted).iterator().next());
+        Assertions.assertEquals(1, ((Collection) converted).size());
+        Assertions.assertEquals(element, ((Iterable) converted).iterator().next());
     }
 
     private static Converter<Object, Set> createConverter() {

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionToObjectConverterFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionToObjectConverterFactoryTests.java
@@ -17,6 +17,7 @@
 package test.org.dockbox.hartshorn.introspect.convert;
 
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
+import org.dockbox.hartshorn.util.introspect.convert.ConverterFactory;
 import org.dockbox.hartshorn.util.introspect.convert.support.OptionToObjectConverterFactory;
 import org.dockbox.hartshorn.util.option.Option;
 import org.junit.jupiter.api.Assertions;
@@ -26,7 +27,7 @@ public class OptionToObjectConverterFactoryTests {
 
     @Test
     void testPresentOptionConvertsToObject() {
-        final OptionToObjectConverterFactory factory = new OptionToObjectConverterFactory();
+        final ConverterFactory<Option<?>, Object> factory = new OptionToObjectConverterFactory();
         final Converter<Option<?>, String> converter = factory.create(String.class);
         final Option<String> option = Option.of("test");
         final String converted = converter.convert(option);
@@ -36,7 +37,7 @@ public class OptionToObjectConverterFactoryTests {
 
     @Test
     void testEmptyOptionConvertsToNull() {
-        final OptionToObjectConverterFactory factory = new OptionToObjectConverterFactory();
+        final ConverterFactory<Option<?>, Object> factory = new OptionToObjectConverterFactory();
         final Converter<Option<?>, String> converter = factory.create(String.class);
         final Option<String> option = Option.empty();
         final String converted = converter.convert(option);

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/PrimitiveWrapperConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/PrimitiveWrapperConverterTests.java
@@ -44,19 +44,19 @@ public class PrimitiveWrapperConverterTests {
     @Test
     void testDoubleToWrapperCanConvert() {
         final GenericConverter converter = new PrimitiveWrapperConverter();
-        final Object converted = converter.convert(1D, double.class, Double.class);
+        final Object converted = converter.convert(1.0D, double.class, Double.class);
         Assertions.assertNotNull(converted);
         Assertions.assertTrue(converted instanceof Double);
-        Assertions.assertEquals(1D, converted);
+        Assertions.assertEquals(1.0D, converted);
     }
 
     @Test
     void testFloatToWrapperCanConvert() {
         final GenericConverter converter = new PrimitiveWrapperConverter();
-        final Object converted = converter.convert(1F, float.class, Float.class);
+        final Object converted = converter.convert(1.0F, float.class, Float.class);
         Assertions.assertNotNull(converted);
         Assertions.assertTrue(converted instanceof Float);
-        Assertions.assertEquals(1F, converted);
+        Assertions.assertEquals(1.0F, converted);
     }
 
     @Test
@@ -116,19 +116,19 @@ public class PrimitiveWrapperConverterTests {
     @Test
     void testWrapperToDoubleCanConvert() {
         final PrimitiveWrapperConverter converter = new PrimitiveWrapperConverter();
-        Assertions.assertTrue(converter.canConvert(Double.valueOf(1D), double.class));
+        Assertions.assertTrue(converter.canConvert(Double.valueOf(1.0D), double.class));
 
-        final double converted = (double) converter.convert(Double.valueOf(1D), Double.class, double.class);
-        Assertions.assertEquals(1D, converted);
+        final double converted = (double) converter.convert(Double.valueOf(1.0D), Double.class, double.class);
+        Assertions.assertEquals(1.0D, converted);
     }
 
     @Test
     void testWrapperToFloatCanConvert() {
         final PrimitiveWrapperConverter converter = new PrimitiveWrapperConverter();
-        Assertions.assertTrue(converter.canConvert(Float.valueOf(1F), float.class));
+        Assertions.assertTrue(converter.canConvert(Float.valueOf(1.0F), float.class));
 
-        final float converted = (float) converter.convert(Float.valueOf(1F), Float.class, float.class);
-        Assertions.assertEquals(1F, converted);
+        final float converted = (float) converter.convert(Float.valueOf(1.0F), Float.class, float.class);
+        Assertions.assertEquals(1.0F, converted);
     }
 
     @Test

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/PrimitiveWrapperConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/PrimitiveWrapperConverterTests.java
@@ -155,7 +155,7 @@ public class PrimitiveWrapperConverterTests {
         Assertions.assertTrue(converter.canConvert(Boolean.TRUE, boolean.class));
 
         final boolean converted = (boolean) converter.convert(Boolean.TRUE, Boolean.class, boolean.class);
-        Assertions.assertEquals(true, converted);
+        Assertions.assertTrue(converted);
     }
 
     @Test

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToBooleanConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToBooleanConverterTests.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class StringToBooleanConverterTests {
-    // TODO: Implement tests for StringToBooleanConverter
-
 
     @Test
     void testTrueCanConvert() {

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToNumberConverterFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToNumberConverterFactoryTests.java
@@ -48,7 +48,7 @@ public class StringToNumberConverterFactoryTests {
         final Converter<String, Float> converter = factory.create(Float.class);
         final Float converted = converter.convert("1");
         Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1F, converted);
+        Assertions.assertEquals(1.0F, converted);
     }
 
     @Test
@@ -57,7 +57,7 @@ public class StringToNumberConverterFactoryTests {
         final Converter<String, Double> converter = factory.create(Double.class);
         final Double converted = converter.convert("1");
         Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1D, converted);
+        Assertions.assertEquals(1.0D, converted);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class StringToNumberConverterFactoryTests {
         final Converter<String, Float> converter = factory.create(Float.class);
         final Float converted = converter.convert("-1");
         Assertions.assertNotNull(converted);
-        Assertions.assertEquals(-1F, converted);
+        Assertions.assertEquals(-1.0F, converted);
     }
 
     @Test
@@ -111,7 +111,7 @@ public class StringToNumberConverterFactoryTests {
         final Converter<String, Double> converter = factory.create(Double.class);
         final Double converted = converter.convert("-1");
         Assertions.assertNotNull(converted);
-        Assertions.assertEquals(-1D, converted);
+        Assertions.assertEquals(-1.0D, converted);
     }
 
     @Test
@@ -204,7 +204,7 @@ public class StringToNumberConverterFactoryTests {
         final Converter<String, Float> converter = factory.create(Float.class);
         final Float converted = converter.convert("0x1");
         Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1F, converted);
+        Assertions.assertEquals(1.0F, converted);
     }
 
     @Test
@@ -213,7 +213,7 @@ public class StringToNumberConverterFactoryTests {
         final Converter<String, Double> converter = factory.create(Double.class);
         final Double converted = converter.convert("0x1");
         Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1D, converted);
+        Assertions.assertEquals(1.0D, converted);
     }
 
     @Test
@@ -258,7 +258,7 @@ public class StringToNumberConverterFactoryTests {
         final Converter<String, Float> converter = factory.create(Float.class);
         final Float converted = converter.convert("01");
         Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1F, converted);
+        Assertions.assertEquals(1.0F, converted);
     }
 
     @Test
@@ -267,7 +267,7 @@ public class StringToNumberConverterFactoryTests {
         final Converter<String, Double> converter = factory.create(Double.class);
         final Double converted = converter.convert("01");
         Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1D, converted);
+        Assertions.assertEquals(1.0D, converted);
     }
 
     @Test

--- a/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
+++ b/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
@@ -168,7 +168,7 @@ public abstract class IntrospectorTests {
     @Test
     void testStaticFieldsReturnsAllModifiers() {
         final List<FieldView<ReflectTestType, ?>> fields = this.introspector().introspect(ReflectTestType.class).fields().all().stream()
-                .filter(FieldView::isStatic)
+                .filter(field -> field.modifiers().isStatic())
                 .toList();
         Assertions.assertEquals(2, fields.size());
     }
@@ -328,7 +328,7 @@ public abstract class IntrospectorTests {
         Assertions.assertEquals(2, fields.size());
         int statics = 0;
         for (final FieldView<ReflectTestType, ?> field : fields) {
-            if (field.isStatic()) statics++;
+            if (field.modifiers().isStatic()) statics++;
         }
         Assertions.assertEquals(1, statics);
     }
@@ -413,7 +413,7 @@ public abstract class IntrospectorTests {
     @Test
     void concreteClassIsCorrectlyIdentified() {
         final TypeView<ConcreteClass> type = this.introspector().introspect(ConcreteClass.class);
-        Assertions.assertFalse(type.isAbstract());
+        Assertions.assertFalse(type.modifiers().isAbstract());
         Assertions.assertFalse(type.isInterface());
         Assertions.assertFalse(type.isRecord());
         Assertions.assertFalse(type.isEnum());
@@ -423,7 +423,7 @@ public abstract class IntrospectorTests {
     @Test
     void abstractClassIsCorrectlyIdentified() {
         final TypeView<AbstractClass> type = this.introspector().introspect(AbstractClass.class);
-        Assertions.assertTrue(type.isAbstract());
+        Assertions.assertTrue(type.modifiers().isAbstract());
         Assertions.assertFalse(type.isInterface());
         Assertions.assertFalse(type.isRecord());
         Assertions.assertFalse(type.isEnum());
@@ -433,7 +433,7 @@ public abstract class IntrospectorTests {
     @Test
     void interfaceIsCorrectlyIdentified() {
         final TypeView<Interface> type = this.introspector().introspect(Interface.class);
-        Assertions.assertTrue(type.isAbstract());
+        Assertions.assertTrue(type.modifiers().isAbstract());
         Assertions.assertTrue(type.isInterface());
         Assertions.assertFalse(type.isRecord());
         Assertions.assertFalse(type.isEnum());
@@ -443,7 +443,7 @@ public abstract class IntrospectorTests {
     @Test
     void recordIsCorrectlyIdentified() {
         final TypeView<RecordType> type = this.introspector().introspect(RecordType.class);
-        Assertions.assertFalse(type.isAbstract());
+        Assertions.assertFalse(type.modifiers().isAbstract());
         Assertions.assertFalse(type.isInterface());
         Assertions.assertTrue(type.isRecord());
         Assertions.assertFalse(type.isEnum());
@@ -453,7 +453,7 @@ public abstract class IntrospectorTests {
     @Test
     void enumIsCorrectlyIdentified() {
         final TypeView<EnumType> type = this.introspector().introspect(EnumType.class);
-        Assertions.assertFalse(type.isAbstract());
+        Assertions.assertFalse(type.modifiers().isAbstract());
         Assertions.assertFalse(type.isInterface());
         Assertions.assertFalse(type.isRecord());
         Assertions.assertTrue(type.isEnum());
@@ -463,7 +463,7 @@ public abstract class IntrospectorTests {
     @Test
     void annotationIsCorrectlyIdentified() {
         final TypeView<AnnotationType> type = this.introspector().introspect(AnnotationType.class);
-        Assertions.assertTrue(type.isAbstract());
+        Assertions.assertTrue(type.modifiers().isAbstract());
         Assertions.assertTrue(type.isInterface());
         Assertions.assertFalse(type.isRecord());
         Assertions.assertFalse(type.isEnum());

--- a/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
+++ b/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
@@ -386,7 +386,7 @@ public abstract class IntrospectorTests {
     public void genericTestMethod(final List<List<String>> nestedGeneric) { }
 
     @SuppressWarnings("unused") // Used by testWildcardsWithUpperBounds
-    public void methodWithWildcardUpperbounds(final List<? extends String> list) { }
+    public void methodWithWildcardUpperbounds(final List<String> list) { }
 
     @Test
     void testWildcardsWithUpperBounds() {

--- a/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/convert/ConversionServiceTests.java
+++ b/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/convert/ConversionServiceTests.java
@@ -169,7 +169,7 @@ public abstract class ConversionServiceTests {
     @Test
     void testCollectionFromObject() {
         final ConversionService conversionService = this.conversionService();
-        final LinkedList<?> linkedList = conversionService.convert("test", LinkedList.class);
+        final List<?> linkedList = conversionService.convert("test", LinkedList.class);
         Assertions.assertNotNull(linkedList);
         Assertions.assertFalse(linkedList.isEmpty());
         Assertions.assertEquals("test", linkedList.get(0));

--- a/hartshorn-jpa/hartshorn-jpa-hibernate/hartshorn-jpa-hibernate.gradle.kts
+++ b/hartshorn-jpa/hartshorn-jpa-hibernate/hartshorn-jpa-hibernate.gradle.kts
@@ -19,12 +19,7 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-config")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    implementation("org.dockbox.hartshorn:hartshorn-jpa")
+    api("org.dockbox.hartshorn:hartshorn-jpa")
 
     implementation(libs.bundles.hibernate)
 

--- a/hartshorn-jpa/hartshorn-jpa-hibernate/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateJpaRepository.java
+++ b/hartshorn-jpa/hartshorn-jpa-hibernate/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateJpaRepository.java
@@ -55,6 +55,7 @@ public class HibernateJpaRepository<T, ID> extends EntityManagerJpaRepository<T,
         this.connection = connection;
     }
 
+    @Override
     public ApplicationContext applicationContext() {
         return this.applicationContext;
     }

--- a/hartshorn-jpa/hartshorn-jpa.gradle.kts
+++ b/hartshorn-jpa/hartshorn-jpa.gradle.kts
@@ -19,12 +19,7 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-config")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-
+    api("org.dockbox.hartshorn:hartshorn-config")
     api(libs.bundles.hibernate)
 
     // Test Containers

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaParameterLoaderContext.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaParameterLoaderContext.java
@@ -18,8 +18,7 @@ package org.dockbox.hartshorn.jpa;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.util.ApplicationBoundParameterLoaderContext;
-import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 
 import jakarta.persistence.Query;
 
@@ -27,8 +26,9 @@ public class JpaParameterLoaderContext extends ApplicationBoundParameterLoaderCo
 
     private final Query query;
 
-    public JpaParameterLoaderContext(final MethodView<?, ?> method, final TypeView<?> type, final Object instance, final ApplicationContext applicationContext, final Query query) {
-        super(method, instance, applicationContext);
+    public JpaParameterLoaderContext(final ExecutableElementView<?> element, final Object instance,
+                                     final ApplicationContext applicationContext, final Query query) {
+        super(element, instance, applicationContext);
         this.query = query;
     }
 

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/PersistenceProviders.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/PersistenceProviders.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.jpa;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.processing.Binds;
+import org.dockbox.hartshorn.component.processing.ProcessingOrder;
 import org.dockbox.hartshorn.jpa.annotations.UsePersistence;
 import org.dockbox.hartshorn.jpa.entitymanager.EntityManagerLookup;
 import org.dockbox.hartshorn.jpa.entitymanager.EntityTypeLookup;
@@ -49,7 +50,7 @@ public class PersistenceProviders {
         return new ProxyAttachedEntityManagerLookup();
     }
 
-    @Binds(phase = -128)
+    @Binds(phase = ProcessingOrder.EARLY)
     public EntityTypeLookup entityTypeLookup() {
         return new JpaEntityTypeLookup();
     }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/entitymanager/MissingEntityManagerException.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/entitymanager/MissingEntityManagerException.java
@@ -17,11 +17,12 @@
 package org.dockbox.hartshorn.jpa.entitymanager;
 
 import org.dockbox.hartshorn.util.ApplicationRuntimeException;
-import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 
 public class MissingEntityManagerException extends ApplicationRuntimeException {
-    public MissingEntityManagerException(final MethodView<?,?> methodContext) {
-        super("No entity manager found in execution cache for method %s in type %s."
-                .formatted(methodContext.qualifiedName(), methodContext.declaredBy().name()));
+
+    public MissingEntityManagerException(final ExecutableElementView<?> elementView) {
+        super("No entity manager found in execution cache for executable %s in type %s."
+                .formatted(elementView.qualifiedName(), elementView.declaredBy().name()));
     }
 }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/ExecuteQueryMethodInterceptor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/ExecuteQueryMethodInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.jpa.query;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/ExecuteQueryMethodInterceptor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/ExecuteQueryMethodInterceptor.java
@@ -1,0 +1,48 @@
+package org.dockbox.hartshorn.jpa.query;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.jpa.query.context.JpaQueryContext;
+import org.dockbox.hartshorn.jpa.query.context.JpaQueryContextCreator;
+import org.dockbox.hartshorn.proxy.MethodInterceptor;
+import org.dockbox.hartshorn.proxy.MethodInterceptorContext;
+import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+
+import jakarta.persistence.EntityManager;
+
+public class ExecuteQueryMethodInterceptor<T, R> implements MethodInterceptor<T, R> {
+
+    private final JpaQueryContextCreator contextCreator;
+    private final ApplicationContext context;
+    private final TypeView<?> entityType;
+    private final MethodView<T, ?> method;
+    private final QueryExecutor function;
+    private final ConversionService conversionService;
+
+    public ExecuteQueryMethodInterceptor(final JpaQueryContextCreator contextCreator, final ApplicationContext context,
+                                         final TypeView<?> entityType, final MethodView<T, ?> method,
+                                         final QueryExecutor function, final ConversionService conversionService) {
+        this.contextCreator = contextCreator;
+        this.context = context;
+        this.entityType = entityType;
+        this.method = method;
+        this.function = function;
+        this.conversionService = conversionService;
+    }
+
+    @Override
+    public R intercept(final MethodInterceptorContext<T, R> interceptorContext) throws Throwable {
+        final T persistenceCapable = interceptorContext.instance();
+        final JpaQueryContext jpaQueryContext = this.contextCreator.create(this.context, interceptorContext, this.entityType, persistenceCapable)
+                .orElseThrow(() -> new IllegalStateException("No JPA query context found for method " + this.method));
+
+        final EntityManager entityManager = jpaQueryContext.entityManager();
+        if (jpaQueryContext.automaticFlush() && entityManager.getTransaction().isActive())
+            entityManager.flush();
+
+        final Object result = this.function.execute(jpaQueryContext);
+        //noinspection unchecked
+        return (R) this.conversionService.convert(result, this.method.returnType().type());
+    }
+}

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryPostProcessor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryPostProcessor.java
@@ -25,7 +25,6 @@ import org.dockbox.hartshorn.jpa.annotations.NamedQuery;
 import org.dockbox.hartshorn.jpa.annotations.Query;
 import org.dockbox.hartshorn.jpa.annotations.Query.QueryType;
 import org.dockbox.hartshorn.jpa.entitymanager.EntityTypeLookup;
-import org.dockbox.hartshorn.jpa.query.context.JpaQueryContext;
 import org.dockbox.hartshorn.jpa.query.context.JpaQueryContextCreator;
 import org.dockbox.hartshorn.proxy.MethodInterceptor;
 import org.dockbox.hartshorn.component.processing.proxy.MethodProxyContext;
@@ -39,8 +38,6 @@ import org.dockbox.hartshorn.util.option.Attempt;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
-
-import jakarta.persistence.EntityManager;
 
 public class QueryPostProcessor extends ServiceMethodInterceptorPostProcessor {
 
@@ -76,19 +73,7 @@ public class QueryPostProcessor extends ServiceMethodInterceptorPostProcessor {
         final JpaQueryContextCreator contextCreator = context.get(JpaQueryContextCreator.class);
         final ConversionService conversionService = context.get(ConversionService.class);
 
-        return interceptorContext -> {
-            final T persistenceCapable = interceptorContext.instance();
-            final JpaQueryContext jpaQueryContext = contextCreator.create(context, interceptorContext, entityType, persistenceCapable)
-                    .orElseThrow(() -> new IllegalStateException("No JPA query context found for method " + method));
-
-            final EntityManager entityManager = jpaQueryContext.entityManager();
-            if (jpaQueryContext.automaticFlush() && entityManager.getTransaction().isActive())
-                entityManager.flush();
-
-            final Object result = function.execute(jpaQueryContext);
-            //noinspection unchecked
-            return (R) conversionService.convert(result, method.returnType().type());
-        };
+        return new ExecuteQueryMethodInterceptor<>(contextCreator, context, entityType, method, function, conversionService);
     }
 
     @NonNull

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryPostProcessor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/QueryPostProcessor.java
@@ -54,7 +54,7 @@ public class QueryPostProcessor extends ServiceMethodInterceptorPostProcessor {
         if (attempt.absent()) return Collections.emptyList();
 
         return processingContext.type().methods().declared().stream()
-                .filter(m -> attempt.get().supports(processingContext, m))
+                .filter(method -> attempt.get().supports(processingContext, method))
                 .collect(Collectors.toSet());
     }
 

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/AbstractJpaQueryContext.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/AbstractJpaQueryContext.java
@@ -104,17 +104,19 @@ public abstract class AbstractJpaQueryContext extends DefaultProvisionContext im
         if(environment.isProxy(this.persistenceCapable)) {
             environment.manager(this.persistenceCapable)
                     .flatMap(manager -> manager.first(QueryExecutionContext.class))
-                    .peek(queryExecutionContext -> {
-                        final LockModeType lockMode = queryExecutionContext.lockMode(this.method);
-                        if(lockMode != null) {
-                            persistenceQuery.setLockMode(lockMode);
-                        }
+                    .peek(queryExecutionContext -> this.configureExecutionContext(persistenceQuery, queryExecutionContext));
+        }
+    }
 
-                        final FlushModeType flushMode = queryExecutionContext.flushMode(this.method);
-                        if(flushMode != null) {
-                            persistenceQuery.setFlushMode(flushMode);
-                        }
-                    });
+    private void configureExecutionContext(final Query persistenceQuery, final QueryExecutionContext queryExecutionContext) {
+        final LockModeType lockMode = queryExecutionContext.lockMode(this.method);
+        if(lockMode != null) {
+            persistenceQuery.setLockMode(lockMode);
+        }
+
+        final FlushModeType flushMode = queryExecutionContext.flushMode(this.method);
+        if(flushMode != null) {
+            persistenceQuery.setFlushMode(flushMode);
         }
     }
 

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/AbstractJpaQueryContext.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/AbstractJpaQueryContext.java
@@ -93,7 +93,7 @@ public abstract class AbstractJpaQueryContext extends DefaultProvisionContext im
         this.modifyQueryFromContext(persistenceQuery);
 
         // Process parameters to modify query
-        final JpaParameterLoaderContext loaderContext = new JpaParameterLoaderContext(this.method, this.entityType, null, this.applicationContext, persistenceQuery);
+        final JpaParameterLoaderContext loaderContext = new JpaParameterLoaderContext(this.method, null, this.applicationContext, persistenceQuery);
         this.parameterLoader().loadArguments(loaderContext, this.args);
 
         return persistenceQuery;

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/AbstractJpaQueryContext.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/AbstractJpaQueryContext.java
@@ -101,16 +101,20 @@ public abstract class AbstractJpaQueryContext extends DefaultProvisionContext im
 
     protected void modifyQueryFromContext(final Query persistenceQuery) {
         final ApplicationEnvironment environment = this.applicationContext().environment();
-        if (environment.isProxy(this.persistenceCapable)) {
-            environment.manager(this.persistenceCapable).peek(manager -> {
-                manager.first(QueryExecutionContext.class).peek(queryExecutionContext -> {
-                    final LockModeType lockMode = queryExecutionContext.lockMode(this.method);
-                    if (lockMode != null) persistenceQuery.setLockMode(lockMode);
+        if(environment.isProxy(this.persistenceCapable)) {
+            environment.manager(this.persistenceCapable)
+                    .flatMap(manager -> manager.first(QueryExecutionContext.class))
+                    .peek(queryExecutionContext -> {
+                        final LockModeType lockMode = queryExecutionContext.lockMode(this.method);
+                        if(lockMode != null) {
+                            persistenceQuery.setLockMode(lockMode);
+                        }
 
-                    final FlushModeType flushMode = queryExecutionContext.flushMode(this.method);
-                    if (flushMode != null) persistenceQuery.setFlushMode(flushMode);
-                });
-            });
+                        final FlushModeType flushMode = queryExecutionContext.flushMode(this.method);
+                        if(flushMode != null) {
+                            persistenceQuery.setFlushMode(flushMode);
+                        }
+                    });
         }
     }
 

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/AggregateJpaQueryContextCreator.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/AggregateJpaQueryContextCreator.java
@@ -59,8 +59,8 @@ public class AggregateJpaQueryContextCreator implements JpaQueryContextCreator {
             }
 
             @Override
-            public int compareTo(@NonNull final PriorityEntry o) {
-                return Integer.compare(this.priority, o.priority);
+            public int compareTo(@NonNull final PriorityEntry other) {
+                return Integer.compare(this.priority, other.priority);
             }
         }
 }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/application/ApplicationNamedQueriesContext.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/application/ApplicationNamedQueriesContext.java
@@ -69,7 +69,7 @@ public class ApplicationNamedQueriesContext extends DefaultProvisionContext impl
     @Override
     public void report(final DiagnosticsPropertyCollector collector) {
         for (final Entry<String, ComponentNamedQueryContext> entry : this.namedQueries.entrySet()) {
-            collector.property(entry.getKey()).write(c -> entry.getValue().report(c));
+            collector.property(entry.getKey()).write(propertyCollector -> entry.getValue().report(propertyCollector));
         }
     }
 }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/unnamed/UnnamedJpaQueryContext.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/unnamed/UnnamedJpaQueryContext.java
@@ -22,7 +22,6 @@ import org.dockbox.hartshorn.jpa.annotations.Query.QueryType;
 import org.dockbox.hartshorn.jpa.query.QueryConstructor;
 import org.dockbox.hartshorn.jpa.query.QueryExecuteType;
 import org.dockbox.hartshorn.jpa.query.QueryExecuteTypeLookup;
-import org.dockbox.hartshorn.jpa.query.UnsupportedQueryTypeException;
 import org.dockbox.hartshorn.jpa.query.context.AbstractJpaQueryContext;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
@@ -65,7 +64,6 @@ public class UnnamedJpaQueryContext extends AbstractJpaQueryContext {
         return switch (queryType) {
             case JPQL -> queryConstructor.createJpqlQuery(query, this);
             case NATIVE -> queryConstructor.createNativeQuery(query, this);
-            default -> throw new UnsupportedQueryTypeException(queryType);
         };
     }
 }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/unnamed/UnnamedJpaQueryContext.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/unnamed/UnnamedJpaQueryContext.java
@@ -57,6 +57,7 @@ public class UnnamedJpaQueryContext extends AbstractJpaQueryContext {
         return this.applicationContext().get(QueryExecuteTypeLookup.class).lookup(this.annotation.value());
     }
 
+    @Override
     protected jakarta.persistence.Query persistenceQuery(final QueryConstructor queryConstructor, final EntityManager entityManager) throws IllegalArgumentException {
         final String query = this.annotation.value();
         final QueryType queryType = this.annotation.type();

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/transaction/TransactionalProxyCallbackPostProcessor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/transaction/TransactionalProxyCallbackPostProcessor.java
@@ -34,6 +34,7 @@ import org.dockbox.hartshorn.jpa.remote.DataSourceList;
 import org.dockbox.hartshorn.proxy.ProxyCallback;
 import org.dockbox.hartshorn.proxy.ProxyFactory;
 import org.dockbox.hartshorn.component.processing.proxy.PhasedProxyCallbackPostProcessor;
+import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.option.Option;
 
@@ -102,8 +103,8 @@ public class TransactionalProxyCallbackPostProcessor extends PhasedProxyCallback
         return this.performAndFlush(context, method, Transactional::rollbackOnError, TransactionManager::rollbackTransaction);
     }
 
-    private <T> ProxyCallback<T> performAndFlush(final ApplicationContext context, final MethodView<T, ?> method, final Predicate<Transactional> rule, final Consumer<TransactionManager> consumer) {
-        final Transactional annotation = method.annotations().get(Transactional.class).get();
+    private <T> ProxyCallback<T> performAndFlush(final ApplicationContext context, final AnnotatedElementView element, final Predicate<Transactional> rule, final Consumer<TransactionManager> consumer) {
+        final Transactional annotation = element.annotations().get(Transactional.class).get();
         final boolean ruleResult = rule.test(annotation);
 
         final ProxyCallback<T> flush = this.flushTarget();

--- a/hartshorn-jpa/src/testFixtures/java/test/org/dockbox/hartshorn/jpa/JpaRepositoryTests.java
+++ b/hartshorn-jpa/src/testFixtures/java/test/org/dockbox/hartshorn/jpa/JpaRepositoryTests.java
@@ -196,7 +196,7 @@ public abstract class JpaRepositoryTests implements DataSourceConfigurationLoade
 
         Assertions.assertTrue(delegate instanceof EntityManagerJpaRepository);
 
-        final EntityManagerCarrier entityJpaRepository = (EntityManagerJpaRepository<?, ?>) delegate;
+        final EntityManagerCarrier entityJpaRepository = (EntityManagerCarrier) delegate;
         final EntityManager em = entityJpaRepository.manager();
         Assertions.assertNotNull(em);
     }

--- a/hartshorn-jpa/src/testFixtures/java/test/org/dockbox/hartshorn/jpa/entity/UserWithNamedQuery.java
+++ b/hartshorn-jpa/src/testFixtures/java/test/org/dockbox/hartshorn/jpa/entity/UserWithNamedQuery.java
@@ -53,10 +53,10 @@ public class UserWithNamedQuery {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof final UserWithNamedQuery that)) return false;
-        return Objects.equals(this.name, that.name);
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (!(other instanceof final UserWithNamedQuery user)) return false;
+        return Objects.equals(this.name, user.name);
     }
 
     @Override

--- a/hartshorn-mvc/hartshorn-mvc-freemarker/hartshorn-mvc-freemarker.gradle.kts
+++ b/hartshorn-mvc/hartshorn-mvc-freemarker/hartshorn-mvc-freemarker.gradle.kts
@@ -19,10 +19,7 @@ apply {
 }
 
 dependencies {
-    api(libs.freemarker)
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-mvc")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
+    api("org.dockbox.hartshorn:hartshorn-mvc")
+
+    implementation(libs.freemarker)
 }

--- a/hartshorn-mvc/hartshorn-mvc.gradle.kts
+++ b/hartshorn-mvc/hartshorn-mvc.gradle.kts
@@ -19,15 +19,9 @@ apply {
 }
 
 dependencies {
-    api(libs.jakartaServlet)
+    api("org.dockbox.hartshorn:hartshorn-web")
 
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    implementation("org.dockbox.hartshorn:hartshorn-events")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-config")
-    implementation("org.dockbox.hartshorn:hartshorn-web")
+    implementation(libs.jakartaServlet)
 
     testImplementation(libs.httpclient)
     testImplementation("org.dockbox.hartshorn:hartshorn-config-jackson")

--- a/hartshorn-mvc/src/main/java/org/dockbox/hartshorn/web/mvc/MvcParameterLoaderContext.java
+++ b/hartshorn-mvc/src/main/java/org/dockbox/hartshorn/web/mvc/MvcParameterLoaderContext.java
@@ -17,8 +17,7 @@
 package org.dockbox.hartshorn.web.mvc;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 import org.dockbox.hartshorn.web.mvc.model.ViewModel;
 import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 
@@ -29,9 +28,11 @@ public class MvcParameterLoaderContext extends HttpRequestParameterLoaderContext
 
     private final ViewModel viewModel;
 
-    public MvcParameterLoaderContext(final MethodView<?, ?> method, final TypeView<?> type, final Object instance, final ApplicationContext applicationContext, final HttpServletRequest request, final HttpServletResponse response,
+    public MvcParameterLoaderContext(final ExecutableElementView<?> element, final Object instance,
+                                     final ApplicationContext applicationContext, final HttpServletRequest request,
+                                     final HttpServletResponse response,
                                      final ViewModel viewModel) {
-        super(method, type, instance, applicationContext, request, response);
+        super(element, instance, applicationContext, request, response);
         this.viewModel = viewModel;
     }
 

--- a/hartshorn-mvc/src/main/java/org/dockbox/hartshorn/web/mvc/MvcServlet.java
+++ b/hartshorn-mvc/src/main/java/org/dockbox/hartshorn/web/mvc/MvcServlet.java
@@ -65,7 +65,7 @@ public class MvcServlet implements WebServlet {
         final ParameterLoader<MvcParameterLoaderContext> loader = this.parameterLoader;
         final ViewModelImpl viewModel = new ViewModelImpl();
         final TypeView<ViewTemplate> typeView = this.applicationContext.environment().introspect(ViewTemplate.class);
-        final MvcParameterLoaderContext loaderContext = new MvcParameterLoaderContext(this.method, typeView,
+        final MvcParameterLoaderContext loaderContext = new MvcParameterLoaderContext(this.method,
                 null, this.applicationContext, req, res, viewModel);
         final List<Object> arguments = loader.loadArguments(loaderContext);
 

--- a/hartshorn-mvc/src/main/java/org/dockbox/hartshorn/web/mvc/ViewModelParameterRule.java
+++ b/hartshorn-mvc/src/main/java/org/dockbox/hartshorn/web/mvc/ViewModelParameterRule.java
@@ -24,7 +24,7 @@ import org.dockbox.hartshorn.web.mvc.model.ViewModel;
 public class ViewModelParameterRule implements ParameterLoaderRule<MvcParameterLoaderContext> {
 
     @Override
-    public boolean accepts(ParameterView<?> parameter, int index, MvcParameterLoaderContext context, Object... args) {
+    public boolean accepts(final ParameterView<?> parameter, final int index, final MvcParameterLoaderContext context, final Object... args) {
         return parameter.type().isChildOf(ViewModel.class);
     }
 

--- a/hartshorn-proxy/hartshorn-proxy-cglib/hartshorn-proxy-cglib.gradle.kts
+++ b/hartshorn-proxy/hartshorn-proxy-cglib/hartshorn-proxy-cglib.gradle.kts
@@ -20,10 +20,9 @@ apply {
 
 dependencies {
     implementation(libs.cglib)
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    implementation("org.dockbox.hartshorn:hartshorn-discovery")
+
+    api("org.dockbox.hartshorn:hartshorn-proxy")
+    api("org.dockbox.hartshorn:hartshorn-discovery")
 
     testImplementation(testFixtures(project(":hartshorn-proxy")))
     testImplementation("org.dockbox.hartshorn:hartshorn-introspect-reflection")

--- a/hartshorn-proxy/hartshorn-proxy-cglib/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibApplicationProxierLoader.java
+++ b/hartshorn-proxy/hartshorn-proxy-cglib/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibApplicationProxierLoader.java
@@ -21,6 +21,12 @@ import org.dockbox.hartshorn.proxy.ApplicationProxier;
 import org.dockbox.hartshorn.proxy.ApplicationProxierLoader;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 
+/**
+ * @deprecated CGLib is not actively maintained, and commonly causes issues with Java 9+.
+ *             It is recommended to use Javassist instead, through the
+ *             {@code org.dockbox.hartshorn.proxy.javassist.JavassistApplicationProxierLoader}.
+ */
+@Deprecated(since = "23.1")
 @ServiceLoader(ApplicationProxierLoader.class)
 public class CglibApplicationProxierLoader implements ApplicationProxierLoader {
     @Override

--- a/hartshorn-proxy/hartshorn-proxy-cglib/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibApplicationProxierLoader.java
+++ b/hartshorn-proxy/hartshorn-proxy-cglib/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibApplicationProxierLoader.java
@@ -24,7 +24,7 @@ import org.dockbox.hartshorn.util.introspect.Introspector;
 @ServiceLoader(ApplicationProxierLoader.class)
 public class CglibApplicationProxierLoader implements ApplicationProxierLoader {
     @Override
-    public ApplicationProxier create(Introspector introspector) {
+    public ApplicationProxier create(final Introspector introspector) {
         return new CglibApplicationProxier(introspector);
     }
 }

--- a/hartshorn-proxy/hartshorn-proxy-cglib/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyConstructorFunction.java
+++ b/hartshorn-proxy/hartshorn-proxy-cglib/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyConstructorFunction.java
@@ -19,7 +19,6 @@ package org.dockbox.hartshorn.proxy.cglib;
 import net.sf.cglib.proxy.Enhancer;
 
 import org.dockbox.hartshorn.proxy.ProxyConstructorFunction;
-import org.dockbox.hartshorn.util.ApplicationException;
 
 import java.lang.reflect.Constructor;
 
@@ -40,13 +39,13 @@ public class CglibProxyConstructorFunction<T> implements ProxyConstructorFunctio
     }
 
     @Override
-    public T create() throws ApplicationException {
+    public T create() {
         final Object instance = this.enhancer.create();
         return this.type.cast(instance);
     }
 
     @Override
-    public T create(final Constructor<T> constructor, final Object[] args) throws ApplicationException {
+    public T create(final Constructor<T> constructor, final Object[] args) {
         final Class<?>[] parameterTypes = constructor.getParameterTypes();
         final Object instance = this.enhancer.create(parameterTypes, args);
         return this.type.cast(instance);

--- a/hartshorn-proxy/hartshorn-proxy-cglib/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyFactory.java
+++ b/hartshorn-proxy/hartshorn-proxy-cglib/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyFactory.java
@@ -36,7 +36,7 @@ public class CglibProxyFactory<T> extends JDKInterfaceProxyFactory<T> {
 
     private static final NamingPolicy NAMING_POLICY = (prefix, className, key, names) -> nameGenerator.get(prefix);
 
-    public CglibProxyFactory(final Class<T> type, CglibApplicationProxier applicationProxier) {
+    public CglibProxyFactory(final Class<T> type, final CglibApplicationProxier applicationProxier) {
         super(type, applicationProxier);
     }
 

--- a/hartshorn-proxy/hartshorn-proxy-javassist/hartshorn-proxy-javassist.gradle.kts
+++ b/hartshorn-proxy/hartshorn-proxy-javassist/hartshorn-proxy-javassist.gradle.kts
@@ -20,10 +20,9 @@ apply {
 
 dependencies {
     implementation(libs.javassist)
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    implementation("org.dockbox.hartshorn:hartshorn-discovery")
+
+    api("org.dockbox.hartshorn:hartshorn-proxy")
+    api("org.dockbox.hartshorn:hartshorn-discovery")
 
     testImplementation(testFixtures(project(":hartshorn-proxy")))
     testImplementation("org.dockbox.hartshorn:hartshorn-introspect-reflection")

--- a/hartshorn-proxy/hartshorn-proxy-javassist/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistApplicationProxier.java
+++ b/hartshorn-proxy/hartshorn-proxy-javassist/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistApplicationProxier.java
@@ -22,11 +22,8 @@ import org.dockbox.hartshorn.util.introspect.Introspector;
 
 public class JavassistApplicationProxier extends AbstractApplicationProxier {
 
-    private final Introspector introspector;
-
     public JavassistApplicationProxier(final Introspector introspector) {
         super(introspector);
-        this.introspector = introspector;
         this.registerProxyLookup(new JavassistProxyLookup());
     }
 

--- a/hartshorn-proxy/hartshorn-proxy-javassist/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistApplicationProxierLoader.java
+++ b/hartshorn-proxy/hartshorn-proxy-javassist/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistApplicationProxierLoader.java
@@ -25,7 +25,7 @@ import org.dockbox.hartshorn.util.introspect.Introspector;
 public class JavassistApplicationProxierLoader implements ApplicationProxierLoader {
 
     @Override
-    public ApplicationProxier create(Introspector introspector) {
+    public ApplicationProxier create(final Introspector introspector) {
         return new JavassistApplicationProxier(introspector);
     }
 }

--- a/hartshorn-proxy/hartshorn-proxy.gradle.kts
+++ b/hartshorn-proxy/hartshorn-proxy.gradle.kts
@@ -33,8 +33,7 @@ tasks {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
+    api("org.dockbox.hartshorn:hartshorn-introspect")
 
     testImplementation(libs.scala)
     testImplementation(libs.groovy)

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/AbstractApplicationProxier.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/AbstractApplicationProxier.java
@@ -29,7 +29,7 @@ public abstract class AbstractApplicationProxier implements ApplicationProxier {
     private final Set<ProxyLookup> proxyLookups = ConcurrentHashMap.newKeySet();
     private final Introspector introspector;
 
-    public AbstractApplicationProxier(Introspector introspector) {
+    protected AbstractApplicationProxier(final Introspector introspector) {
         this.introspector = introspector;
         this.registerProxyLookup(new NativeProxyLookup());
         this.registerProxyLookup(new HartshornProxyLookup());

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/AbstractApplicationProxier.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/AbstractApplicationProxier.java
@@ -89,7 +89,7 @@ public abstract class AbstractApplicationProxier implements ApplicationProxier {
         return this.proxyLookups.stream().anyMatch(lookup -> lookup.isProxy(candidate));
     }
 
-    public void registerProxyLookup(final ProxyLookup proxyLookup) {
+    public final void registerProxyLookup(final ProxyLookup proxyLookup) {
         this.proxyLookups.add(proxyLookup);
     }
 }

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/DefaultProxyFactory.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/DefaultProxyFactory.java
@@ -16,6 +16,13 @@
 
 package org.dockbox.hartshorn.proxy;
 
+import org.dockbox.hartshorn.util.TypeUtils;
+import org.dockbox.hartshorn.util.collections.ConcurrentClassMap;
+import org.dockbox.hartshorn.util.collections.MultiMap;
+import org.dockbox.hartshorn.util.collections.StandardMultiMap.ConcurrentSetMultiMap;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -24,13 +31,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
-import org.dockbox.hartshorn.util.TypeUtils;
-import org.dockbox.hartshorn.util.collections.ConcurrentClassMap;
-import org.dockbox.hartshorn.util.collections.MultiMap;
-import org.dockbox.hartshorn.util.collections.StandardMultiMap.ConcurrentSetMultiMap;
-import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
 /**
  * The default implementation of {@link ProxyFactory}. This implementation is state-aware, as is suggested by its
@@ -221,23 +221,23 @@ public abstract class DefaultProxyFactory<T> implements StateAwareProxyFactory<T
 
     @Override
     public StateAwareProxyFactory<T> wrapAround(final MethodView<T, ?> method, final Consumer<MethodWrapperFactory<T>> wrapper) {
-        return method.method().map(m -> this.wrapAround(m, wrapper)).orElse(this);
+        return method.method().map(jlrMethod -> this.wrapAround(jlrMethod, wrapper)).orElse(this);
     }
 
 
     @Override
     public StateAwareProxyFactory<T> delegate(final MethodView<T, ?> method, final T delegate) {
-        return method.method().map(m -> this.delegate(m, delegate)).orElse(this);
+        return method.method().map(jlrMethod -> this.delegate(jlrMethod, delegate)).orElse(this);
     }
 
     @Override
     public <R> StateAwareProxyFactory<T> intercept(final MethodView<T, R> method, final MethodInterceptor<T, R> interceptor) {
-        return method.method().map(m -> this.intercept(m, interceptor)).orElse(this);
+        return method.method().map(jlrMethod -> this.intercept(jlrMethod, interceptor)).orElse(this);
     }
 
     @Override
     public StateAwareProxyFactory<T> wrapAround(final MethodView<T, ?> method, final MethodWrapper<T> wrapper) {
-        return method.method().map(m -> this.wrapAround(m, wrapper)).orElse(this);
+        return method.method().map(jlrMethod -> this.wrapAround(jlrMethod, wrapper)).orElse(this);
     }
 
     @Override

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/MethodInterceptorContext.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/MethodInterceptorContext.java
@@ -121,9 +121,9 @@ public class MethodInterceptorContext<T, R> {
     }
 
     @Deprecated
-    public R checkedCast(final Object o) {
+    public R checkedCast(final Object object) {
         if (this.method.returnType().isVoid()) return null;
-        else if (this.method.returnType().isInstance(o)) return this.method.returnType().cast(o);
-        else throw new UnsupportedOperationException("Cannot cast " + o.getClass().getName() + " to " + this.method.returnType().name() + ", use a ConversionService instance to convert the result.");
+        else if (this.method.returnType().isInstance(object)) return this.method.returnType().cast(object);
+        else throw new UnsupportedOperationException("Cannot cast " + object.getClass().getName() + " to " + this.method.returnType().name() + ", use a ConversionService instance to convert the result.");
     }
 }

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyConstructorFunction.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyConstructorFunction.java
@@ -17,11 +17,12 @@
 package org.dockbox.hartshorn.proxy;
 
 import org.dockbox.hartshorn.util.ApplicationException;
-import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 
 import java.lang.reflect.Constructor;
 
 public interface ProxyConstructorFunction<T> {
+
     T create() throws ApplicationException;
+
     T create(Constructor<T> constructor, Object[] args) throws ApplicationException;
 }

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyContextContainer.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyContextContainer.java
@@ -35,6 +35,7 @@ public class ProxyContextContainer extends DefaultContext {
     }
 
     // Change access level to public
+    @Override
     public MultiMap<String, Context> namedContexts() {
         return super.namedContexts();
     }

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/StandardMethodInterceptor.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/StandardMethodInterceptor.java
@@ -133,7 +133,7 @@ public class StandardMethodInterceptor<T> implements ProxyMethodInterceptor<T>, 
     }
 
     protected Object interceptWithoutDelegate(final T self, final T callbackTarget, final Invokable source, final Invokable proxy, final Object[] args) throws Throwable {
-        Option<Object> defaultMethod = this.tryInvokeDefaultMethod(self, source, args);
+        final Option<Object> defaultMethod = this.tryInvokeDefaultMethod(self, source, args);
         if (defaultMethod.present()) return defaultMethod.get();
 
         final Object result;
@@ -175,7 +175,7 @@ public class StandardMethodInterceptor<T> implements ProxyMethodInterceptor<T>, 
     }
 
     protected Object invokeDelegate(final Object delegate, final T self, final Invokable source, final Object[] args) throws Throwable {
-        Option<Object> defaultMethod = this.tryInvokeDefaultMethod(self, source, args);
+        final Option<Object> defaultMethod = this.tryInvokeDefaultMethod(self, source, args);
         if (defaultMethod.present()) return defaultMethod.get();
 
         final Object result = source.invoke(delegate, args);

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/StandardMethodInterceptor.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/StandardMethodInterceptor.java
@@ -223,7 +223,7 @@ public class StandardMethodInterceptor<T> implements ProxyMethodInterceptor<T>, 
     @Override
     public Object[] resolveArgs(final MethodInvokable method, final Object instance, final Object[] args) {
         final MethodView<?, ?> methodView = method.toIntrospector();
-        final ProxyParameterLoaderContext context = new ProxyParameterLoaderContext(methodView, instance, applicationProxier);
+        final ProxyParameterLoaderContext context = new ProxyParameterLoaderContext(methodView, instance, this.applicationProxier);
         return this.parameterLoader().loadArguments(context, args).toArray();
     }
 

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/StandardMethodWrapperFactory.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/StandardMethodWrapperFactory.java
@@ -26,24 +26,24 @@ public class StandardMethodWrapperFactory<T> implements MethodWrapperFactory<T> 
 
     private final ProxyFactory<T> factory;
 
-    public StandardMethodWrapperFactory(ProxyFactory<T> factory) {
+    public StandardMethodWrapperFactory(final ProxyFactory<T> factory) {
         this.factory = factory;
     }
 
     @Override
-    public MethodWrapperFactory<T> before(ProxyCallback<T> callback) {
+    public MethodWrapperFactory<T> before(final ProxyCallback<T> callback) {
         this.before = callback;
         return this;
     }
 
     @Override
-    public MethodWrapperFactory<T> after(ProxyCallback<T> callback) {
+    public MethodWrapperFactory<T> after(final ProxyCallback<T> callback) {
         this.after = callback;
         return this;
     }
 
     @Override
-    public MethodWrapperFactory<T> onError(ProxyCallback<T> callback) {
+    public MethodWrapperFactory<T> onError(final ProxyCallback<T> callback) {
         this.onError = callback;
         return this;
     }

--- a/hartshorn-proxy/src/testFixtures/java/test/org/dockbox/hartshorn/proxy/EqualInterfaceProxy.java
+++ b/hartshorn-proxy/src/testFixtures/java/test/org/dockbox/hartshorn/proxy/EqualInterfaceProxy.java
@@ -17,7 +17,7 @@
 package test.org.dockbox.hartshorn.proxy;
 
 public interface EqualInterfaceProxy {
-    default boolean test(final EqualInterfaceProxy o) {
-        return this.equals(o);
+    default boolean test(final EqualInterfaceProxy proxy) {
+        return this.equals(proxy);
     }
 }

--- a/hartshorn-proxy/src/testFixtures/java/test/org/dockbox/hartshorn/proxy/MethodStubTests.java
+++ b/hartshorn-proxy/src/testFixtures/java/test/org/dockbox/hartshorn/proxy/MethodStubTests.java
@@ -43,7 +43,7 @@ public abstract class MethodStubTests {
 
     @Test
     void testDefaultBehaviorIsDefaultOrNull() throws ApplicationException {
-        ApplicationProxier proxier = proxierLoader().create(this.introspector());
+        final ApplicationProxier proxier = this.proxierLoader().create(this.introspector());
         final ProxyFactory<StubbedInterfaceProxy> proxyFactory = proxier.factory(StubbedInterfaceProxy.class);
         final StubbedInterfaceProxy proxy = proxyFactory.proxy().get();
 
@@ -62,7 +62,7 @@ public abstract class MethodStubTests {
 
     @Test
     void testStubBehaviorCanBeChanged() throws ApplicationException {
-        final ProxyFactory<StubbedInterfaceProxy> proxyFactory = proxierLoader().create(this.introspector()).factory(StubbedInterfaceProxy.class);
+        final ProxyFactory<StubbedInterfaceProxy> proxyFactory = this.proxierLoader().create(this.introspector()).factory(StubbedInterfaceProxy.class);
 
         // Also verifies that the stub result is not cached
         final AtomicInteger integer = new AtomicInteger(0);
@@ -79,7 +79,7 @@ public abstract class MethodStubTests {
 
     @Test
     void testStubsAreObserved() throws ApplicationException, NoSuchMethodException {
-        final ProxyFactory<StubbedInterfaceProxy> proxyFactory = proxierLoader().create(this.introspector()).factory(StubbedInterfaceProxy.class);
+        final ProxyFactory<StubbedInterfaceProxy> proxyFactory = this.proxierLoader().create(this.introspector()).factory(StubbedInterfaceProxy.class);
 
         final AtomicBoolean beforeObserved = new AtomicBoolean(false);
         final AtomicBoolean afterObserved = new AtomicBoolean(false);

--- a/hartshorn-proxy/src/testFixtures/java/test/org/dockbox/hartshorn/proxy/ProxyTests.java
+++ b/hartshorn-proxy/src/testFixtures/java/test/org/dockbox/hartshorn/proxy/ProxyTests.java
@@ -334,14 +334,14 @@ public abstract class ProxyTests {
 
     @Test
     public void testConcreteClassProxyWithNonEqualsImplementedDelegateDoesNotEqual() throws ApplicationException {
-        CheckedSupplier<DemoServiceC> supplier = () -> proxierLoader().create(this.introspector())
+        final CheckedSupplier<DemoServiceC> supplier = () -> this.proxierLoader().create(this.introspector())
                 .factory(DemoServiceC.class)
                 .delegate(new DemoServiceC())
                 .proxy()
                 .get();
 
-        DemoServiceC serviceC3 = supplier.get();
-        DemoServiceC serviceC4 = supplier.get();
+        final DemoServiceC serviceC3 = supplier.get();
+        final DemoServiceC serviceC4 = supplier.get();
 
         Assertions.assertNotSame(serviceC3, serviceC4);
         Assertions.assertNotEquals(serviceC3, serviceC4);
@@ -349,7 +349,7 @@ public abstract class ProxyTests {
 
     @Test
     void testConcreteClassProxyWithDelegateDoesNotEqual() throws ApplicationException {
-        CheckedSupplier<DemoServiceD> supplier = () -> proxierLoader().create(this.introspector())
+        final CheckedSupplier<DemoServiceD> supplier = () -> this.proxierLoader().create(this.introspector())
                 .factory(DemoServiceD.class)
                 .delegate(new DemoServiceD("name"))
                 .proxy()
@@ -425,8 +425,8 @@ public abstract class ProxyTests {
 
     @Test
     void testLambdaCanBeProxied() throws NoSuchMethodException, ApplicationException {
-        Class<Supplier<String>> supplierClass = (Class<Supplier<String>>) (Class<?>) Supplier.class;
-        final StateAwareProxyFactory<Supplier<String>> factory = proxierLoader().create(this.introspector()).factory(supplierClass);
+        final Class<Supplier<String>> supplierClass = (Class<Supplier<String>>) (Class<?>) Supplier.class;
+        final StateAwareProxyFactory<Supplier<String>> factory = this.proxierLoader().create(this.introspector()).factory(supplierClass);
         factory.intercept(Supplier.class.getMethod("get"), context -> "foo");
         final Option<Supplier<String>> proxy = factory.proxy();
         Assertions.assertTrue(proxy.present());
@@ -435,8 +435,8 @@ public abstract class ProxyTests {
 
     @Test
     void testIsProxyIsTrueIfTypeIsProxy() throws ApplicationException {
-        Introspector introspector = this.introspector();
-        ApplicationProxier proxier = this.proxierLoader().create(introspector);
+        final Introspector introspector = this.introspector();
+        final ApplicationProxier proxier = this.proxierLoader().create(introspector);
         final ProxyFactory<?> factory = proxier.factory(Object.class);
         final Object proxy = factory.proxy().get();
 
@@ -449,8 +449,8 @@ public abstract class ProxyTests {
 
     @Test
     void testIsProxyIsFalseIfTypeIsNormal() {
-        Introspector introspector = this.introspector();
-        ApplicationProxier proxier = this.proxierLoader().create(introspector);
+        final Introspector introspector = this.introspector();
+        final ApplicationProxier proxier = this.proxierLoader().create(introspector);
         final TypeView<?> view = introspector.introspect(Object.class);
         final boolean isProxy = proxier.isProxy(view);
         Assertions.assertFalse(isProxy);

--- a/hartshorn-proxy/src/testFixtures/java/test/org/dockbox/hartshorn/proxy/ProxyTests.java
+++ b/hartshorn-proxy/src/testFixtures/java/test/org/dockbox/hartshorn/proxy/ProxyTests.java
@@ -386,11 +386,11 @@ public abstract class ProxyTests {
         }
 
         @Override
-        public boolean equals(final Object o) {
-            if (this == o) return true;
-            if (o == null || this.getClass() != o.getClass()) return false;
-            final DemoServiceD that = (DemoServiceD) o;
-            return this.name.equals(that.name);
+        public boolean equals(final Object other) {
+            if (this == other) return true;
+            if (other == null || this.getClass() != other.getClass()) return false;
+            final DemoServiceD service = (DemoServiceD) other;
+            return this.name.equals(service.name);
         }
     }
 

--- a/hartshorn-proxy/src/testFixtures/java/test/org/dockbox/hartshorn/proxy/ProxyTests.java
+++ b/hartshorn-proxy/src/testFixtures/java/test/org/dockbox/hartshorn/proxy/ProxyTests.java
@@ -54,7 +54,7 @@ public abstract class ProxyTests {
     @Test
     void testConcreteMethodsCanBeProxied() throws ApplicationException, NoSuchMethodException {
         final Method name = ConcreteProxyTarget.class.getMethod("name");
-        final ProxyFactory<ConcreteProxyTarget> handler = proxierLoader().create(this.introspector()).factory(ConcreteProxyTarget.class);
+        final ProxyFactory<ConcreteProxyTarget> handler = this.proxierLoader().create(this.introspector()).factory(ConcreteProxyTarget.class);
         handler.intercept(name, context -> "Hartshorn");
         final ConcreteProxyTarget proxy = handler.proxy().get();
 
@@ -66,7 +66,7 @@ public abstract class ProxyTests {
     @Test
     void testFinalMethodsCanNotBeProxied() throws ApplicationException, NoSuchMethodException {
         final Method name = FinalProxyTarget.class.getMethod("name");
-        final ProxyFactory<FinalProxyTarget> handler = proxierLoader().create(this.introspector()).factory(FinalProxyTarget.class);
+        final ProxyFactory<FinalProxyTarget> handler = this.proxierLoader().create(this.introspector()).factory(FinalProxyTarget.class);
         handler.intercept(name, context -> "Hartshorn");
         final FinalProxyTarget proxy = handler.proxy().get();
 
@@ -87,14 +87,14 @@ public abstract class ProxyTests {
     @Test
     void testRecordProxyCannotBeCreated() {
         // Records are final and cannot be proxied
-        final ProxyFactory<RecordProxy> handler = proxierLoader().create(this.introspector()).factory(RecordProxy.class);
+        final ProxyFactory<RecordProxy> handler = this.proxierLoader().create(this.introspector()).factory(RecordProxy.class);
         Assertions.assertThrows(ApplicationException.class, handler::proxy);
     }
 
     @ParameterizedTest
     @MethodSource("proxyTypes")
     void testEmptyProxyCanCreate(final Class<? extends InterfaceProxy> proxyParent) throws ApplicationException {
-        final ProxyFactory<? extends InterfaceProxy> handler = proxierLoader().create(this.introspector()).factory(proxyParent);
+        final ProxyFactory<? extends InterfaceProxy> handler = this.proxierLoader().create(this.introspector()).factory(proxyParent);
         final InterfaceProxy proxy = handler.proxy().get();
         Assertions.assertNotNull(proxy);
     }
@@ -102,7 +102,7 @@ public abstract class ProxyTests {
     @ParameterizedTest
     @MethodSource("proxyTypes")
     void testMethodsCanBeDelegatedToOriginalInstance(final Class<InterfaceProxy> proxyType) throws ApplicationException {
-        final ProxyFactory<InterfaceProxy> factory = proxierLoader().create(this.introspector()).factory(proxyType);
+        final ProxyFactory<InterfaceProxy> factory = this.proxierLoader().create(this.introspector()).factory(proxyType);
         factory.delegate(new ConcreteProxy());
         final Option<InterfaceProxy> proxy = factory.proxy();
         Assertions.assertTrue(proxy.present());
@@ -113,7 +113,7 @@ public abstract class ProxyTests {
 
     @Test
     void testConcreteProxyWithNonDefaultConstructorUsesConstructor() {
-        final StateAwareProxyFactory<ConcreteProxyWithNonDefaultConstructor> factory = proxierLoader().create(this.introspector()).factory(ConcreteProxyWithNonDefaultConstructor.class);
+        final StateAwareProxyFactory<ConcreteProxyWithNonDefaultConstructor> factory = this.proxierLoader().create(this.introspector()).factory(ConcreteProxyWithNonDefaultConstructor.class);
 
         final TypeView<ConcreteProxyWithNonDefaultConstructor> typeView = this.introspector().introspect(ConcreteProxyWithNonDefaultConstructor.class);
         final ConstructorView<ConcreteProxyWithNonDefaultConstructor> constructor = typeView.constructors().all().get(0);
@@ -127,7 +127,7 @@ public abstract class ProxyTests {
     @ParameterizedTest
     @MethodSource("proxyTypes")
     void testMethodsCanBeIntercepted(final Class<? extends InterfaceProxy> proxyType) throws ApplicationException, NoSuchMethodException {
-        final ProxyFactory<? extends InterfaceProxy> factory = proxierLoader().create(this.introspector()).factory(proxyType);
+        final ProxyFactory<? extends InterfaceProxy> factory = this.proxierLoader().create(this.introspector()).factory(proxyType);
         factory.intercept(proxyType.getMethod("name"), context -> "Hartshorn");
         final Option<? extends InterfaceProxy> proxy = factory.proxy();
         Assertions.assertTrue(proxy.present());
@@ -139,7 +139,7 @@ public abstract class ProxyTests {
     @ParameterizedTest
     @MethodSource("proxyTypes")
     void testMethodsCanBeDelegated(final Class<? extends InterfaceProxy> proxyType) throws ApplicationException, NoSuchMethodException {
-        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) proxierLoader().create(this.introspector()).factory(proxyType);
+        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) this.proxierLoader().create(this.introspector()).factory(proxyType);
         factory.delegate(proxyType.getMethod("name"), new ConcreteProxy());
         final Option<? extends InterfaceProxy> proxy = factory.proxy();
         Assertions.assertTrue(proxy.present());
@@ -151,7 +151,7 @@ public abstract class ProxyTests {
     @Test
     void testTypesCanBeDelegated() throws ApplicationException {
         // Use a custom interface for this type of delegation, as the other proxy types override methods from their parent
-        final ProxyFactory<NamedAgedProxy> factory = proxierLoader().create(this.introspector()).factory(NamedAgedProxy.class);
+        final ProxyFactory<NamedAgedProxy> factory = this.proxierLoader().create(this.introspector()).factory(NamedAgedProxy.class);
         factory.delegate(AgedProxy.class, () -> 12);
         factory.delegate(NamedProxy.class, () -> "NamedProxy");
         final Option<NamedAgedProxy> proxy = factory.proxy();
@@ -165,7 +165,7 @@ public abstract class ProxyTests {
     @ParameterizedTest
     @MethodSource("proxyTypes")
     void testWrapperInterceptionIsCorrect(final Class<? extends InterfaceProxy> proxyType) throws NoSuchMethodException, ApplicationException {
-        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) proxierLoader().create(this.introspector()).factory(proxyType);
+        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) this.proxierLoader().create(this.introspector()).factory(proxyType);
         final AtomicInteger count = new AtomicInteger();
         factory.intercept(proxyType.getMethod("name"), context -> "done");
         factory.wrapAround(proxyType.getMethod("name"), new MethodWrapper<>() {
@@ -196,7 +196,7 @@ public abstract class ProxyTests {
     @ParameterizedTest
     @MethodSource("proxyTypes")
     void testErrorWrapperInterceptionIsCorrect(final Class<? extends InterfaceProxy> proxyType) throws NoSuchMethodException, ApplicationException {
-        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) proxierLoader().create(this.introspector()).factory((proxyType));
+        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) this.proxierLoader().create(this.introspector()).factory((proxyType));
         final AtomicInteger count = new AtomicInteger();
         factory.intercept(proxyType.getMethod("name"), context -> {
             throw new IllegalStateException("not done");
@@ -232,7 +232,7 @@ public abstract class ProxyTests {
 
     @Test
     void testProxyManagerTracksInterceptorsAndDelegates() throws NoSuchMethodException, ApplicationException {
-        final ProxyFactory<NamedAgedProxy> factory = proxierLoader().create(this.introspector()).factory(NamedAgedProxy.class);
+        final ProxyFactory<NamedAgedProxy> factory = this.proxierLoader().create(this.introspector()).factory(NamedAgedProxy.class);
 
         final AgedProxy aged = () -> 12;
         factory.delegate(AgedProxy.class, aged);
@@ -257,7 +257,7 @@ public abstract class ProxyTests {
     @ParameterizedTest
     @MethodSource("proxyTypes")
     void testProxyCanHaveExtraInterfaces(final Class<? extends InterfaceProxy> proxyType) throws ApplicationException {
-        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) proxierLoader().create(this.introspector()).factory(proxyType);
+        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) this.proxierLoader().create(this.introspector()).factory(proxyType);
         factory.implement(DescribedProxy.class);
         final Option<InterfaceProxy> proxy = factory.proxy();
         Assertions.assertTrue(proxy.present());
@@ -270,7 +270,7 @@ public abstract class ProxyTests {
     @ParameterizedTest
     @MethodSource("proxyTypes")
     void testProxiesAlwaysImplementProxyType(final Class<? extends InterfaceProxy> proxyType) throws ApplicationException {
-        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) proxierLoader().create(this.introspector()).factory(proxyType);
+        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) this.proxierLoader().create(this.introspector()).factory(proxyType);
         final Option<InterfaceProxy> proxy = factory.proxy();
         Assertions.assertTrue(proxy.present());
         final InterfaceProxy proxyInstance = proxy.get();
@@ -280,7 +280,7 @@ public abstract class ProxyTests {
     @ParameterizedTest
     @MethodSource("proxyTypes")
     void testProxiesExposeManager(final Class<? extends InterfaceProxy> proxyType) throws ApplicationException {
-        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) proxierLoader().create(this.introspector()).factory(proxyType);
+        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) this.proxierLoader().create(this.introspector()).factory(proxyType);
         final Option<InterfaceProxy> proxy = factory.proxy();
         Assertions.assertTrue(proxy.present());
 
@@ -291,7 +291,7 @@ public abstract class ProxyTests {
     @ParameterizedTest
     @MethodSource("proxyTypes")
     void testProxyManagerExposesTargetAndProxyType(final Class<? extends InterfaceProxy> proxyType) throws ApplicationException {
-        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) proxierLoader().create(this.introspector()).factory(proxyType);
+        final ProxyFactory<InterfaceProxy> factory = (ProxyFactory<InterfaceProxy>) this.proxierLoader().create(this.introspector()).factory(proxyType);
         final Option<InterfaceProxy> proxy = factory.proxy();
         Assertions.assertTrue(proxy.present());
 
@@ -362,8 +362,8 @@ public abstract class ProxyTests {
         Assertions.assertEquals(serviceD1, serviceD2);
     }
 
-    private <T> T createProxy(Class<T> type) throws ApplicationException {
-        return proxierLoader().create(this.introspector()).factory(type).proxy().get();
+    private <T> T createProxy(final Class<T> type) throws ApplicationException {
+        return this.proxierLoader().create(this.introspector()).factory(type).proxy().get();
     }
 
     public interface DemoServiceA { }
@@ -375,7 +375,7 @@ public abstract class ProxyTests {
     public static class DemoServiceD {
         private String name;
 
-        public DemoServiceD(String name) {
+        public DemoServiceD(final String name) {
             this.name = name;
         }
 
@@ -386,17 +386,17 @@ public abstract class ProxyTests {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(final Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            DemoServiceD that = (DemoServiceD) o;
-            return name.equals(that.name);
+            if (o == null || this.getClass() != o.getClass()) return false;
+            final DemoServiceD that = (DemoServiceD) o;
+            return this.name.equals(that.name);
         }
     }
 
     @Test
     void testConcreteProxySelfEquality() throws ApplicationException {
-        final ProxyFactory<EqualProxy> factory = proxierLoader().create(this.introspector()).factory(EqualProxy.class);
+        final ProxyFactory<EqualProxy> factory = this.proxierLoader().create(this.introspector()).factory(EqualProxy.class);
         final Option<EqualProxy> proxy = factory.proxy();
         Assertions.assertTrue(proxy.present());
 
@@ -407,14 +407,14 @@ public abstract class ProxyTests {
 
     @Test
     void testServiceSelfEquality() throws ApplicationException {
-        final EqualServiceProxy service = proxierLoader().create(this.introspector()).factory(EqualServiceProxy.class).proxy().get();
+        final EqualServiceProxy service = this.proxierLoader().create(this.introspector()).factory(EqualServiceProxy.class).proxy().get();
         Assertions.assertEquals(service, service);
         Assertions.assertTrue(service.test(service));
     }
 
     @Test
     void testInterfaceProxySelfEquality() throws ApplicationException {
-        final ProxyFactory<EqualInterfaceProxy> factory = proxierLoader().create(this.introspector()).factory(EqualInterfaceProxy.class);
+        final ProxyFactory<EqualInterfaceProxy> factory = this.proxierLoader().create(this.introspector()).factory(EqualInterfaceProxy.class);
         final Option<EqualInterfaceProxy> proxy = factory.proxy();
         Assertions.assertTrue(proxy.present());
 

--- a/hartshorn-reporting/hartshorn-reporting.gradle.kts
+++ b/hartshorn-reporting/hartshorn-reporting.gradle.kts
@@ -19,11 +19,9 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    api(libs.bundles.jackson)
+    api("org.dockbox.hartshorn:hartshorn-core")
+
+    implementation(libs.bundles.jackson)
 
     testImplementation("org.dockbox.hartshorn:hartshorn-introspect-reflection")
     testImplementation("org.dockbox.hartshorn:hartshorn-proxy-javassist")

--- a/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/aggregate/AggregateDiagnosticsReporter.java
+++ b/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/aggregate/AggregateDiagnosticsReporter.java
@@ -30,9 +30,9 @@ public class AggregateDiagnosticsReporter implements ConfigurableDiagnosticsRepo
     public void report(final DiagnosticsPropertyCollector collector) {
         final Set<CategorizedDiagnosticsReporter> reporters = this.configuration().reporters();
 
-        collector.property("reporters").write(c -> {
+        collector.property("reporters").write(reporterCollector -> {
             for (final CategorizedDiagnosticsReporter reporter : reporters) {
-                c.property(reporter.category()).write(reporter.getClass().getCanonicalName());
+                reporterCollector.property(reporter.category()).write(reporter.getClass().getCanonicalName());
             }
         });
 

--- a/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/component/ComponentProcessorsReportable.java
+++ b/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/component/ComponentProcessorsReportable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.reporting.component;
 
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;

--- a/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/component/ComponentReportingConfiguration.java
+++ b/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/component/ComponentReportingConfiguration.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.reporting.component;
 
 import java.util.EnumMap;
+import java.util.Map;
 
 public class ComponentReportingConfiguration {
 
@@ -58,7 +59,7 @@ public class ComponentReportingConfiguration {
         return this;
     }
 
-    public EnumMap<ComponentAttribute, Boolean> attributes() {
+    public Map<ComponentAttribute, Boolean> attributes() {
         return this.attributes;
     }
 

--- a/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/component/ComponentReportingConfiguration.java
+++ b/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/component/ComponentReportingConfiguration.java
@@ -24,7 +24,7 @@ public class ComponentReportingConfiguration {
     private ComponentAttribute groupBy = ComponentAttribute.STEREOTYPE;
     private boolean includeDependencies = true;
     private boolean includeRequiredConditions = true;
-    private final EnumMap<ComponentAttribute, Boolean> attributes = new EnumMap<>(ComponentAttribute.class);
+    private final Map<ComponentAttribute, Boolean> attributes = new EnumMap<>(ComponentAttribute.class);
 
     public ComponentReportingConfiguration() {
         // Package is included by type definition, so we don't need to include it by default

--- a/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/serialize/NodeToJacksonVisitor.java
+++ b/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/serialize/NodeToJacksonVisitor.java
@@ -34,13 +34,13 @@ class NodeToJacksonVisitor implements NodeVisitor<JsonNode> {
     public JsonNode visit(final Node<?> node) {
         final JsonNodeFactory factory = JsonNodeFactory.instance;
         final Object value = node.value();
-        if (value instanceof String string) return factory.textNode(string);
-        else if (value instanceof Integer integer) return factory.numberNode(integer);
-        else if (value instanceof Double dbl) return factory.numberNode(dbl);
-        else if (value instanceof Long lng) return factory.numberNode(lng);
-        else if (value instanceof Short shrt) return factory.numberNode(shrt);
-        else if (value instanceof Boolean bool) return factory.booleanNode(bool);
-        else if (value instanceof Node<?> n) return n.accept(this);
+        if (value instanceof String stringValue) return factory.textNode(stringValue);
+        else if (value instanceof Integer integerValue) return factory.numberNode(integerValue);
+        else if (value instanceof Double doubleValue) return factory.numberNode(doubleValue);
+        else if (value instanceof Long longValue) return factory.numberNode(longValue);
+        else if (value instanceof Short shortValue) return factory.numberNode(shortValue);
+        else if (value instanceof Boolean booleanValue) return factory.booleanNode(booleanValue);
+        else if (value instanceof Node<?> nodeValue) return nodeValue.accept(this);
         else throw new IllegalArgumentException("Unsupported type " + value.getClass().getName());
     }
 
@@ -59,13 +59,13 @@ class NodeToJacksonVisitor implements NodeVisitor<JsonNode> {
         final JsonNodeFactory factory = JsonNodeFactory.instance;
         final List<JsonNode> nodes = new ArrayList<>();
         for (final Object value : node.value()) {
-            if (value instanceof String string) nodes.add(factory.textNode(string));
-            else if (value instanceof Integer integer) nodes.add(factory.numberNode(integer));
-            else if (value instanceof Double dbl) nodes.add(factory.numberNode(dbl));
-            else if (value instanceof Long lng) nodes.add(factory.numberNode(lng));
-            else if (value instanceof Short shrt) nodes.add(factory.numberNode(shrt));
-            else if (value instanceof Boolean bool) nodes.add(factory.booleanNode(bool));
-            else if (value instanceof Node<?> n) nodes.add(n.accept(this));
+            if (value instanceof String stringValue) nodes.add(factory.textNode(stringValue));
+            else if (value instanceof Integer integerValue) nodes.add(factory.numberNode(integerValue));
+            else if (value instanceof Double doubleValue) nodes.add(factory.numberNode(doubleValue));
+            else if (value instanceof Long longValue) nodes.add(factory.numberNode(longValue));
+            else if (value instanceof Short shortValue) nodes.add(factory.numberNode(shortValue));
+            else if (value instanceof Boolean booleanValue) nodes.add(factory.booleanNode(booleanValue));
+            else if (value instanceof Node<?> nodeValue) nodes.add(nodeValue.accept(this));
             else throw new IllegalArgumentException("Unsupported type " + value.getClass().getName());
         }
         return factory.arrayNode().addAll(nodes);

--- a/hartshorn-test-suite/hartshorn-test-suite.gradle.kts
+++ b/hartshorn-test-suite/hartshorn-test-suite.gradle.kts
@@ -15,10 +15,7 @@
  */
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
+    api("org.dockbox.hartshorn:hartshorn-core")
 
     implementation(libs.slf4j)
     implementation(libs.logback)

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/DefaultNamedContext.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/DefaultNamedContext.java
@@ -23,7 +23,7 @@ public abstract class DefaultNamedContext extends DefaultContext implements Name
 
     private final String name;
 
-    public DefaultNamedContext(final String name) {
+    protected DefaultNamedContext(final String name) {
         this.name = name;
     }
 

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/SimpleContextIdentity.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/SimpleContextIdentity.java
@@ -21,11 +21,11 @@ public class SimpleContextIdentity<T extends Context> implements ContextIdentity
     private final Class<T> type;
     private final String name;
 
-    public SimpleContextIdentity(Class<T> type) {
+    public SimpleContextIdentity(final Class<T> type) {
         this(type, null);
     }
 
-    public SimpleContextIdentity(Class<T> type, String name) {
+    public SimpleContextIdentity(final Class<T> type, final String name) {
         this.type = type;
         this.name = name;
     }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/GenericType.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/GenericType.java
@@ -52,7 +52,7 @@ public abstract class GenericType<T> implements Comparable<GenericType<T>> {
     }
 
     @Override
-    public int compareTo(@NonNull final GenericType<T> o) {
+    public int compareTo(@NonNull final GenericType<T> other) {
         return 0;
     }
 

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/Named.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/Named.java
@@ -18,5 +18,12 @@ package org.dockbox.hartshorn.util;
 
 @FunctionalInterface
 public interface Named {
+
+    /**
+     * Returns the simple name of the element. This can represent the actual {@code name}
+     * property, or a derived value, such as the name of a field or method.
+     *
+     * @return the simple name of the element
+     */
     String name();
 }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/SimpleNode.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/SimpleNode.java
@@ -26,14 +26,17 @@ public class SimpleNode<T> implements Node<T> {
         this.value = value;
     }
 
+    @Override
     public String name() {
         return this.name;
     }
 
+    @Override
     public T value() {
         return this.value;
     }
 
+    @Override
     public <R> R accept(final NodeVisitor<R> visitor) {
         return visitor.visit(this);
     }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/StringTypeAdapterImpl.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/StringTypeAdapterImpl.java
@@ -39,6 +39,7 @@ public final class StringTypeAdapterImpl<T> implements StringTypeAdapter<T> {
         this.function = function;
     }
 
+    @Override
     public Class<T> type() {
         return this.type;
     }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/StringUtilities.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/StringUtilities.java
@@ -16,15 +16,15 @@
 
 package org.dockbox.hartshorn.util;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.util.option.Option;
+
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.dockbox.hartshorn.util.option.Option;
 
 public final class StringUtilities {
 
@@ -41,11 +41,11 @@ public final class StringUtilities {
                 : (value.substring(0, 1).toUpperCase() + value.substring(1));
     }
 
-    public static boolean empty(final String value) {
+    public static boolean empty(final CharSequence value) {
         return null == value || value.isEmpty();
     }
 
-    public static boolean notEmpty(final String value) {
+    public static boolean notEmpty(final CharSequence value) {
         return null != value && !value.isEmpty();
     }
 

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/StringUtilities.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/StringUtilities.java
@@ -16,15 +16,15 @@
 
 package org.dockbox.hartshorn.util;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.dockbox.hartshorn.util.option.Option;
-
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.util.option.Option;
 
 public final class StringUtilities {
 
@@ -114,7 +114,7 @@ public final class StringUtilities {
         final Map<String, String> map = new HashMap<>();
 
         for (int i = 0; i < args.length; i++) {
-            final String arg = "" + args[i];
+            final String arg = String.valueOf(args[i]);
             map.put(String.format("{%d}", i), arg);
         }
         return StringUtilities.format(format, map);

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/Tuple.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/Tuple.java
@@ -64,10 +64,10 @@ public class Tuple<K, V> implements Entry<K, V> {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
-        final Tuple<?, ?> tuple = (Tuple<?, ?>) o;
+    public boolean equals(final Object other) {
+        if (this == other) return true;
+        if (other == null || this.getClass() != other.getClass()) return false;
+        final Tuple<?, ?> tuple = (Tuple<?, ?>) other;
         return Objects.equals(this.key, tuple.key) && Objects.equals(this.value, tuple.value);
     }
 

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/TypeConversionException.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/TypeConversionException.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.util;
 
 public class TypeConversionException extends ApplicationRuntimeException {
 
-    public TypeConversionException(String message) {
+    public TypeConversionException(final String message) {
         super(message);
     }
 

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/TypeUtils.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/TypeUtils.java
@@ -172,4 +172,14 @@ public class TypeUtils {
         }
         return Arrays.stream(boxed);
     }
+
+    public static boolean isAssignable(final Class<?> source, final Class<?> target) {
+        if (target.isAssignableFrom(source)) {
+            return true;
+        }
+        if (target.isPrimitive() && TypeUtils.isPrimitiveWrapper(source, target)) {
+            return true;
+        }
+        return source.isPrimitive() && TypeUtils.isPrimitiveWrapper(target, source);
+    }
 }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/TypeUtils.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/TypeUtils.java
@@ -39,17 +39,17 @@ public class TypeUtils {
     );
 
     private static final Map<?, Function<String, ?>> PRIMITIVE_FROM_STRING = Map.ofEntries(
-            Map.entry(boolean.class, s -> {
+            Map.entry(boolean.class, input -> {
                 // Boolean.valueOf only checks if the input equals 'true', and otherwise
                 // defaults to 'false'. We want to be more strict.
-                if ("true".equals(s)) return true;
-                else if ("false".equals(s)) return false;
-                else throw new TypeConversionException("Invalid boolean value: " + s);
+                if ("true".equals(input)) return true;
+                else if ("false".equals(input)) return false;
+                else throw new TypeConversionException("Invalid boolean value: " + input);
             }),
             Map.entry(byte.class, Byte::valueOf),
-            Map.entry(char.class, s -> {
-                if (s.length() == 1) return s.charAt(0);
-                else throw new TypeConversionException("Invalid char value: " + s + " (length != 1)");
+            Map.entry(char.class, input -> {
+                if (input.length() == 1) return input.charAt(0);
+                else throw new TypeConversionException("Invalid char value: " + input + " (length != 1)");
             }),
             Map.entry(double.class, Double::valueOf),
             Map.entry(float.class, Float::valueOf),

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/AbstractBiMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/AbstractBiMap.java
@@ -51,8 +51,8 @@ public abstract class AbstractBiMap<K, V> implements BiMap<K, V> {
     }
 
     @Override
-    public void putAll(final Map<? extends K, ? extends V> m) {
-        m.forEach(this::put);
+    public void putAll(final Map<? extends K, ? extends V> map) {
+        map.forEach(this::put);
     }
 
     @Override

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/AbstractMultiMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/AbstractMultiMap.java
@@ -142,7 +142,7 @@ public abstract class AbstractMultiMap<K, V> implements MultiMap<K, V> {
     }
 
     @Override
-    public void forEach(BiConsumer<K, V> consumer) {
+    public void forEach(final BiConsumer<K, V> consumer) {
         this.map().forEach((k, v) -> v.forEach(v1 -> consumer.accept(k, v1)));
     }
 }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/AbstractMultiMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/AbstractMultiMap.java
@@ -41,7 +41,7 @@ public abstract class AbstractMultiMap<K, V> implements MultiMap<K, V> {
 
     @Override
     public void putAll(final K key, final Collection<V> values) {
-        values.forEach(v -> this.put(key, v));
+        values.forEach(value -> this.put(key, value));
     }
 
     @Override
@@ -53,12 +53,12 @@ public abstract class AbstractMultiMap<K, V> implements MultiMap<K, V> {
 
     @Override
     public void put(final K key, final V value) {
-        this.map().computeIfAbsent(key, k -> this.createEmptyCollection()).add(value);
+        this.map().computeIfAbsent(key, key0 -> this.createEmptyCollection()).add(value);
     }
 
     @Override
     public void putIfAbsent(final K key, final V value) {
-        this.map().computeIfAbsent(key, k -> this.createEmptyCollection());
+        this.map().computeIfAbsent(key, key0 -> this.createEmptyCollection());
         if (!this.map().get(key).contains(value)) {
             this.map().get(key).add(value);
         }
@@ -91,7 +91,7 @@ public abstract class AbstractMultiMap<K, V> implements MultiMap<K, V> {
 
     @Override
     public boolean containsValue(final V value) {
-        return this.map().values().stream().anyMatch(v -> v.contains(value));
+        return this.map().values().stream().anyMatch(value0 -> value0.contains(value));
     }
 
     @Override
@@ -143,6 +143,6 @@ public abstract class AbstractMultiMap<K, V> implements MultiMap<K, V> {
 
     @Override
     public void forEach(final BiConsumer<K, V> consumer) {
-        this.map().forEach((k, v) -> v.forEach(v1 -> consumer.accept(k, v1)));
+        this.map().forEach((key, value) -> value.forEach(value0 -> consumer.accept(key, value0)));
     }
 }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/AbstractMultiMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/AbstractMultiMap.java
@@ -27,10 +27,10 @@ public abstract class AbstractMultiMap<K, V> implements MultiMap<K, V> {
     protected abstract Map<K, Collection<V>> map();
     protected abstract Collection<V> createEmptyCollection();
 
-    public AbstractMultiMap() {
+    protected AbstractMultiMap() {
     }
 
-    public AbstractMultiMap(MultiMap<K, V> map) {
+    protected AbstractMultiMap(final MultiMap<K, V> map) {
         this.putAll(map);
     }
 

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/ConcurrentClassMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/ConcurrentClassMap.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.util.collections;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ConcurrentClassMap<T> extends ConcurrentHashMap<Class<T>, T> {
@@ -23,7 +24,7 @@ public class ConcurrentClassMap<T> extends ConcurrentHashMap<Class<T>, T> {
     public ConcurrentClassMap() {
     }
 
-    public ConcurrentClassMap(final ConcurrentClassMap<T> map) {
+    public ConcurrentClassMap(final Map<Class<T>, T> map) {
         super(map);
     }
 }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/StandardBiMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/StandardBiMap.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public abstract class StandardBiMap<K, V> extends AbstractBiMap<K, V> {
 
 
-    protected StandardBiMap(Map<K, V> forward, Map<V, K> backward) {
+    protected StandardBiMap(final Map<K, V> forward, final Map<V, K> backward) {
         super(forward, backward);
     }
 

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/StandardMultiMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/StandardMultiMap.java
@@ -46,7 +46,7 @@ public abstract class StandardMultiMap<K, V> extends AbstractMultiMap<K, V> {
 
     protected abstract Map<K, Collection<V>> createEmptyMap();
 
-    public static abstract class ConcurrentMultiMap<K, V> extends StandardMultiMap<K, V> {
+    public abstract static class ConcurrentMultiMap<K, V> extends StandardMultiMap<K, V> {
 
         public ConcurrentMultiMap() {
         }
@@ -91,7 +91,7 @@ public abstract class StandardMultiMap<K, V> extends AbstractMultiMap<K, V> {
         }
     }
 
-    public static abstract class HashMultiMap<K, V> extends StandardMultiMap<K, V> {
+    public abstract static class HashMultiMap<K, V> extends StandardMultiMap<K, V> {
 
         public HashMultiMap() {
         }
@@ -136,7 +136,7 @@ public abstract class StandardMultiMap<K, V> extends AbstractMultiMap<K, V> {
         }
     }
 
-    public static abstract class TreeMultiMap<K extends Comparable<K>, V> extends StandardMultiMap<K, V> {
+    public abstract static class TreeMultiMap<K extends Comparable<K>, V> extends StandardMultiMap<K, V> {
 
         public TreeMultiMap() {
         }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/StandardMultiMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/StandardMultiMap.java
@@ -39,7 +39,7 @@ public abstract class StandardMultiMap<K, V> extends AbstractMultiMap<K, V> {
     @Override
     protected Map<K, Collection<V>> map() {
         if (this.map == null) {
-            this.map = createEmptyMap();
+            this.map = this.createEmptyMap();
         }
         return this.map;
     }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/StandardMultiMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/StandardMultiMap.java
@@ -29,10 +29,10 @@ public abstract class StandardMultiMap<K, V> extends AbstractMultiMap<K, V> {
 
     protected Map<K, Collection<V>> map;
 
-    public StandardMultiMap() {
+    protected StandardMultiMap() {
     }
 
-    public StandardMultiMap(final MultiMap<K, V> map) {
+    protected StandardMultiMap(final MultiMap<K, V> map) {
         super(map);
     }
 
@@ -48,10 +48,10 @@ public abstract class StandardMultiMap<K, V> extends AbstractMultiMap<K, V> {
 
     public abstract static class ConcurrentMultiMap<K, V> extends StandardMultiMap<K, V> {
 
-        public ConcurrentMultiMap() {
+        protected ConcurrentMultiMap() {
         }
 
-        public ConcurrentMultiMap(final MultiMap<K, V> map) {
+        protected ConcurrentMultiMap(final MultiMap<K, V> map) {
             super(map);
         }
 
@@ -93,10 +93,10 @@ public abstract class StandardMultiMap<K, V> extends AbstractMultiMap<K, V> {
 
     public abstract static class HashMultiMap<K, V> extends StandardMultiMap<K, V> {
 
-        public HashMultiMap() {
+        protected HashMultiMap() {
         }
 
-        public HashMultiMap(final MultiMap<K, V> map) {
+        protected HashMultiMap(final MultiMap<K, V> map) {
             super(map);
         }
 
@@ -138,10 +138,10 @@ public abstract class StandardMultiMap<K, V> extends AbstractMultiMap<K, V> {
 
     public abstract static class TreeMultiMap<K extends Comparable<K>, V> extends StandardMultiMap<K, V> {
 
-        public TreeMultiMap() {
+        protected TreeMultiMap() {
         }
 
-        public TreeMultiMap(final MultiMap<K, V> map) {
+        protected TreeMultiMap(final MultiMap<K, V> map) {
             super(map);
         }
 

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/StandardMultiMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/StandardMultiMap.java
@@ -36,6 +36,7 @@ public abstract class StandardMultiMap<K, V> extends AbstractMultiMap<K, V> {
         super(map);
     }
 
+    @Override
     protected Map<K, Collection<V>> map() {
         if (this.map == null) {
             this.map = createEmptyMap();

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/SynchronizedMultiMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/SynchronizedMultiMap.java
@@ -26,10 +26,10 @@ public abstract class SynchronizedMultiMap<K, V> extends AbstractMultiMap<K, V> 
 
     private transient Map<K, Collection<V>> map;
 
-    public SynchronizedMultiMap() {
+    protected SynchronizedMultiMap() {
     }
 
-    public SynchronizedMultiMap(final MultiMap<K, V> map) {
+    protected SynchronizedMultiMap(final MultiMap<K, V> map) {
         super(map);
     }
 

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/SynchronizedMultiMap.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/collections/SynchronizedMultiMap.java
@@ -37,7 +37,7 @@ public abstract class SynchronizedMultiMap<K, V> extends AbstractMultiMap<K, V> 
     protected synchronized Map<K, Collection<V>> map() {
         synchronized (this) {
             if (this.map == null) {
-                this.map = createEmptyMap();
+                this.map = this.createEmptyMap();
             }
             return this.map;
         }

--- a/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/BuiltInStringTypeAdaptersTests.java
+++ b/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/BuiltInStringTypeAdaptersTests.java
@@ -25,140 +25,140 @@ public class BuiltInStringTypeAdaptersTests {
 
     @Test
     void testStringAdapterReturnsSame() {
-        Option<String> adapted = BuiltInStringTypeAdapters.STRING.adapt("test");
+        final Option<String> adapted = BuiltInStringTypeAdapters.STRING.adapt("test");
         Assertions.assertTrue(adapted.present());
         Assertions.assertEquals("test", adapted.get());
     }
 
     @Test
     void testCharacterAdapterReturnsFirstCharacterIfStringOneCharacter() {
-        Option<Character> adapted = BuiltInStringTypeAdapters.CHARACTER.adapt("t");
+        final Option<Character> adapted = BuiltInStringTypeAdapters.CHARACTER.adapt("t");
         Assertions.assertTrue(adapted.present());
         Assertions.assertEquals('t', adapted.get());
     }
 
     @Test
     void testCharacterAdapterReturnsEmptyIfStringNotOneCharacter() {
-        Option<Character> adapted = BuiltInStringTypeAdapters.CHARACTER.adapt("test");
+        final Option<Character> adapted = BuiltInStringTypeAdapters.CHARACTER.adapt("test");
         Assertions.assertFalse(adapted.present());
     }
 
     @Test
     void testCharacterAdapterReturnsEmptyIfStringEmpty() {
-        Option<Character> adapted = BuiltInStringTypeAdapters.CHARACTER.adapt("");
+        final Option<Character> adapted = BuiltInStringTypeAdapters.CHARACTER.adapt("");
         Assertions.assertFalse(adapted.present());
     }
 
     @Test
     void testBooleanAdapterReturnsTrueIfStringIsTrue() {
-        Option<Boolean> adapted = BuiltInStringTypeAdapters.BOOLEAN.adapt("true");
+        final Option<Boolean> adapted = BuiltInStringTypeAdapters.BOOLEAN.adapt("true");
         Assertions.assertTrue(adapted.present());
         Assertions.assertTrue(adapted.get());
     }
 
     @Test
     void testBooleanAdapterReturnsFalseIfStringIsFalse() {
-        Option<Boolean> adapted = BuiltInStringTypeAdapters.BOOLEAN.adapt("false");
+        final Option<Boolean> adapted = BuiltInStringTypeAdapters.BOOLEAN.adapt("false");
         Assertions.assertTrue(adapted.present());
         Assertions.assertFalse(adapted.get());
     }
 
     @Test
     void testBooleanAdapterReturnsTrueIfStringIsYes() {
-        Option<Boolean> adapted = BuiltInStringTypeAdapters.BOOLEAN.adapt("yes");
+        final Option<Boolean> adapted = BuiltInStringTypeAdapters.BOOLEAN.adapt("yes");
         Assertions.assertTrue(adapted.present());
         Assertions.assertTrue(adapted.get());
     }
 
     @Test
     void testBooleanAdapterReturnsFalseIfStringIsNo() {
-        Option<Boolean> adapted = BuiltInStringTypeAdapters.BOOLEAN.adapt("no");
+        final Option<Boolean> adapted = BuiltInStringTypeAdapters.BOOLEAN.adapt("no");
         Assertions.assertTrue(adapted.present());
         Assertions.assertFalse(adapted.get());
     }
 
     @Test
     void testBooleanAdapterReturnsFalseIfStringIsNotBoolean() {
-        Option<Boolean> adapted = BuiltInStringTypeAdapters.BOOLEAN.adapt("test");
+        final Option<Boolean> adapted = BuiltInStringTypeAdapters.BOOLEAN.adapt("test");
         Assertions.assertTrue(adapted.present());
         Assertions.assertFalse(adapted.get());
     }
 
     @Test
     void testDoubleAdapterReturnsDoubleIfStringIsDouble() {
-        Option<Double> adapted = BuiltInStringTypeAdapters.DOUBLE.adapt("1.0");
+        final Option<Double> adapted = BuiltInStringTypeAdapters.DOUBLE.adapt("1.0");
         Assertions.assertTrue(adapted.present());
         Assertions.assertEquals(1.0, adapted.get());
     }
 
     @Test
     void testDoubleAdapterReturnsEmptyIfStringIsNotDouble() {
-        Option<Double> adapted = BuiltInStringTypeAdapters.DOUBLE.adapt("test");
+        final Option<Double> adapted = BuiltInStringTypeAdapters.DOUBLE.adapt("test");
         Assertions.assertFalse(adapted.present());
     }
 
     @Test
     void testFloatAdapterReturnsFloatIfStringIsFloat() {
-        Option<Float> adapted = BuiltInStringTypeAdapters.FLOAT.adapt("1.0");
+        final Option<Float> adapted = BuiltInStringTypeAdapters.FLOAT.adapt("1.0");
         Assertions.assertTrue(adapted.present());
         Assertions.assertEquals(1.0f, adapted.get());
     }
 
     @Test
     void testFloatAdapterReturnsEmptyIfStringIsNotFloat() {
-        Option<Float> adapted = BuiltInStringTypeAdapters.FLOAT.adapt("test");
+        final Option<Float> adapted = BuiltInStringTypeAdapters.FLOAT.adapt("test");
         Assertions.assertFalse(adapted.present());
     }
 
     @Test
     void testIntegerAdapterReturnsIntegerIfStringIsInteger() {
-        Option<Integer> adapted = BuiltInStringTypeAdapters.INTEGER.adapt("1");
+        final Option<Integer> adapted = BuiltInStringTypeAdapters.INTEGER.adapt("1");
         Assertions.assertTrue(adapted.present());
         Assertions.assertEquals(1, adapted.get());
     }
 
     @Test
     void testIntegerAdapterReturnsEmptyIfStringIsNotInteger() {
-        Option<Integer> adapted = BuiltInStringTypeAdapters.INTEGER.adapt("test");
+        final Option<Integer> adapted = BuiltInStringTypeAdapters.INTEGER.adapt("test");
         Assertions.assertFalse(adapted.present());
     }
 
     @Test
     void testLongAdapterReturnsLongIfStringIsLong() {
-        Option<Long> adapted = BuiltInStringTypeAdapters.LONG.adapt("1");
+        final Option<Long> adapted = BuiltInStringTypeAdapters.LONG.adapt("1");
         Assertions.assertTrue(adapted.present());
         Assertions.assertEquals(1L, adapted.get());
     }
 
     @Test
     void testLongAdapterReturnsEmptyIfStringIsNotLong() {
-        Option<Long> adapted = BuiltInStringTypeAdapters.LONG.adapt("test");
+        final Option<Long> adapted = BuiltInStringTypeAdapters.LONG.adapt("test");
         Assertions.assertFalse(adapted.present());
     }
 
     @Test
     void testShortAdapterReturnsShortIfStringIsShort() {
-        Option<Short> adapted = BuiltInStringTypeAdapters.SHORT.adapt("1");
+        final Option<Short> adapted = BuiltInStringTypeAdapters.SHORT.adapt("1");
         Assertions.assertTrue(adapted.present());
         Assertions.assertEquals(1, (short) adapted.get());
     }
 
     @Test
     void testShortAdapterReturnsEmptyIfStringIsNotShort() {
-        Option<Short> adapted = BuiltInStringTypeAdapters.SHORT.adapt("test");
+        final Option<Short> adapted = BuiltInStringTypeAdapters.SHORT.adapt("test");
         Assertions.assertFalse(adapted.present());
     }
 
     @Test
     void testUUIDAdapterReturnsUUIDIfStringIsUUID() {
-        Option<java.util.UUID> adapted = BuiltInStringTypeAdapters.UNIQUE_ID.adapt("00000000-0000-0000-0000-000000000000");
+        final Option<java.util.UUID> adapted = BuiltInStringTypeAdapters.UNIQUE_ID.adapt("00000000-0000-0000-0000-000000000000");
         Assertions.assertTrue(adapted.present());
         Assertions.assertEquals(java.util.UUID.fromString("00000000-0000-0000-0000-000000000000"), adapted.get());
     }
 
     @Test
     void testUUIDAdapterReturnsEmptyIfStringIsNotUUID() {
-        Option<java.util.UUID> adapted = BuiltInStringTypeAdapters.UNIQUE_ID.adapt("test");
+        final Option<java.util.UUID> adapted = BuiltInStringTypeAdapters.UNIQUE_ID.adapt("test");
         Assertions.assertFalse(adapted.present());
     }
 }

--- a/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/GenericTypeTests.java
+++ b/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/GenericTypeTests.java
@@ -36,7 +36,7 @@ public class GenericTypeTests {
 
         final Option<Class<String>> classOption = genericType.asClass();
         Assertions.assertTrue(classOption.present());
-        Assertions.assertEquals(String.class, classOption.get());
+        Assertions.assertSame(String.class, classOption.get());
     }
 
     @Test

--- a/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/NodeTests.java
+++ b/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/NodeTests.java
@@ -30,20 +30,20 @@ public class NodeTests {
 
     @Test
     void testSimpleNodeCanHaveNullValue() {
-        Node<Object> node = new SimpleNode<>("node", null);
+        final Node<Object> node = new SimpleNode<>("node", null);
         Assertions.assertNull(node.value());
     }
 
     @Test
     void testArrayNodeIsNonNull() {
-        Node<List<Object>> node = new ArrayNode<>("node");
+        final Node<List<Object>> node = new ArrayNode<>("node");
         Assertions.assertNotNull(node.value());
         Assertions.assertTrue(node.value().isEmpty());
     }
 
     @Test
     void testArrayNodeUsesInsertionOrder() {
-        Node<List<Object>> node = new ArrayNode<>("node", "a", "b", "c");
+        final Node<List<Object>> node = new ArrayNode<>("node", "a", "b", "c");
         Assertions.assertEquals("a", node.value().get(0));
         Assertions.assertEquals("b", node.value().get(1));
         Assertions.assertEquals("c", node.value().get(2));
@@ -51,14 +51,14 @@ public class NodeTests {
 
     @Test
     void testGroupNodeIsNonNull() {
-        Node<List<Node<?>>> node = new GroupNode("node");
+        final Node<List<Node<?>>> node = new GroupNode("node");
         Assertions.assertNotNull(node.value());
         Assertions.assertTrue(node.value().isEmpty());
     }
 
     @Test
     void testGroupNodeUsesInsertionOrder() {
-        GroupNode node = new GroupNode("node");
+        final GroupNode node = new GroupNode("node");
         node.add(new SimpleNode<>("a", "a"));
         node.add(new SimpleNode<>("b", "b"));
         node.add(new SimpleNode<>("c", "c"));
@@ -69,22 +69,22 @@ public class NodeTests {
 
     @Test
     void testSimpleNodeValueVisitor() {
-        Node<Integer> node = new SimpleNode<>("node", 12);
+        final Node<Integer> node = new SimpleNode<>("node", 12);
         node.accept(new NodeVisitor<Void>() {
             @Override
-            public Void visit(Node<?> node) {
+            public Void visit(final Node<?> node) {
                 Assertions.assertEquals(12, node.value());
                 return null;
             }
 
             @Override
-            public Void visit(GroupNode node) {
+            public Void visit(final GroupNode node) {
                 Assertions.fail("GroupNode should not be visited");
                 return null;
             }
 
             @Override
-            public Void visit(ArrayNode<?> node) {
+            public Void visit(final ArrayNode<?> node) {
                 Assertions.fail("ArrayNode should not be visited");
                 return null;
             }
@@ -93,22 +93,22 @@ public class NodeTests {
 
     @Test
     void testGroupNodeValueVisitor() {
-        GroupNode node = new GroupNode("node");
+        final GroupNode node = new GroupNode("node");
         node.accept(new NodeVisitor<Void>() {
             @Override
-            public Void visit(Node<?> node) {
+            public Void visit(final Node<?> node) {
                 Assertions.fail("Node should not be visited");
                 return null;
             }
 
             @Override
-            public Void visit(GroupNode node) {
+            public Void visit(final GroupNode node) {
                 Assertions.assertEquals("node", node.name());
                 return null;
             }
 
             @Override
-            public Void visit(ArrayNode<?> node) {
+            public Void visit(final ArrayNode<?> node) {
                 Assertions.fail("ArrayNode should not be visited");
                 return null;
             }
@@ -117,22 +117,22 @@ public class NodeTests {
 
     @Test
     void testArrayNodeValueVisitor() {
-        ArrayNode<Integer> node = new ArrayNode<>("node");
+        final ArrayNode<Integer> node = new ArrayNode<>("node");
         node.accept(new NodeVisitor<Void>() {
             @Override
-            public Void visit(Node<?> node) {
+            public Void visit(final Node<?> node) {
                 Assertions.fail("Node should not be visited");
                 return null;
             }
 
             @Override
-            public Void visit(GroupNode node) {
+            public Void visit(final GroupNode node) {
                 Assertions.fail("GroupNode should not be visited");
                 return null;
             }
 
             @Override
-            public Void visit(ArrayNode<?> node) {
+            public Void visit(final ArrayNode<?> node) {
                 Assertions.assertEquals("node", node.name());
                 return null;
             }

--- a/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/OptionTests.java
+++ b/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/OptionTests.java
@@ -748,25 +748,25 @@ public class OptionTests {
     void testPeekErrorWithMatchingExactType() {
         final Attempt<Object, NullPointerException> attempt = Attempt.of(new NullPointerException());
         final AtomicBoolean called = new AtomicBoolean(false);
-        attempt.peekError(NullPointerException.class, e -> called.set(true));
+        attempt.peekError(NullPointerException.class, exception -> called.set(true));
         Assertions.assertTrue(called.get());
     }
 
     @Test
     void testPeekErrorWithNonExactType() {
         final Attempt<Object, RuntimeException> attempt = Attempt.of(new NullPointerException());
-        attempt.peekError(RuntimeException.class, e -> Assertions.fail());
+        attempt.peekError(RuntimeException.class, exception -> Assertions.fail());
     }
 
     @Test
     void testPeekErrorWithNonMatchingType() {
         final Attempt<Object, RuntimeException> attempt = Attempt.of(new NullPointerException());
-        attempt.peekError(IllegalArgumentException.class, e -> Assertions.fail());
+        attempt.peekError(IllegalArgumentException.class, exception -> Assertions.fail());
     }
 
     @Test
     void testPeekErrorWithEmpty() {
         final Attempt<Object, RuntimeException> attempt = Attempt.empty();
-        attempt.peekError(RuntimeException.class, e -> Assertions.fail());
+        attempt.peekError(RuntimeException.class, exception -> Assertions.fail());
     }
 }

--- a/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/UtilitiesTests.java
+++ b/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/UtilitiesTests.java
@@ -195,8 +195,8 @@ public class UtilitiesTests {
 
     @ParameterizedTest
     @MethodSource("differences")
-    void testDifferenceInCollections(final Collection<String> a, final Collection<String> b, final Collection<String> expected) {
-        final Set<String> difference = CollectionUtilities.difference(a, b);
+    void testDifferenceInCollections(final Collection<String> collectionOne, final Collection<String> collectionTwo, final Collection<String> expected) {
+        final Set<String> difference = CollectionUtilities.difference(collectionOne, collectionTwo);
         Assertions.assertEquals(difference.size(), expected.size());
         Assertions.assertTrue(difference.containsAll(expected));
         Assertions.assertTrue(expected.containsAll(difference));

--- a/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/UtilitiesTests.java
+++ b/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/UtilitiesTests.java
@@ -205,7 +205,7 @@ public class UtilitiesTests {
     @Test
     void testSplitCapitals() {
         final String input = "ThisIsAString";
-        final String[] expected = new String[]{ "This", "Is", "A", "String" };
+        final String[] expected = { "This", "Is", "A", "String" };
         final String[] actual = StringUtilities.splitCapitals(input);
         Assertions.assertArrayEquals(expected, actual);
     }
@@ -230,8 +230,8 @@ public class UtilitiesTests {
                 Arguments.of("1", long.class, 1L),
                 Arguments.of("1", short.class, (short) 1),
                 Arguments.of("1", byte.class, (byte) 1),
-                Arguments.of("1", float.class, 1f),
-                Arguments.of("1", double.class, 1d),
+                Arguments.of("1", float.class, 1.0f),
+                Arguments.of("1", double.class, 1.0d),
                 Arguments.of("true", boolean.class, true),
                 Arguments.of("1", char.class, '1'),
                 Arguments.of("ONE", TestEnum.class, TestEnum.ONE),

--- a/hartshorn-web/hartshorn-web-jetty/hartshorn-web-jetty.gradle.kts
+++ b/hartshorn-web/hartshorn-web-jetty/hartshorn-web-jetty.gradle.kts
@@ -19,10 +19,7 @@ apply {
 }
 
 dependencies {
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-config")
-    implementation("org.dockbox.hartshorn:hartshorn-web")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
+    api("org.dockbox.hartshorn:hartshorn-web")
+
     implementation(libs.bundles.jetty)
 }

--- a/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
+++ b/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
@@ -80,10 +80,12 @@ public class JettyHttpWebServer extends DefaultHttpWebServer {
         return this.servletHandler;
     }
 
+    @Override
     public JsonInclusionRule skipBehavior() {
         return this.skipBehavior;
     }
 
+    @Override
     public JettyHttpWebServer skipBehavior(final JsonInclusionRule skipBehavior) {
         this.skipBehavior = skipBehavior;
         return this;

--- a/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
+++ b/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
@@ -16,6 +16,10 @@
 
 package org.dockbox.hartshorn.web.jetty;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Enumeration;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.web.HttpStatus;
 import org.dockbox.hartshorn.web.servlet.DirectoryServlet;
@@ -24,10 +28,6 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.server.ResourceService;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
-
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.Enumeration;
 
 import jakarta.inject.Inject;
 import jakarta.servlet.RequestDispatcher;
@@ -137,8 +137,9 @@ public class JettyResourceService extends ResourceService {
         catch (final IllegalArgumentException e)
         {
             this.applicationContext.handle(e);
-            if (!response.isCommitted())
-                response.sendError(500, e.getMessage());
+            if (!response.isCommitted()) {
+                response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage());
+            }
         }
         finally
         {

--- a/hartshorn-web/hartshorn-web.gradle.kts
+++ b/hartshorn-web/hartshorn-web.gradle.kts
@@ -19,14 +19,10 @@ apply {
 }
 
 dependencies {
-    api(libs.jakartaServlet)
+    implementation(libs.jakartaServlet)
 
-    implementation("org.dockbox.hartshorn:hartshorn-core")
-    implementation("org.dockbox.hartshorn:hartshorn-util")
-    implementation("org.dockbox.hartshorn:hartshorn-proxy")
-    implementation("org.dockbox.hartshorn:hartshorn-introspect")
-    implementation("org.dockbox.hartshorn:hartshorn-events")
-    implementation("org.dockbox.hartshorn:hartshorn-config")
+    api("org.dockbox.hartshorn:hartshorn-events")
+    api("org.dockbox.hartshorn:hartshorn-config")
 
     testImplementation(libs.httpclient)
     testImplementation("org.dockbox.hartshorn:hartshorn-config-jackson")

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
@@ -84,7 +84,7 @@ public class ServletHandler {
                 if (this.addHeader) res.addHeader("Hartshorn-Version", Hartshorn.VERSION);
 
                 final ParameterLoader<HttpRequestParameterLoaderContext> loader = this.starter.loader();
-                final HttpRequestParameterLoaderContext loaderContext = new HttpRequestParameterLoaderContext(this.method, this.method.declaredBy(), null, this.context, req, res);
+                final HttpRequestParameterLoaderContext loaderContext = new HttpRequestParameterLoaderContext(this.method, this.method.declaredBy(), this.context, req, res);
                 final List<Object> arguments = loader.loadArguments(loaderContext);
                 final Object instance = this.context.get(this.method.declaredBy().type());
                 final Attempt<?, Throwable> result = this.method.invoke(TypeUtils.adjustWildcards(instance, Object.class), arguments);

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpRequestParameterLoaderContext.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpRequestParameterLoaderContext.java
@@ -18,8 +18,7 @@ package org.dockbox.hartshorn.web.processing;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.util.ApplicationBoundParameterLoaderContext;
-import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -29,8 +28,10 @@ public class HttpRequestParameterLoaderContext extends ApplicationBoundParameter
     private final HttpServletRequest request;
     private final HttpServletResponse response;
 
-    public HttpRequestParameterLoaderContext(final MethodView<?, ?> method, final TypeView<?> type, final Object instance, final ApplicationContext applicationContext, final HttpServletRequest request, final HttpServletResponse response) {
-        super(method, instance, applicationContext);
+    public HttpRequestParameterLoaderContext(final ExecutableElementView<?> element, final Object instance,
+                                             final ApplicationContext applicationContext, final HttpServletRequest request,
+                                             final HttpServletResponse response) {
+        super(element, instance, applicationContext);
         this.request = request;
         this.response = response;
     }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/BodyRequestParameterRule.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/BodyRequestParameterRule.java
@@ -43,7 +43,7 @@ public class BodyRequestParameterRule extends AnnotatedParameterLoaderRule<Reque
         if (parameter.type().is(String.class)) {
             return body
                     .cast(parameter.type().type())
-                    .mapError(e -> e);
+                    .mapError(error -> error);
         }
 
         final MediaType mediaType = parameter.declaredBy().annotations().get(HttpRequest.class).get().consumes();
@@ -54,8 +54,8 @@ public class BodyRequestParameterRule extends AnnotatedParameterLoaderRule<Reque
         final FileFormat bodyFormat = mediaType.fileFormat().get();
         final ObjectMapper objectMapper = context.provider().get(ObjectMapper.class).fileType(bodyFormat);
         return body
-                .flatMap(b -> objectMapper.read(b, parameter.type().type()))
+                .flatMap(bodyContent -> objectMapper.read(bodyContent, parameter.type().type()))
                 .attempt(ObjectMappingException.class)
-                .mapError(e -> e);
+                .mapError(error -> error);
     }
 }


### PR DESCRIPTION
# Description
As 23.1 will introduce several larger refactored APIs, there are several places where code quality is not optimal or up-to-date. This PR is the result of an investigation into codestyle warnings across the codebase, resolving the majority of the relevant warnings.

Changes:
- Add missing deprecation notice to `CglibApplicationProxierLoader`
- Move default bindings for initializing contexts to dedicated class
    - Previously `InitializingContext` declared `applyTo` which cluttered the class, and bloated its scope. This responsibility has been moved to the `ContextBinderConfiguration`. Specifically, the `InitializingContextBinderConfiguration` captures this scope for the `InitializingContext`
- Extract complex lambda-based reportables to dedicated classes
- Extract complex lambdas to dedicated classes or methods
- Extract method interceptors to dedicated classes
    - Complex method interceptors were previously only captured inside the `ComponentProcessor` which was responsible for creating it. These interceptors have now moved to their own dedicated implementations
- Weaken types where possible
- Rename short lambda parameter names
- Rename ambiguous, short, or unclear variables and members
- Simplify notation for doubles and arrays
- Add `this` to unqualified members
- Weaken access modifiers for abstract class constructors to `protected`
- Add missing explicit `final` modifiers
- Weaken overly strong casts
- Use `assertSame` for class comparisons
- Resolve or suppress public field usage
    - Some `public static` classes were not `final` while they should have been. Usages where the field is intentionally non-final have been marked as such
- Make component initializers `final`, state remains mutable
    - The initializers can be configured to yield different results. The initializer itself however should never be replaced.
- Clean up minor code smells and duplication
- Use `ProcessingOrder` constants where possible
- Clean up modifiers for possible finals and missorted modifiers
- Resolve transitive dependencies in Gradle setup
    - **Important**, this resolves the transitive dependencies between projects and published artifacts. This way we no longer need to explicitly add all required transitive dependencies.
- null safe string comparisons and serialization
- Add missing `@Override` annotations

Fixes #966

## Type of change
- [x] Style (style changes)
- [x] Chore (changes to the build process or auxiliary tools)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
