### PR TITLE
#971 Replace internal field injections with constructor injections

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -203,7 +203,7 @@ allprojects {
 
             // Automatically generate test reports. This is not always required, but it's nice to
             // have, and makes CI integration easier.
-            finalizedBy(":jacocoMergedReport")
+//            finalizedBy(":jacocoMergedReport")
         }
 
         withType<JavaCompile> {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/ApplicationSystemSubject.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/ApplicationSystemSubject.java
@@ -16,11 +16,19 @@
 
 package org.dockbox.hartshorn.commands;
 
+import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.i18n.Message;
 
+import jakarta.inject.Inject;
+
 @Component
 public class ApplicationSystemSubject extends SystemSubject {
+
+    @Inject
+    public ApplicationSystemSubject(final ApplicationContext applicationContext) {
+        super(applicationContext);
+    }
 
     @Override
     public void send(final Message text) {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
@@ -52,12 +52,16 @@ public class CommandGatewayImpl implements CommandGateway {
     private final transient MultiMap<String, CommandExecutorContext> contexts = new CopyOnWriteArrayListMultiMap<>();
     private final transient List<CommandExecutorExtension> extensions = new CopyOnWriteArrayList<>();
 
+    private final CommandParser parser;
+    private final CommandResources resources;
+    private final ApplicationContext context;
+
     @Inject
-    private CommandParser parser;
-    @Inject
-    private CommandResources resources;
-    @Inject
-    private ApplicationContext context;
+    public CommandGatewayImpl(final CommandParser parser, final CommandResources resources, final ApplicationContext context) {
+        this.parser = parser;
+        this.resources = resources;
+        this.context = context;
+    }
 
     protected MultiMap<String, CommandExecutorContext> contexts() {
         return this.contexts;

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandListenerImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandListenerImpl.java
@@ -27,20 +27,19 @@ import jakarta.inject.Inject;
 
 public class CommandListenerImpl implements CommandListener {
 
+    private final ApplicationContext context;
+    private final CommandGateway gateway;
+
     @Inject
-    private ApplicationContext context;
-    @Inject
-    private CommandGateway gateway;
+    public CommandListenerImpl(final ApplicationContext applicationContext, final CommandGateway gateway) {
+        this.context = applicationContext;
+        this.gateway = gateway;
+        this.source(SystemSubject.instance(applicationContext));
+    }
 
     private boolean async;
     private InputStream input = System.in;
     private CommandSource source;
-
-    @Inject
-    protected void context(final ApplicationContext applicationContext) {
-        this.context = applicationContext;
-        this.source(SystemSubject.instance(applicationContext));
-    }
 
     public boolean async() {
         return this.async;

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
@@ -52,8 +52,12 @@ public class CommandParserImpl implements CommandParser {
     // to indicate it is a single element and not part of a piece of text.
     private static final Pattern FLAG = Pattern.compile(" -(-?\\w+)(?: ([^ -]+))?");
 
+    private final CommandResources resources;
+
     @Inject
-    private CommandResources resources;
+    public CommandParserImpl(final CommandResources resources) {
+        this.resources = resources;
+    }
 
     @Override
     public Option<CommandContext> parse(final String command, final CommandSource source, final CommandExecutorContext context) throws ParsingException {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandProviders.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandProviders.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.commands;
 
+import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.contextual.StaticBinds;
 import org.dockbox.hartshorn.commands.annotations.UseCommands;
 import org.dockbox.hartshorn.commands.arguments.CommandParameterLoader;
@@ -46,8 +47,8 @@ public class CommandProviders {
     public Class<? extends CommandParser> commandParser = CommandParserImpl.class;
 
     @StaticBinds
-    public static CooldownExtension cooldownExtension() {
-        return new CooldownExtension();
+    public static CooldownExtension cooldownExtension(final ApplicationContext applicationContext) {
+        return new CooldownExtension(applicationContext);
     }
 
     @Binds("command_loader")

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/SystemSubject.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/SystemSubject.java
@@ -28,14 +28,18 @@ import jakarta.inject.Singleton;
 @Singleton
 public abstract class SystemSubject implements CommandSource, Identifiable {
 
-    @Inject
-    private ApplicationContext applicationContext;
+    private final ApplicationContext applicationContext;
     private Locale locale = Locale.getDefault();
 
     public static final UUID UNIQUE_ID = new UUID(0, 0);
 
     public static SystemSubject instance(final ApplicationContext context) {
         return context.get(SystemSubject.class);
+    }
+
+    @Inject
+    protected SystemSubject(final ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
     }
 
     @Override

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/HashtagParameterPattern.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/HashtagParameterPattern.java
@@ -36,8 +36,12 @@ import jakarta.inject.Inject;
 @Component
 public class HashtagParameterPattern extends PrefixedParameterPattern {
 
+    private final CommandParameterResources resources;
+
     @Inject
-    private CommandParameterResources resources;
+    public HashtagParameterPattern(final CommandParameterResources resources) {
+        this.resources = resources;
+    }
 
     @Override
     protected char opening() {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/extension/CooldownExtension.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/extension/CooldownExtension.java
@@ -16,12 +16,14 @@
 
 package org.dockbox.hartshorn.commands.extension;
 
+import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.commands.CommandResources;
 import org.dockbox.hartshorn.commands.CommandSource;
 import org.dockbox.hartshorn.commands.annotations.Cooldown;
 import org.dockbox.hartshorn.commands.context.CommandContext;
 import org.dockbox.hartshorn.commands.context.CommandExecutorContext;
 import org.dockbox.hartshorn.component.Component;
+import org.dockbox.hartshorn.i18n.Message;
 import org.dockbox.hartshorn.util.Identifiable;
 
 import java.time.LocalDateTime;
@@ -40,10 +42,13 @@ import jakarta.inject.Inject;
 @Component
 public class CooldownExtension implements CommandExecutorExtension {
 
-    @Inject
-    private CommandResources resources;
-
     private final Map<Object, CooldownEntry> activeCooldowns = new ConcurrentHashMap<>();
+    private final ApplicationContext applicationContext;
+
+    @Inject
+    public CooldownExtension(final ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
 
     @Override
     public ExtensionResult execute(final CommandContext context, final CommandExecutorContext executorContext) {
@@ -53,13 +58,18 @@ public class CooldownExtension implements CommandExecutorExtension {
         final String id = this.id((Identifiable) sender, context);
         if (this.inCooldown(id)) {
             context.applicationContext().log().debug("Executor with ID '%s' is in active cooldown, rejecting command execution of %s".formatted(id, context.command()));
-            return ExtensionResult.reject(this.resources.cooldownActive());
+            final Message cooldownMessage = this.activeCooldownMessage();
+            return ExtensionResult.reject(cooldownMessage);
         }
         else {
             final Cooldown cooldown = executorContext.element().annotations().get(Cooldown.class).get();
             this.cooldown(id, cooldown.duration(), cooldown.unit());
             return ExtensionResult.accept();
         }
+    }
+
+    protected Message activeCooldownMessage() {
+        return this.applicationContext.get(CommandResources.class).cooldownActive();
     }
 
     @Override

--- a/hartshorn-commands/src/test/java/test/org/dockbox/hartshorn/commands/HashtagParameterPatternTests.java
+++ b/hartshorn-commands/src/test/java/test/org/dockbox/hartshorn/commands/HashtagParameterPatternTests.java
@@ -17,6 +17,7 @@
 package test.org.dockbox.hartshorn.commands;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.commands.CommandParameterResources;
 import org.dockbox.hartshorn.commands.SystemSubject;
 import org.dockbox.hartshorn.commands.annotations.UseCommands;
 import org.dockbox.hartshorn.commands.arguments.ConverterException;
@@ -54,7 +55,7 @@ public class HashtagParameterPatternTests {
     }
 
     private HashtagParameterPattern pattern() {
-        return new HashtagParameterPattern() {
+        return new HashtagParameterPattern(this.applicationContext.get(CommandParameterResources.class)) {
             @Override
             protected Message wrongFormat() {
                 // Override resources as these are otherwise requested through bound resource references

--- a/hartshorn-commands/src/test/java/test/org/dockbox/hartshorn/commands/JUnitSystemSubject.java
+++ b/hartshorn-commands/src/test/java/test/org/dockbox/hartshorn/commands/JUnitSystemSubject.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.commands;
 
+import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.commands.SystemSubject;
 import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.i18n.Message;
@@ -23,10 +24,17 @@ import org.dockbox.hartshorn.i18n.Message;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.inject.Inject;
+
 @Component
 public class JUnitSystemSubject extends SystemSubject {
 
     private final List<Message> received = new ArrayList<>();
+
+    @Inject
+    public JUnitSystemSubject(final ApplicationContext applicationContext) {
+        super(applicationContext);
+    }
 
     @Override
     public void send(final Message text) {

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/PathSerializationSourceConverter.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/PathSerializationSourceConverter.java
@@ -36,8 +36,12 @@ import jakarta.inject.Inject;
 @Component(singleton = true)
 public class PathSerializationSourceConverter implements SerializationSourceConverter {
 
+    private final ApplicationFSProvider fileSystem;
+
     @Inject
-    private ApplicationFSProvider fileSystem;
+    public PathSerializationSourceConverter(final ApplicationFSProvider fileSystem) {
+        this.fileSystem = fileSystem;
+    }
 
     @Override
     public InputStream inputStream(final AnnotatedElementView context, final Object... args) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/FactoryServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/factory/FactoryServicePreProcessor.java
@@ -16,9 +16,6 @@
 
 package org.dockbox.hartshorn.component.factory;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
@@ -33,6 +30,9 @@ import org.dockbox.hartshorn.inject.processing.BindingProcessor;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class FactoryServicePreProcessor extends ComponentPreProcessor implements ExitingComponentProcessor {
 
@@ -49,6 +49,7 @@ public class FactoryServicePreProcessor extends ComponentPreProcessor implements
             if (!"".equals(annotation.value())) componentKey = componentKey.mutable().name(annotation.value()).build();
 
             if (!lookupMatchingConstructor(context, factoryContext, (MethodView<Object, ?>) method, componentKey)) {
+                // TODO: Fix L
                 if (annotation.required()) throw new MissingFactoryConstructorException(componentKey, method);
             }
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ConcreteContextCarrier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ConcreteContextCarrier.java
@@ -25,13 +25,9 @@ import jakarta.inject.Inject;
  * A concrete implementation of {@link ContextCarrier}.
  */
 @Component
-public class ConcreteContextCarrier implements ContextCarrier {
+public record ConcreteContextCarrier(ApplicationContext applicationContext) implements ContextCarrier {
 
     @Inject
-    private ApplicationContext applicationContext;
-
-    @Override
-    public ApplicationContext applicationContext() {
-        return this.applicationContext;
+    public ConcreteContextCarrier {
     }
 }

--- a/hartshorn-events/src/test/java/test/org/dockbox/hartshorn/events/TestEventBus.java
+++ b/hartshorn-events/src/test/java/test/org/dockbox/hartshorn/events/TestEventBus.java
@@ -17,6 +17,7 @@
 package test.org.dockbox.hartshorn.events;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.events.EventBusImpl;
@@ -25,8 +26,15 @@ import org.dockbox.hartshorn.events.EventWrapper;
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.inject.Inject;
+
 @Component(singleton = true)
 public class TestEventBus extends EventBusImpl {
+
+    @Inject
+    public TestEventBus(final ApplicationContext applicationContext) {
+        super(applicationContext);
+    }
 
     public @NonNull Map<ComponentKey<?>, Set<EventWrapper>> invokers() {
         return this.listenerToInvokers;

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Interpreter.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/Interpreter.java
@@ -108,8 +108,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
-import jakarta.inject.Inject;
-
 /**
  * Standard interpreter for HSL. This interpreter is capable of executing HSL code by visiting the AST
  * step by step. The interpreter is capable of handling all types of statements and expressions. The
@@ -140,15 +138,13 @@ public class Interpreter implements ExpressionVisitor<Object>, StatementVisitor<
     private final Set<String> activeModules = ConcurrentHashMap.newKeySet();
 
     private final Map<String, NativeModule> externalModules;
+    private final ApplicationContext applicationContext;
     private final ResultCollector resultCollector;
 
     private VariableScope global = new VariableScope();
     private VariableScope visitingScope = this.global;
     private boolean isRunning;
     private ExecutionOptions executionOptions;
-
-    @Inject
-    private ApplicationContext applicationContext;
 
     @Bound
     public Interpreter(final ResultCollector resultCollector, final Map<String, NativeModule> externalModules) {
@@ -158,6 +154,7 @@ public class Interpreter implements ExpressionVisitor<Object>, StatementVisitor<
     @Bound
     public Interpreter(final ResultCollector resultCollector, final Map<String, NativeModule> externalModules, final ExecutionOptions executionOptions) {
         this.resultCollector = resultCollector;
+        this.applicationContext = resultCollector.applicationContext();
         this.externalModules = new ConcurrentHashMap<>(externalModules);
         this.executionOptions = executionOptions;
     }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/ResultCollector.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/interpreter/ResultCollector.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.hsl.interpreter;
 
+import org.dockbox.hartshorn.context.ContextCarrier;
 import org.dockbox.hartshorn.util.option.Option;
 
 /**
@@ -25,7 +26,7 @@ import org.dockbox.hartshorn.util.option.Option;
  * @author Guus Lieben
  * @since 22.4
  */
-public interface ResultCollector {
+public interface ResultCollector extends ContextCarrier {
 
     /**
      * Adds a global result to the stack, if a global result already exists it will be

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/BundledTranslationService.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/BundledTranslationService.java
@@ -20,16 +20,16 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.util.option.Option;
 
-import jakarta.inject.Inject;
-
 @Component
 public class BundledTranslationService implements TranslationService {
 
-    @Inject
-    private ApplicationContext applicationContext;
-
-    @Inject
+    private final ApplicationContext applicationContext;
     private TranslationBundle bundle;
+
+    public BundledTranslationService(final ApplicationContext applicationContext, final TranslationBundle bundle) {
+        this.applicationContext = applicationContext;
+        this.bundle = bundle;
+    }
 
     @Override
     public ApplicationContext applicationContext() {

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
@@ -20,6 +20,7 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.config.FileFormat;
 import org.dockbox.hartshorn.config.ObjectMapper;
+import org.dockbox.hartshorn.util.CollectionUtilities;
 import org.dockbox.hartshorn.util.option.Option;
 
 import java.nio.file.Path;
@@ -31,8 +32,6 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
-import jakarta.inject.Inject;
 
 @Component
 public class DefaultTranslationBundle implements TranslationBundle {
@@ -94,10 +93,15 @@ public class DefaultTranslationBundle implements TranslationBundle {
 
     @Override
     public TranslationBundle merge(final TranslationBundle bundle) {
-        final DefaultTranslationBundle translationBundle = new DefaultTranslationBundle().primaryLanguage(this.primaryLanguage());
+        final DefaultTranslationBundle translationBundle = new DefaultTranslationBundle(this.applicationContext)
+                .primaryLanguage(this.primaryLanguage());
+
         final Map<String, Message> messageDict = translationBundle.messages;
-        for (final Message message : this.messages()) messageDict.put(message.key(), this.mergeMessages(message, messageDict));
-        for (final Message message : bundle.messages()) messageDict.put(message.key(), this.mergeMessages(message, messageDict));
+        CollectionUtilities.forEach(
+                message -> messageDict.put(message.key(), this.mergeMessages(message, messageDict)),
+                this.messages(), bundle.messages()
+        );
+
         return translationBundle;
     }
 

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
@@ -38,10 +38,12 @@ import jakarta.inject.Inject;
 public class DefaultTranslationBundle implements TranslationBundle {
 
     private final Map<String, Message> messages = new ConcurrentHashMap<>();
-
-    @Inject
-    private ApplicationContext applicationContext;
+    private final ApplicationContext applicationContext;
     private Locale primaryLanguage = Locale.getDefault();
+
+    public DefaultTranslationBundle(final ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
 
     @Override
     public Locale primaryLanguage() {

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationProviders.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationProviders.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.i18n;
 
+import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
@@ -29,13 +30,13 @@ import org.dockbox.hartshorn.i18n.services.TranslationKeyGenerator;
 public class TranslationProviders {
 
     @Binds
-    public TranslationService translationService() {
-        return new BundledTranslationService();
+    public TranslationService translationService(final ApplicationContext applicationContext, final TranslationBundle bundle) {
+        return new BundledTranslationService(applicationContext, bundle);
     }
 
     @Binds
-    public TranslationBundle translationBundle() {
-        return new DefaultTranslationBundle();
+    public TranslationBundle translationBundle(final ApplicationContext applicationContext) {
+        return new DefaultTranslationBundle(applicationContext);
     }
 
     @Binds

--- a/hartshorn-i18n/src/test/java/test/org/dockbox/hartshorn/i18n/MessageTemplateServiceTests.java
+++ b/hartshorn-i18n/src/test/java/test/org/dockbox/hartshorn/i18n/MessageTemplateServiceTests.java
@@ -16,8 +16,6 @@
 
 package test.org.dockbox.hartshorn.i18n;
 
-import java.util.Locale;
-
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.i18n.DefaultTranslationBundle;
 import org.dockbox.hartshorn.i18n.Message;
@@ -34,6 +32,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.Locale;
+
+import jakarta.inject.Inject;
+
 @HartshornTest(includeBasePackages = false)
 @UseTranslations
 public class MessageTemplateServiceTests {
@@ -41,10 +43,13 @@ public class MessageTemplateServiceTests {
     private static final Locale NL_NL = new Locale("nl", "NL");
     private static final Locale EN_US = Locale.US;
 
+    @Inject
+    private ApplicationContext applicationContext;
+
     private TranslationBundle bundle() {
         final Message english = new MessageTemplate("value", "demo", EN_US);
         final Message dutch = new MessageTemplate("waarde", "demo", NL_NL);
-        final TranslationBundle bundle = new DefaultTranslationBundle();
+        final TranslationBundle bundle = new DefaultTranslationBundle(this.applicationContext);
         bundle.register(english);
         bundle.register(dutch);
         return bundle;

--- a/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionExecutableParametersIntrospector.java
+++ b/hartshorn-introspect/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionExecutableParametersIntrospector.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
 public class ReflectionExecutableParametersIntrospector implements ExecutableParametersIntrospector {
@@ -99,14 +100,29 @@ public class ReflectionExecutableParametersIntrospector implements ExecutablePar
     }
 
     @Override
+    public boolean matchesExact(final Class<?>... parameterTypes) {
+        return this.matchesExact(Arrays.asList(parameterTypes));
+    }
+
+    @Override
+    public boolean matchesExact(final List<Class<?>> parameterTypes) {
+        return this.matches(parameterTypes, TypeView::is);
+    }
+
+    @Override
     public boolean matches(final List<Class<?>> parameterTypes) {
+        return this.matches(parameterTypes, TypeView::isParentOf);
+    }
+
+    private boolean matches(final List<Class<?>> parameterTypes, final BiPredicate<TypeView<?>, Class<?>> predicate) {
         if (parameterTypes.size() != this.count()) return false;
         final List<TypeView<?>> types = this.types();
         for (int i = 0; i < types.size(); i++) {
             final TypeView<?> type = types.get(i);
             final Class<?> expected = parameterTypes.get(i);
-            if (!type.is(expected)) return false;
+            if (!predicate.test(type, expected)) return false;
         }
         return true;
+
     }
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ExecutableParametersIntrospector.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ExecutableParametersIntrospector.java
@@ -39,6 +39,10 @@ public interface ExecutableParametersIntrospector {
 
     boolean matches(Class<?>... parameterTypes);
 
+    boolean matchesExact(Class<?>... parameterTypes);
+
     boolean matches(List<Class<?>> parameterTypes);
+
+    boolean matchesExact(List<Class<?>> parameterTypes);
 
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/util/ParameterLoadException.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/util/ParameterLoadException.java
@@ -24,7 +24,7 @@ public class ParameterLoadException extends ApplicationRuntimeException {
     private final ParameterView<?> parameter;
 
     public ParameterLoadException(final ParameterView<?> parameter, final Throwable cause) {
-        super("Failed to load parameter " + parameter.name() + " of type " + parameter.type().name() + " for " + parameter.declaredBy().qualifiedName(), cause);
+        super("Failed to load parameter '" + parameter.name() + "' of type " + parameter.type().name() + " for " + parameter.declaredBy().qualifiedName(), cause);
         this.parameter = parameter;
     }
 

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/util/ParameterLoadException.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/util/ParameterLoadException.java
@@ -24,7 +24,7 @@ public class ParameterLoadException extends ApplicationRuntimeException {
     private final ParameterView<?> parameter;
 
     public ParameterLoadException(final ParameterView<?> parameter, final Throwable cause) {
-        super("Failed to load parameter " + parameter.name() + " of type " + parameter.type().name(), cause);
+        super("Failed to load parameter " + parameter.name() + " of type " + parameter.type().name() + " for " + parameter.declaredBy().qualifiedName(), cause);
         this.parameter = parameter;
     }
 

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/util/RuleBasedParameterLoader.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/util/RuleBasedParameterLoader.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.util.introspect.util;
 
+import org.dockbox.hartshorn.util.ApplicationRuntimeException;
 import org.dockbox.hartshorn.util.introspect.view.ParameterView;
 import org.dockbox.hartshorn.util.option.Option;
 
@@ -71,7 +72,7 @@ public class RuleBasedParameterLoader<C extends ParameterLoaderContext> extends 
                 }
                 arguments.add(this.loadDefault(parameter, i, context, args));
             }
-            catch (final Exception e) {
+            catch (final ApplicationRuntimeException e) {
                 throw new ParameterLoadException(parameter, e);
             }
         }

--- a/hartshorn-jpa/hartshorn-jpa-hibernate/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateDataSourceList.java
+++ b/hartshorn-jpa/hartshorn-jpa-hibernate/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateDataSourceList.java
@@ -25,16 +25,19 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.annotation.PostConstruct;
-import jakarta.inject.Inject;
 
 @Component(singleton = true)
 public class HibernateDataSourceList implements RefreshableDataSourceList {
 
-    @Inject
-    private HibernateDataSourceConfigurationObject sources;
-    @Inject
-    private ApplicationContext applicationContext;
     private final Map<String, DataSourceConfiguration> configurations = new ConcurrentHashMap<>();
+    private final ApplicationContext applicationContext;
+
+    private HibernateDataSourceConfigurationObject sources;
+
+    public HibernateDataSourceList(final ApplicationContext applicationContext, final HibernateDataSourceConfigurationObject sources) {
+        this.applicationContext = applicationContext;
+        this.sources = sources;
+    }
 
     @Override
     public void add(final String id, final DataSourceConfiguration configuration) {

--- a/hartshorn-jpa/hartshorn-jpa-hibernate/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateEntityManagerCarrier.java
+++ b/hartshorn-jpa/hartshorn-jpa-hibernate/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateEntityManagerCarrier.java
@@ -66,21 +66,20 @@ public class HibernateEntityManagerCarrier implements EntityManagerCarrier, Cont
     public static final String HH_HIBERNATE_DIALECT = "hartshorn.data.hibernate.dialect";
 
     private final Configuration hibernateConfiguration = new Configuration();
+    private final ApplicationContext applicationContext;
 
     private SessionFactory factory;
     private DataSourceConfiguration configuration;
     private Session session;
 
     @Inject
-    private ApplicationContext applicationContext;
-
-    @Inject
-    public HibernateEntityManagerCarrier() {
-        this(null);
+    public HibernateEntityManagerCarrier(final ApplicationContext applicationContext) {
+        this(applicationContext, null);
     }
 
     @Bound
-    public HibernateEntityManagerCarrier(final DataSourceConfiguration configuration) {
+    public HibernateEntityManagerCarrier(final ApplicationContext applicationContext, final DataSourceConfiguration configuration) {
+        this.applicationContext = applicationContext;
         this.configuration = configuration;
     }
 

--- a/hartshorn-jpa/hartshorn-jpa-hibernate/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateJpaRepository.java
+++ b/hartshorn-jpa/hartshorn-jpa-hibernate/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateJpaRepository.java
@@ -18,8 +18,6 @@ package org.dockbox.hartshorn.jpa.hibernate;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
-import org.dockbox.hartshorn.inject.Enable;
-import org.dockbox.hartshorn.inject.Required;
 import org.dockbox.hartshorn.inject.binding.Bound;
 import org.dockbox.hartshorn.jpa.entitymanager.EntityManagerCarrier;
 import org.dockbox.hartshorn.jpa.entitymanager.EntityManagerJpaRepository;
@@ -29,35 +27,29 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 
 import jakarta.annotation.PostConstruct;
-import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 
 @Component
 public class HibernateJpaRepository<T, ID> extends EntityManagerJpaRepository<T, ID> {
 
     private final DataSourceConfiguration connection;
-
-    @Inject
-    @Enable(false) // Enabling is delegated
-    @Required
-    private HibernateEntityManagerCarrier entityManager;
-    @Inject
-    private ApplicationContext applicationContext;
+    private final HibernateEntityManagerCarrier entityManager;
 
     @Bound
     public HibernateJpaRepository(final Class<T> type) {
-        this(type, null);
+        this(type, new HibernateEntityManagerCarrier());
     }
 
     @Bound
-    public HibernateJpaRepository(final Class<T> type, final DataSourceConfiguration connection) {
+    public HibernateJpaRepository(final Class<T> type, final HibernateEntityManagerCarrier entityManagerCarrier) {
         super(type);
-        this.connection = connection;
+        this.entityManager = entityManagerCarrier;
+        this.connection = entityManagerCarrier.configuration();
     }
 
     @Override
     public ApplicationContext applicationContext() {
-        return this.applicationContext;
+        return this.entityManager.applicationContext();
     }
 
     @Override

--- a/hartshorn-jpa/hartshorn-jpa-hibernate/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateJpaRepository.java
+++ b/hartshorn-jpa/hartshorn-jpa-hibernate/src/main/java/org/dockbox/hartshorn/jpa/hibernate/HibernateJpaRepository.java
@@ -36,8 +36,8 @@ public class HibernateJpaRepository<T, ID> extends EntityManagerJpaRepository<T,
     private final HibernateEntityManagerCarrier entityManager;
 
     @Bound
-    public HibernateJpaRepository(final Class<T> type) {
-        this(type, new HibernateEntityManagerCarrier());
+    public HibernateJpaRepository(final Class<T> type, final ApplicationContext applicationContext) {
+        this(type, new HibernateEntityManagerCarrier(applicationContext));
     }
 
     @Bound

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaRepositoryDelegationPostProcessor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaRepositoryDelegationPostProcessor.java
@@ -51,7 +51,7 @@ public class JpaRepositoryDelegationPostProcessor extends ProxyDelegationPostPro
                 .orElseThrow(() -> new IllegalStateException("No data source found for repository " + repositoryType.type().getName()));
 
         final EntityManagerCarrier entityManagerCarrier = context.get(EntityManagerFactory.class)
-                .entityManagerCarrier(sourceConfiguration);
+                .entityManagerCarrier(context, sourceConfiguration);
 
         return context.get(JpaRepositoryFactory.class).repository(type, entityManagerCarrier);
     }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaRepositoryDelegationPostProcessor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaRepositoryDelegationPostProcessor.java
@@ -18,6 +18,8 @@ package org.dockbox.hartshorn.jpa;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.jpa.annotations.DataSource;
+import org.dockbox.hartshorn.jpa.entitymanager.EntityManagerCarrier;
+import org.dockbox.hartshorn.jpa.entitymanager.EntityManagerFactory;
 import org.dockbox.hartshorn.jpa.remote.DataSourceConfiguration;
 import org.dockbox.hartshorn.jpa.remote.DataSourceList;
 import org.dockbox.hartshorn.proxy.ProxyFactory;
@@ -48,6 +50,9 @@ public class JpaRepositoryDelegationPostProcessor extends ProxyDelegationPostPro
                 .orCompute(dataSourceList::defaultConnection)
                 .orElseThrow(() -> new IllegalStateException("No data source found for repository " + repositoryType.type().getName()));
 
-        return context.get(JpaRepositoryFactory.class).repository(type, sourceConfiguration);
+        final EntityManagerCarrier entityManagerCarrier = context.get(EntityManagerFactory.class)
+                .entityManagerCarrier(sourceConfiguration);
+
+        return context.get(JpaRepositoryFactory.class).repository(type, entityManagerCarrier);
     }
 }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaRepositoryFactory.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaRepositoryFactory.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.jpa;
 
+import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.factory.Factory;
@@ -59,5 +60,5 @@ public interface JpaRepositoryFactory {
      */
     @Factory
     @Enable(false)
-    <T> JpaRepository<T, ?> repository(Class<T> type);
+    <T> JpaRepository<T, ?> repository(Class<T> type, ApplicationContext applicationContext);
 }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaRepositoryFactory.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/JpaRepositoryFactory.java
@@ -21,7 +21,7 @@ import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.factory.Factory;
 import org.dockbox.hartshorn.inject.Enable;
 import org.dockbox.hartshorn.jpa.annotations.UsePersistence;
-import org.dockbox.hartshorn.jpa.remote.DataSourceConfiguration;
+import org.dockbox.hartshorn.jpa.entitymanager.EntityManagerCarrier;
 
 /**
  * Default factory for bound {@link JpaRepository} instances.
@@ -37,20 +37,20 @@ public interface JpaRepositoryFactory {
      * The connection is immediately set up.
      *
      * @param type The entity type
-     * @param connection The connection configuration
+     * @param entityManagerCarrier The entity manager carrier, which is used to set up the connection
      * @return A new {@link JpaRepository} instance
      * @param <T> The entity type
      * @since 22.4
      */
     @Factory
-    <T> JpaRepository<T, ?> repository(Class<T> type, DataSourceConfiguration connection);
+    <T> JpaRepository<T, ?> repository(Class<T> type, EntityManagerCarrier entityManagerCarrier);
 
     /**
      * Creates a new {@link JpaRepository} instance for the given type, without setting the
      * connection. As the connection is not set, the repository will not be enabled automatically.
      *
-     * This is useful for creating a repository that is configured manually. In scenarios where
-     * the connection is already known, use {@link #repository(Class, DataSourceConfiguration)}.
+     * <p>This is useful for creating a repository that is configured manually. In scenarios where
+     * the connection is already known, use {@link #repository(Class, EntityManagerCarrier)}.
      *
      * @param type The entity type
      * @return A new {@link JpaRepository} instance

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/entitymanager/EntityManagerFactory.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/entitymanager/EntityManagerFactory.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.jpa.entitymanager;
 
+import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.factory.Factory;
@@ -27,6 +28,6 @@ import org.dockbox.hartshorn.jpa.remote.DataSourceConfiguration;
 public interface EntityManagerFactory {
 
     @Factory
-    EntityManagerCarrier entityManagerCarrier(DataSourceConfiguration configuration);
+    EntityManagerCarrier entityManagerCarrier(ApplicationContext applicationContext, DataSourceConfiguration configuration);
 
 }

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/EntityManagerQueryConstructor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/query/context/EntityManagerQueryConstructor.java
@@ -18,16 +18,12 @@ package org.dockbox.hartshorn.jpa.query.context;
 
 import org.dockbox.hartshorn.inject.binding.Bound;
 import org.dockbox.hartshorn.jpa.query.QueryConstructor;
-import org.dockbox.hartshorn.jpa.query.QueryExecuteTypeLookup;
 
-import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 
 public class EntityManagerQueryConstructor implements QueryConstructor {
 
-    @Inject
-    private QueryExecuteTypeLookup queryExecuteTypeLookup;
     private final EntityManager entityManager;
 
     @Bound

--- a/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/transaction/TransactionalProxyCallbackPostProcessor.java
+++ b/hartshorn-jpa/src/main/java/org/dockbox/hartshorn/jpa/transaction/TransactionalProxyCallbackPostProcessor.java
@@ -61,7 +61,7 @@ public class TransactionalProxyCallbackPostProcessor extends PhasedProxyCallback
             // Do not fail if no data source is configured, as this may be configured in a different way.
             if (sourceConfiguration != null) {
                 final EntityManagerFactory factory = context.get(EntityManagerFactory.class);
-                final EntityManagerCarrier carrier = factory.entityManagerCarrier(sourceConfiguration);
+                final EntityManagerCarrier carrier = factory.entityManagerCarrier(context, sourceConfiguration);
                 final EntityManagerContext entityManagerContext = new EntityManagerContext(carrier::manager);
                 proxyFactory.contextContainer().add(entityManagerContext);
             }

--- a/hartshorn-jpa/src/testFixtures/java/test/org/dockbox/hartshorn/jpa/JpaRepositoryTests.java
+++ b/hartshorn-jpa/src/testFixtures/java/test/org/dockbox/hartshorn/jpa/JpaRepositoryTests.java
@@ -167,7 +167,7 @@ public abstract class JpaRepositoryTests implements DataSourceConfigurationLoade
         if (!mySql.isRunning()) mySql.start();
 
         final JpaRepositoryFactory factory = this.applicationContext.get(JpaRepositoryFactory.class);
-        final JpaRepository<User, ?> repository = factory.repository(User.class);
+        final JpaRepository<User, ?> repository = factory.repository(User.class, this.applicationContext);
         Assertions.assertTrue(repository instanceof EntityManagerCarrier);
 
         this.applicationContext.get(LazyJdbcRepositoryConfigurationInitializer.class).initialize(mySql, MySQLContainer.MYSQL_PORT);

--- a/hartshorn-mvc/src/main/java/org/dockbox/hartshorn/web/mvc/MvcServlet.java
+++ b/hartshorn-mvc/src/main/java/org/dockbox/hartshorn/web/mvc/MvcServlet.java
@@ -21,16 +21,16 @@ import org.dockbox.hartshorn.inject.binding.Bound;
 import org.dockbox.hartshorn.introspect.ViewContextAdapter;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.TypeUtils;
-import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
-import org.dockbox.hartshorn.util.option.Attempt;
 import org.dockbox.hartshorn.util.introspect.util.ParameterLoader;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
+import org.dockbox.hartshorn.util.option.Attempt;
 import org.dockbox.hartshorn.web.HttpAction;
 import org.dockbox.hartshorn.web.HttpStatus;
 import org.dockbox.hartshorn.web.mvc.model.ViewModelImpl;
 import org.dockbox.hartshorn.web.mvc.template.ViewTemplate;
 import org.dockbox.hartshorn.web.servlet.WebServlet;
 
+import java.io.IOException;
 import java.util.List;
 
 import jakarta.inject.Inject;
@@ -64,7 +64,6 @@ public class MvcServlet implements WebServlet {
     public void get(final HttpServletRequest req, final HttpServletResponse res, final HttpAction fallback) throws ApplicationException {
         final ParameterLoader<MvcParameterLoaderContext> loader = this.parameterLoader;
         final ViewModelImpl viewModel = new ViewModelImpl();
-        final TypeView<ViewTemplate> typeView = this.applicationContext.environment().introspect(ViewTemplate.class);
         final MvcParameterLoaderContext loaderContext = new MvcParameterLoaderContext(this.method,
                 null, this.applicationContext, req, res, viewModel);
         final List<Object> arguments = loader.loadArguments(loaderContext);
@@ -81,7 +80,7 @@ public class MvcServlet implements WebServlet {
                     res.setStatus(HttpStatus.OK.value());
                     res.getWriter().write(content);
                     return;
-                } catch (final Exception e) {
+                } catch (final IOException e) {
                     res.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
                     throw new ApplicationException(e);
                 }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/CollectionUtilities.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/CollectionUtilities.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public final class CollectionUtilities {
@@ -96,5 +97,12 @@ public final class CollectionUtilities {
         mergedDifference.addAll(differenceInTwo);
 
         return Set.copyOf(mergedDifference);
+    }
+
+    @SafeVarargs
+    public static <T> void forEach(final Consumer<T> consumer, final Collection<T>... collections) {
+        for (final Collection<T> collection : collections) {
+            collection.forEach(consumer);
+        }
     }
 }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/AbstractGraphVisitor.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/AbstractGraphVisitor.java
@@ -1,0 +1,14 @@
+package org.dockbox.hartshorn.util.graph;
+
+public abstract class AbstractGraphVisitor<T> implements GraphIterator<T> {
+
+    protected abstract boolean visit(GraphNode<T> node);
+
+    protected void beforePathVisited() {
+        // Do nothing by default, can be overridden
+    }
+
+    protected void afterPathVisited() {
+        // Do nothing by default, can be overridden
+    }
+}

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/BreadthFirstGraphVisitor.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/BreadthFirstGraphVisitor.java
@@ -1,0 +1,42 @@
+package org.dockbox.hartshorn.util.graph;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class BreadthFirstGraphVisitor<T> extends AbstractGraphVisitor<T> {
+
+    @Override
+    public final void iterate(final Graph<T> graph) {
+        final Set<GraphNode<T>> visited = new HashSet<>();
+
+        Set<GraphNode<T>> nodes = graph.roots();
+        while (!nodes.isEmpty()) {
+            this.beforePathVisited();
+            final Set<GraphNode<T>> currentRow = this.filterNodesWithUnresolvedParents(visited, nodes);
+            nodes = this.visitRow(visited, currentRow);
+            this.afterPathVisited();
+        }
+    }
+
+    private Set<GraphNode<T>> visitRow(final Set<GraphNode<T>> visited, final Set<GraphNode<T>> currentRow) {
+        final Set<GraphNode<T>> nextRow = new HashSet<>();
+        for (final GraphNode<T> node : currentRow) {
+            if (visited.add(node) && this.visit(node)) {
+                nextRow.addAll(node.children());
+            }
+        }
+        return nextRow;
+    }
+
+    private Set<GraphNode<T>> filterNodesWithUnresolvedParents(final Set<GraphNode<T>> visited, final Set<GraphNode<T>> nodes) {
+        final Set<GraphNode<T>> currentRow = new HashSet<>(nodes);
+        // Filter out nodes that have parents that haven't been visited yet, as they can't be visited yet
+        // until their parents have been visited first.
+        for (final GraphNode<T> node : nodes) {
+            if (!visited.containsAll(node.parents())) {
+                currentRow.remove(node);
+            }
+        }
+        return currentRow;
+    }
+}

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/DepthFirstGraphVisitor.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/DepthFirstGraphVisitor.java
@@ -1,0 +1,51 @@
+package org.dockbox.hartshorn.util.graph;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class DepthFirstGraphVisitor<T> extends AbstractGraphVisitor<T> {
+
+    @Override
+    public void iterate(final Graph<T> graph) {
+        final Set<GraphNode<T>> visited = new HashSet<>();
+        for (final GraphNode<T> root : graph.roots()) {
+            this.visitSingleRoot(visited, root);
+        }
+    }
+
+    private void visitSingleRoot(final Set<GraphNode<T>> visited, final GraphNode<T> root) {
+        final Deque<GraphNode<T>> stack = new ArrayDeque<>();
+        stack.push(root);
+        boolean atNextPathStart = true;
+        while (!stack.isEmpty()) {
+            final GraphNode<T> node = stack.pop();
+            if (visited.add(node) && this.visit(node)) {
+                atNextPathStart = this.visitNextNode(stack, visited, atNextPathStart, node);
+            }
+        }
+    }
+
+    private boolean visitNextNode(final Deque<GraphNode<T>> stack, final Set<GraphNode<T>> visited, boolean atNextPathStart, final GraphNode<T> node) {
+        if (node.children().isEmpty()) {
+            this.afterPathVisited();
+            atNextPathStart = true;
+        } else {
+            this.pushResolvedNodes(stack, visited, node);
+            if (atNextPathStart) {
+                this.beforePathVisited();
+                atNextPathStart = false;
+            }
+        }
+        return atNextPathStart;
+    }
+
+    private void pushResolvedNodes(final Deque<GraphNode<T>> stack, final Set<GraphNode<T>> visited, final GraphNode<T> node) {
+        for (final GraphNode<T> child : node.children()) {
+            if (visited.containsAll(child.parents())) {
+                stack.push(child);
+            }
+        }
+    }
+}

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/Graph.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/Graph.java
@@ -1,0 +1,15 @@
+package org.dockbox.hartshorn.util.graph;
+
+import java.util.Set;
+
+public interface Graph<T> {
+    Set<GraphNode<T>> roots();
+
+    void addRoot(GraphNode<T> root);
+
+    void addRoots(Set<GraphNode<T>> roots);
+
+    void clear();
+
+    boolean isEmpty();
+}

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/GraphIterator.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/GraphIterator.java
@@ -1,0 +1,8 @@
+package org.dockbox.hartshorn.util.graph;
+
+@FunctionalInterface
+public interface GraphIterator<T> {
+
+    void iterate(Graph<T> graph);
+
+}

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/GraphNode.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/GraphNode.java
@@ -1,0 +1,29 @@
+package org.dockbox.hartshorn.util.graph;
+
+import java.util.Collection;
+import java.util.Set;
+
+public interface GraphNode<T> {
+
+    T value();
+
+    Set<GraphNode<T>> parents();
+
+    Set<GraphNode<T>> children();
+
+    void addParent(GraphNode<T> parent);
+
+    void addParents(Collection<GraphNode<T>> parents);
+
+    void addChild(GraphNode<T> child);
+
+    void addChildren(Collection<GraphNode<T>> children);
+
+    default boolean isRoot() {
+        return this.parents().isEmpty();
+    }
+
+    default boolean isLeaf() {
+        return this.children().isEmpty();
+    }
+}

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/SimpleGraph.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/SimpleGraph.java
@@ -1,0 +1,49 @@
+package org.dockbox.hartshorn.util.graph;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class SimpleGraph<T> implements Graph<T> {
+
+    private final Set<GraphNode<T>> nodes;
+
+    public SimpleGraph() {
+        this(new HashSet<>());
+    }
+
+    public SimpleGraph(final Set<GraphNode<T>> nodes) {
+        this.nodes = new HashSet<>();
+        this.addRoots(nodes);
+    }
+
+    @Override
+    public Set<GraphNode<T>> roots() {
+        // Node could have been modified to no longer be a root, so filter out any non-root nodes
+        this.nodes.removeIf(node -> !node.isRoot());
+        return Set.copyOf(this.nodes);
+    }
+
+    @Override
+    public void addRoot(final GraphNode<T> root) {
+        if (root.isRoot()) {
+            this.nodes.add(root);
+        }
+    }
+
+    @Override
+    public void addRoots(final Set<GraphNode<T>> roots) {
+        for (final GraphNode<T> root : roots) {
+            this.addRoot(root);
+        }
+    }
+
+    @Override
+    public void clear() {
+        this.nodes.clear();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.nodes.isEmpty();
+    }
+}

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/SimpleGraphNode.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/SimpleGraphNode.java
@@ -1,0 +1,64 @@
+package org.dockbox.hartshorn.util.graph;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SimpleGraphNode<T> implements GraphNode<T> {
+
+    private final T value;
+    private final Set<GraphNode<T>> parents = new HashSet<>();
+    private final Set<GraphNode<T>> children = new HashSet<>();
+
+    public SimpleGraphNode(final T value) {
+        this.value = value;
+    }
+
+    @Override
+    public T value() {
+        return this.value;
+    }
+
+    @Override
+    public Set<GraphNode<T>> parents() {
+        return Set.copyOf(this.parents);
+    }
+
+    @Override
+    public Set<GraphNode<T>> children() {
+        return Set.copyOf(this.children);
+    }
+
+    @Override
+    public void addParent(final GraphNode<T> parent) {
+        if (!this.parents.contains(parent)) {
+            this.parents.add(parent);
+            parent.addChild(this);
+        }
+    }
+
+    @Override
+    public void addParents(final Collection<GraphNode<T>> parents) {
+        parents.forEach(this::addParent);
+    }
+
+    @Override
+    public void addChild(final GraphNode<T> child) {
+        if (!this.children.contains(child)) {
+            this.children.add(child);
+            child.addParent(this);
+        }
+    }
+
+    @Override
+    public void addChildren(final Collection<GraphNode<T>> children) {
+        children.forEach(this::addChild);
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleGraphNode{" +
+                "value=" + this.value +
+                '}';
+    }
+}

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/SimpleGraphTest.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/graph/SimpleGraphTest.java
@@ -1,0 +1,131 @@
+package org.dockbox.hartshorn.util.graph;
+
+import java.util.List;
+import java.util.Set;
+
+@SuppressWarnings("UseOfSystemOutOrSystemErr")
+public class SimpleGraphTest {
+
+    public static void main(final String[] args) {
+        testGraphsWithDefinedRoots();
+//        testGraphsWithUndefinedRoots();
+    }
+
+    /**
+     * <img src="https://static.javatpoint.com/ds/images/tree-vs-graph-data-structure3.png"/>
+     */
+    private static void testGraphsWithUndefinedRoots() {
+        final GraphIterator<Integer> integerVisitor = new PrintGraphVisitor<>();
+
+        System.out.println("Unknown roots:");
+        final Graph<Integer> unknownRootsGraph = createUnknownRootsGraph();
+        integerVisitor.iterate(unknownRootsGraph);
+    }
+
+    /**
+     * <img src="https://techdifferences.com/wp-content/uploads/2018/03/Untitled-1.jpg" />
+     */
+    private static void testGraphsWithDefinedRoots() {
+        final GraphIterator<String> visitor = new PrintGraphVisitor<>();
+
+        // BFS: A -> BC -> D -> EH -> F -> G
+        // DFS: AC -> BDEFHG
+        System.out.println("Graph:");
+        final Graph<String> graph = createGraph();
+        visitor.iterate(graph);
+
+        // A -> BC -> DEF -> GH
+        // DFS: ABD -> EG -> H -> CF
+        System.out.println("Tree:");
+        final Graph<String> tree = createTree();
+        visitor.iterate(tree);
+    }
+
+    private static Graph<String> createGraph() {
+        final Graph<String> graph = new SimpleGraph<>();
+
+        final GraphNode<String> nodeA = new SimpleGraphNode<>("A");
+        final GraphNode<String> nodeB = new SimpleGraphNode<>("B");
+        final GraphNode<String> nodeC = new SimpleGraphNode<>("C");
+        final GraphNode<String> nodeD = new SimpleGraphNode<>("D");
+        final GraphNode<String> nodeE = new SimpleGraphNode<>("E");
+        final GraphNode<String> nodeF = new SimpleGraphNode<>("F");
+        final GraphNode<String> nodeG = new SimpleGraphNode<>("G");
+        final GraphNode<String> nodeH = new SimpleGraphNode<>("H");
+
+        nodeA.addChildren(List.of(nodeB, nodeC));
+        nodeB.addChild(nodeD);
+        nodeD.addChildren(List.of(nodeE, nodeH));
+        nodeE.addChild(nodeF);
+        nodeH.addChild(nodeG);
+        nodeF.addChild(nodeG);
+
+        graph.addRoot(nodeA);
+        return graph;
+    }
+
+    private static Graph<String> createTree() {
+        final Graph<String> graph = new SimpleGraph<>();
+        final GraphNode<String> nodeA = new SimpleGraphNode<>("A");
+        final GraphNode<String> nodeB = new SimpleGraphNode<>("B");
+        final GraphNode<String> nodeC = new SimpleGraphNode<>("C");
+        final GraphNode<String> nodeD = new SimpleGraphNode<>("D");
+        final GraphNode<String> nodeE = new SimpleGraphNode<>("E");
+        final GraphNode<String> nodeF = new SimpleGraphNode<>("F");
+        final GraphNode<String> nodeG = new SimpleGraphNode<>("G");
+        final GraphNode<String> nodeH = new SimpleGraphNode<>("H");
+
+        nodeA.addChildren(List.of(nodeB, nodeC));
+        nodeB.addChildren(List.of(nodeD, nodeE));
+        nodeE.addChildren(List.of(nodeG, nodeH));
+        nodeC.addChild(nodeF);
+
+        graph.addRoot(nodeA);
+
+        return graph;
+    }
+
+    private static Graph<Integer> createUnknownRootsGraph() {
+        final Graph<Integer> graph = new SimpleGraph<>();
+        final GraphNode<Integer> node1 = new SimpleGraphNode<>(1);
+        final GraphNode<Integer> node2 = new SimpleGraphNode<>(2);
+        final GraphNode<Integer> node3 = new SimpleGraphNode<>(3);
+        final GraphNode<Integer> node4 = new SimpleGraphNode<>(4);
+        final GraphNode<Integer> node5 = new SimpleGraphNode<>(5);
+        final GraphNode<Integer> node6 = new SimpleGraphNode<>(6);
+        final GraphNode<Integer> node7 = new SimpleGraphNode<>(7);
+
+        node1.addChildren(List.of(node5, node6, node2));
+        node2.addChild(node3);
+        node4.addChild(node3);
+        node5.addChildren(List.of(node4, node7));
+        node6.addChild(node3);
+        node7.addChild(node3);
+
+        graph.addRoots(Set.of(
+                node1,
+                node2,
+                node3,
+                node4,
+                node5,
+                node6,
+                node7
+        ));
+
+        return graph;
+    }
+
+    private static class PrintGraphVisitor<T> extends DepthFirstGraphVisitor<T> {
+
+        @Override
+        protected boolean visit(final GraphNode<T> node) {
+            System.out.print(node.value() + " ");
+            return true;
+        }
+
+        @Override
+        protected void afterPathVisited() {
+            System.out.println();
+        }
+    }
+}

--- a/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyDirectoryServlet.java
+++ b/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyDirectoryServlet.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.web.jetty;
 
-import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.web.HttpStatus;
 import org.dockbox.hartshorn.web.HttpWebServer;
 import org.dockbox.hartshorn.web.servlet.DirectoryServlet;
@@ -26,14 +25,10 @@ import org.eclipse.jetty.util.resource.Resource;
 import java.io.IOException;
 import java.net.URI;
 
-import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public class JettyDirectoryServlet implements DirectoryServlet {
-
-    @Inject
-    private ApplicationContext applicationContext;
 
     @Override
     public void handle(final HttpServletRequest request, final HttpServletResponse response, final URI uri, final String path) throws IOException {

--- a/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyErrorHandler.java
+++ b/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyErrorHandler.java
@@ -40,7 +40,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import jakarta.inject.Inject;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -49,13 +48,16 @@ import jakarta.servlet.http.HttpServletResponse;
 @Component
 public class JettyErrorHandler extends ErrorHandler {
 
-    @Inject
-    private ApplicationContext context;
-    @Inject
-    private ErrorServlet errorServlet;
+    private final ApplicationContext context;
+    private final ErrorServlet errorServlet;
 
     @Value("hartshorn.web.headers.hartshorn")
     private boolean addHeader = true;
+
+    public JettyErrorHandler(final ApplicationContext context, final ErrorServlet errorServlet) {
+        this.context = context;
+        this.errorServlet = errorServlet;
+    }
 
     @Override
     protected void generateAcceptableResponse(final Request baseRequest, final HttpServletRequest request, final HttpServletResponse response, final int code, String message, final String contentType)

--- a/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
+++ b/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
@@ -47,14 +47,14 @@ public class JettyHttpWebServer extends DefaultHttpWebServer {
 
     private final ServletContextHandler contextHandler;
     private final HandlerWrapper servletHandler;
+    private final ApplicationContext applicationContext;
 
-    @Inject
-    private ApplicationContext context;
     private JsonInclusionRule skipBehavior = JsonInclusionRule.SKIP_NONE;
     private JettyServer server;
 
     @Inject
     public JettyHttpWebServer(final JettyResourceService resourceService) {
+        this.applicationContext = resourceService.applicationContext();
         this.contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
         this.contextHandler.setContextPath("/");
         final URL staticContent = Hartshorn.class.getClassLoader().getResource(HttpWebServer.STATIC_CONTENT.substring(1));
@@ -69,7 +69,7 @@ public class JettyHttpWebServer extends DefaultHttpWebServer {
     }
 
     public ApplicationContext context() {
-        return this.context;
+        return this.applicationContext;
     }
 
     public ServletContextHandler contextHandler() {
@@ -97,13 +97,13 @@ public class JettyHttpWebServer extends DefaultHttpWebServer {
             if (this.server != null)
                 this.server.stop();
 
-            this.context.log().info("Starting service [JettyServer]");
-            this.server = this.context.get(JettyServer.class);
+            this.applicationContext.log().info("Starting service [JettyServer]");
+            this.server = this.applicationContext.get(JettyServer.class);
             this.server.setConnectors(new Connector[]{ this.connector(this.server, port) });
             this.server.setHandler(this.servletHandler);
             this.server.setErrorHandler(this.errorHandler());
             this.server.start();
-            this.context.log().info("Service [JettyServer] started on port [{}]", port);
+            this.applicationContext.log().info("Service [JettyServer] started on port [{}]", port);
         } catch (final Exception e) {
             throw new ApplicationException(e);
         }
@@ -185,6 +185,6 @@ public class JettyHttpWebServer extends DefaultHttpWebServer {
     }
 
     protected ErrorHandler errorHandler() {
-        return this.context.get(JettyErrorHandler.class);
+        return this.applicationContext.get(JettyErrorHandler.class);
     }
 }

--- a/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
+++ b/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
@@ -16,10 +16,6 @@
 
 package org.dockbox.hartshorn.web.jetty;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.Enumeration;
-
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.web.HttpStatus;
 import org.dockbox.hartshorn.web.servlet.DirectoryServlet;
@@ -29,7 +25,10 @@ import org.eclipse.jetty.server.ResourceService;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 
-import jakarta.inject.Inject;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Enumeration;
+
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -37,11 +36,21 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public class JettyResourceService extends ResourceService {
 
-    @Inject
-    private DirectoryServlet servlet;
+    private final DirectoryServlet servlet;
+    private final ApplicationContext applicationContext;
 
-    @Inject
-    private ApplicationContext applicationContext;
+    public JettyResourceService(final DirectoryServlet servlet, final ApplicationContext applicationContext) {
+        this.servlet = servlet;
+        this.applicationContext = applicationContext;
+    }
+
+    public DirectoryServlet directoryServlet() {
+        return this.servlet;
+    }
+
+    public ApplicationContext applicationContext() {
+        return this.applicationContext;
+    }
 
     @Override
     protected void sendDirectory(final HttpServletRequest req,

--- a/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyServer.java
+++ b/hartshorn-web/hartshorn-web-jetty/src/main/java/org/dockbox/hartshorn/web/jetty/JettyServer.java
@@ -28,18 +28,19 @@ import org.eclipse.jetty.server.Server;
 
 import java.io.IOException;
 
-import jakarta.inject.Inject;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 
 @Component
 public class JettyServer extends Server {
 
-    @Inject
-    private JettyErrorHandler errorHandler;
+    private final JettyErrorHandler errorHandler;
+    private final ApplicationContext applicationContext;
 
-    @Inject
-    private ApplicationContext applicationContext;
+    public JettyServer(final JettyErrorHandler errorHandler, final ApplicationContext applicationContext) {
+        this.errorHandler = errorHandler;
+        this.applicationContext = applicationContext;
+    }
 
     @Override
     public void handle(final HttpChannel channel) throws IOException, ServletException {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
@@ -102,7 +102,7 @@ public class HttpWebServerInitializer implements LifecycleObserver {
     protected WebServlet servlet(final ApplicationContext applicationContext, final RequestHandlerContext context, final HttpWebServer webServer) {
         final WebServlet servlet = this.webServletFactory.webServlet(webServer, context);
         if (servlet instanceof HandleWebServlet handleWebServlet) {
-            handleWebServlet.handler().mapper().skipBehavior(webServer.skipBehavior());
+            handleWebServlet.handler().objectMapper().skipBehavior(webServer.skipBehavior());
         }
         return servlet;
     }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
@@ -42,19 +42,22 @@ public class HttpWebServerInitializer implements LifecycleObserver {
     public static final int DEFAULT_PORT = 8080;
 
     @Value("hartshorn.web.port")
-    private final int port = DEFAULT_PORT;
+    private int port = DEFAULT_PORT;
 
     @Value("hartshorn.web.servlet.directory")
-    private final boolean useDirectoryServlet = true;
+    private boolean useDirectoryServlet = true;
+
+    private final WebServletFactory webServletFactory;
+    private final HttpWebServer webServer;
+    private final List<WebContextLoader> contextLoaders;
 
     @Inject
-    private WebServletFactory webServletFactory;
-
-    @Inject
-    private HttpWebServer webServer;
-
-    @Inject
-    private List<WebContextLoader> contextLoaders;
+    public HttpWebServerInitializer(final WebServletFactory webServletFactory, final HttpWebServer webServer,
+                                    final List<WebContextLoader> contextLoaders) {
+        this.webServletFactory = webServletFactory;
+        this.webServer = webServer;
+        this.contextLoaders = contextLoaders;
+    }
 
     @Override
     public void onStarted(final ApplicationContext applicationContext) {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletFactory.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletFactory.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.web;
 
+import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.factory.Factory;
@@ -27,5 +28,6 @@ import org.dockbox.hartshorn.web.annotations.UseHttpServer;
 @FunctionalInterface
 public interface ServletFactory {
     @Factory
-    ServletHandler servletHandler(final HttpWebServer starter, final HttpMethod httpMethod, final MethodView<?, ?> methodContext);
+    ServletHandler servletHandler(final ApplicationContext applicationContext, final HttpWebServer starter,
+                                  final HttpMethod httpMethod, final MethodView<?, ?> methodContext);
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServletImpl.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServletImpl.java
@@ -35,7 +35,7 @@ public class WebServletImpl implements HandleWebServlet {
     @Bound
     public WebServletImpl(final HttpWebServer starter, final RequestHandlerContext context) {
         this.handler = context.applicationContext().get(ServletFactory.class)
-                .servletHandler(starter, context.httpRequest().method(), context.method());
+                .servletHandler(context.applicationContext(), starter, context.httpRequest().method(), context.method());
     }
 
     @Override


### PR DESCRIPTION
# Description
> The majority of Hartshorn's internal types use constructor injection if required, or will lazily request dependencies through a provided `ApplicationContext`. However, there are still a few types that currently depend on field injection. To cite just some sources, it should be clear why field injection is not recommended:
> - [Field Dependency Injection Considered Harmful (Jun. 2018, Vojtech Ruzicka)](https://www.vojtechruzicka.com/field-dependency-injection-considered-harmful/)
> - [What exactly is Field Injection and how to avoid it (Oct. 2016, T. Jung)](https://stackoverflow.com/questions/39890849/what-exactly-is-field-injection-and-how-to-avoid-it)
> - [Field injection is not recommended (Aug. 2021, Marc Nuri)](https://blog.marcnuri.com/field-injection-is-not-recommended)
> - [Constructor Injection vs Field Injection (Apr. 2022, Kiran Kumar M)](https://www.linkedin.com/pulse/constructor-injection-vs-field-kiran-kumar-matam/)

These changes replace the internal usages of `@Inject` with constructor injection, and resolve any lazy-loading issues which may be caused by this process.

Fixes #971

## Type of change
- [x] Refactor (code changes that do not affect the behavior of the code)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
