### PR TITLE
#987 cyclic non concrete lookup

### DIFF
--- a/hartshorn-commands/src/test/java/test/org/dockbox/hartshorn/commands/CommandConditionMatchingTests.java
+++ b/hartshorn-commands/src/test/java/test/org/dockbox/hartshorn/commands/CommandConditionMatchingTests.java
@@ -31,7 +31,7 @@ import test.org.dockbox.hartshorn.commands.types.SampleCommand;
 @HartshornTest(includeBasePackages = false)
 @UseCommands
 @UseExpressionValidation
-@TestComponents({SampleCommand.class, JUnitSystemSubject.class})
+@TestComponents(components = {SampleCommand.class, JUnitSystemSubject.class})
 public class CommandConditionMatchingTests {
 
     @Inject

--- a/hartshorn-commands/src/test/java/test/org/dockbox/hartshorn/commands/CommandDefinitionContextTests.java
+++ b/hartshorn-commands/src/test/java/test/org/dockbox/hartshorn/commands/CommandDefinitionContextTests.java
@@ -52,7 +52,7 @@ public class CommandDefinitionContextTests {
     private final ComponentKey<SampleCommand> typeContext = ComponentKey.of(SampleCommand.class);
 
     @Test
-    @TestComponents(SampleCommand.class)
+    @TestComponents(components = SampleCommand.class)
     void testParsingCanSucceed() {
         final CommandGateway gateway = this.applicationContext.get(CommandGatewayImpl.class);
         gateway.register(this.typeContext);
@@ -60,7 +60,7 @@ public class CommandDefinitionContextTests {
     }
 
     @Test
-    @TestComponents(SampleCommandExtension.class)
+    @TestComponents(components = SampleCommandExtension.class)
     void testExtensionCanSucceed() {
         final CommandGateway gateway = this.applicationContext.get(CommandGatewayImpl.class);
         gateway.register(this.typeContext);
@@ -69,7 +69,7 @@ public class CommandDefinitionContextTests {
     }
 
     @Test
-    @TestComponents(SampleCommand.class)
+    @TestComponents(components = SampleCommand.class)
     void testComplexParsingCanSucceed() {
         final CommandGateway gateway = this.applicationContext.get(CommandGatewayImpl.class);
         gateway.register(this.typeContext);
@@ -98,7 +98,7 @@ public class CommandDefinitionContextTests {
     }
 
     @Test
-    @TestComponents(SampleCommand.class)
+    @TestComponents(components = SampleCommand.class)
     void testArgumentParameters() {
         final CommandGateway gateway = this.applicationContext.get(CommandGatewayImpl.class);
         gateway.register(this.typeContext);
@@ -116,7 +116,7 @@ public class CommandDefinitionContextTests {
     }
 
     @Test
-    @TestComponents(SampleCommand.class)
+    @TestComponents(components = SampleCommand.class)
     void testGroups() throws ParsingException {
         final CommandGateway gateway = this.applicationContext.get(CommandGatewayImpl.class);
         gateway.register(this.typeContext);

--- a/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/ConfigurationManagerTests.java
+++ b/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/ConfigurationManagerTests.java
@@ -47,7 +47,7 @@ public abstract class ConfigurationManagerTests {
     private ApplicationContext applicationContext;
 
     @Test
-    @TestComponents(DemoClasspathConfiguration.class)
+    @TestComponents(components = DemoClasspathConfiguration.class)
     void testClassPathConfigurations() {
         // Configuration is read from resources/junit.yml
         final DemoClasspathConfiguration configuration = this.applicationContext.get(DemoClasspathConfiguration.class);
@@ -58,7 +58,7 @@ public abstract class ConfigurationManagerTests {
     }
 
     @Test
-    @TestComponents(DemoClasspathConfiguration.class)
+    @TestComponents(components = DemoClasspathConfiguration.class)
     void testDefaultValuesAreUsedIfPropertyIsAbsent() {
         final DemoClasspathConfiguration configuration = this.applicationContext.get(DemoClasspathConfiguration.class);
 
@@ -68,7 +68,7 @@ public abstract class ConfigurationManagerTests {
     }
 
     @Test
-    @TestComponents(DemoClasspathConfiguration.class)
+    @TestComponents(components = DemoClasspathConfiguration.class)
     void testNumberValuesAreParsed() {
         final DemoClasspathConfiguration configuration = this.applicationContext.get(DemoClasspathConfiguration.class);
 
@@ -77,7 +77,7 @@ public abstract class ConfigurationManagerTests {
     }
 
     @Test
-    @TestComponents(DemoClasspathConfiguration.class)
+    @TestComponents(components = DemoClasspathConfiguration.class)
     void testCollectionsAreParsed() {
         final DemoClasspathConfiguration configuration = this.applicationContext.get(DemoClasspathConfiguration.class);
 
@@ -87,7 +87,7 @@ public abstract class ConfigurationManagerTests {
     }
 
     @Test
-    @TestComponents(DemoClasspathConfiguration.class)
+    @TestComponents(components = DemoClasspathConfiguration.class)
     void testCollectionsAreSorted() {
         final DemoClasspathConfiguration configuration = this.applicationContext.get(DemoClasspathConfiguration.class);
 
@@ -99,7 +99,7 @@ public abstract class ConfigurationManagerTests {
     }
 
     @Test
-    @TestComponents(DemoClasspathConfiguration.class)
+    @TestComponents(components = DemoClasspathConfiguration.class)
     void testCustomCollectionsAreConverted() {
         final DemoClasspathConfiguration configuration = this.applicationContext.get(DemoClasspathConfiguration.class);
 
@@ -110,7 +110,7 @@ public abstract class ConfigurationManagerTests {
     }
 
     @Test
-    @TestComponents(DemoFSConfiguration.class)
+    @TestComponents(components = DemoFSConfiguration.class)
     void testFsConfigurations() {
         final Path file = FileFormats.YAML.asPath(this.applicationContext.environment().applicationPath(), "junit");
         final ObjectMapper objectMapper = this.applicationContext.get(ObjectMapper.class);
@@ -129,7 +129,7 @@ public abstract class ConfigurationManagerTests {
     }
 
     @Test
-    @TestComponents(ValueTyped.class)
+    @TestComponents(components = ValueTyped.class)
     void testNormalValuesAreAccessible() {
         this.applicationContext.get(PropertyHolder.class).set("demo", "Hartshorn");
         final ValueTyped typed = this.applicationContext.get(ValueTyped.class);
@@ -139,7 +139,7 @@ public abstract class ConfigurationManagerTests {
     }
 
     @Test
-    @TestComponents(ValueTyped.class)
+    @TestComponents(components = ValueTyped.class)
     void testNestedValuesAreAccessible() {
         this.applicationContext.get(PropertyHolder.class).set("nested.demo", "Hartshorn");
         final ValueTyped typed = this.applicationContext.get(ValueTyped.class);
@@ -150,7 +150,7 @@ public abstract class ConfigurationManagerTests {
     }
 
     @Test
-    @TestComponents(SampleConfigurationObject.class)
+    @TestComponents(components = SampleConfigurationObject.class)
     void testConfigurationObjects() {
         final PropertyHolder propertyHolder = this.applicationContext.get(PropertyHolder.class);
         propertyHolder.set("user.name", "Hartshorn");
@@ -163,7 +163,7 @@ public abstract class ConfigurationManagerTests {
     }
 
     @Test
-    @TestComponents(SampleSetterConfigurationObject.class)
+    @TestComponents(components = SampleSetterConfigurationObject.class)
     void testSetterConfigurationObjects() {
         final PropertyHolder propertyHolder = this.applicationContext.get(PropertyHolder.class);
         propertyHolder.set("user.name", "Hartshorn");

--- a/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/SerializationTests.java
+++ b/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/SerializationTests.java
@@ -36,7 +36,7 @@ public abstract class SerializationTests {
     private ApplicationContext applicationContext;
 
     @Test
-    @TestComponents(PersistenceService.class)
+    @TestComponents(components = PersistenceService.class)
     void testToStringSerialization() {
         final PersistenceService service = this.applicationContext.get(PersistenceService.class);
         final PersistentElement element = new PersistentElement("sample");
@@ -47,7 +47,7 @@ public abstract class SerializationTests {
     }
 
     @Test
-    @TestComponents(PersistenceService.class)
+    @TestComponents(components = PersistenceService.class)
     void testFromStringDeserialization() {
         final PersistenceService service = this.applicationContext.get(PersistenceService.class);
         final String json = "{\"name\":\"sample\"}";
@@ -58,7 +58,7 @@ public abstract class SerializationTests {
     }
 
     @Test
-    @TestComponents(PathPersistenceService.class)
+    @TestComponents(components = PathPersistenceService.class)
     void testToPathSerialization() {
         final PathPersistenceService service = this.applicationContext.get(PathPersistenceService.class);
         final PersistentElement element = new PersistentElement("sample");
@@ -72,7 +72,7 @@ public abstract class SerializationTests {
     }
 
     @Test
-    @TestComponents(PathPersistenceService.class)
+    @TestComponents(components = PathPersistenceService.class)
     void testFromPathDeserialization() {
         final PathPersistenceService service = this.applicationContext.get(PathPersistenceService.class);
         final PersistentElement element = new PersistentElement("sample");
@@ -87,7 +87,7 @@ public abstract class SerializationTests {
     }
 
     @Test
-    @TestComponents(AnnotationPathPersistenceService.class)
+    @TestComponents(components = AnnotationPathPersistenceService.class)
     void testToAnnotationPathSerialization() {
         final AnnotationPathPersistenceService service = this.applicationContext.get(AnnotationPathPersistenceService.class);
         final PersistentElement element = new PersistentElement("sample");
@@ -97,7 +97,7 @@ public abstract class SerializationTests {
     }
 
     @Test
-    @TestComponents(AnnotationPathPersistenceService.class)
+    @TestComponents(components = AnnotationPathPersistenceService.class)
     void testFromAnnotationPathDeserialization() {
         final AnnotationPathPersistenceService service = this.applicationContext.get(AnnotationPathPersistenceService.class);
         final PersistentElement element = new PersistentElement("sample");

--- a/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/StandardPropertyHolderTests.java
+++ b/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/StandardPropertyHolderTests.java
@@ -64,7 +64,7 @@ public abstract class StandardPropertyHolderTests {
     }
 
     @Test
-    @TestComponents(ComponentWithUserValue.class)
+    @TestComponents(components = ComponentWithUserValue.class)
     void testValueComponents() {
         final PropertyHolder propertyHolder = this.propertyHolder(this.applicationContext);
         propertyHolder.set("user.name", "John Doe");

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationBindingFunction.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.context.ContextCarrier;
 import org.dockbox.hartshorn.inject.Provider;
 import org.dockbox.hartshorn.inject.binding.Binder;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
+import org.dockbox.hartshorn.inject.binding.IllegalScopeException;
 import org.dockbox.hartshorn.util.function.CheckedSupplier;
 
 /**
@@ -48,7 +49,7 @@ public class DelegatingApplicationBindingFunction<T> implements BindingFunction<
     }
 
     @Override
-    public BindingFunction<T> installTo(Class<? extends Scope> scope) {
+    public BindingFunction<T> installTo(Class<? extends Scope> scope) throws IllegalScopeException {
         return this.delegate.installTo(scope);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchyAwareComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchyAwareComponentProvider.java
@@ -16,6 +16,9 @@
 
 package org.dockbox.hartshorn.component;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey.ComponentKeyView;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
@@ -46,9 +49,6 @@ import org.dockbox.hartshorn.util.collections.HashSetMultiMap;
 import org.dockbox.hartshorn.util.collections.MultiMap;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class HierarchyAwareComponentProvider extends DefaultProvisionContext implements HierarchicalComponentProvider, ContextCarrier {
 
@@ -190,7 +190,7 @@ public class HierarchyAwareComponentProvider extends DefaultProvisionContext imp
         }
 
         if (this.singletonCache.contains(componentKey)) {
-            return this.singletonCache.get(componentKey);
+            return this.singletonCache.get(componentKey).orNull();
         }
 
         this.owner.componentLocator().validate(componentKey);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeModuleContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeModuleContext.java
@@ -16,17 +16,17 @@
 
 package org.dockbox.hartshorn.component;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.context.DefaultApplicationAwareContext;
 import org.dockbox.hartshorn.context.InstallIfAbsent;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
 import org.dockbox.hartshorn.inject.binding.NativeBindingHierarchy;
 import org.dockbox.hartshorn.util.TypeUtils;
-import org.dockbox.hartshorn.util.collections.MultiMap;
 import org.dockbox.hartshorn.util.collections.ConcurrentSetMultiMap;
-
-import java.util.Collection;
-import java.util.Collections;
+import org.dockbox.hartshorn.util.collections.MultiMap;
 
 import jakarta.inject.Inject;
 
@@ -54,7 +54,9 @@ public class ScopeModuleContext extends DefaultApplicationAwareContext {
     }
 
     public Collection<BindingHierarchy<?>> hierarchies(final Class<? extends Scope> type) {
-        if (type == Scope.class) return Collections.emptyList();
+        if (type == Scope.class) {
+            return Collections.emptyList();
+        }
         return this.scopeModules.get(type);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentFinalizingPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentFinalizingPostProcessor.java
@@ -16,6 +16,8 @@
 
 package org.dockbox.hartshorn.component.processing;
 
+import java.util.Collection;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentContainer;
@@ -31,8 +33,6 @@ import org.dockbox.hartshorn.util.ApplicationRuntimeException;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Collection;
 
 public class ComponentFinalizingPostProcessor extends ComponentPostProcessor {
 
@@ -95,7 +95,7 @@ public class ComponentFinalizingPostProcessor extends ComponentPostProcessor {
         TypeView<T> factoryType = context.environment().introspect(factory.type());
         // Ensure we use a non-default constructor if there is no default constructor to use
         if (!factoryType.isInterface() && factoryType.constructors().defaultConstructor().absent()) {
-            ConstructorView<T> constructor = CyclingConstructorAnalyzer.findConstructor(factoryType)
+            ConstructorView<? extends T> constructor = CyclingConstructorAnalyzer.create(context).findConstructor(factoryType)
                     .rethrow()
                     .orElseThrow(() -> new ApplicationException("No default or injectable constructor found for proxy factory " + factoryType.name()));
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentFinalizingPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentFinalizingPostProcessor.java
@@ -24,7 +24,7 @@ import org.dockbox.hartshorn.component.ComponentContainer;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.ComponentPopulator;
 import org.dockbox.hartshorn.component.ContextualComponentPopulator;
-import org.dockbox.hartshorn.inject.CyclingConstructorAnalyzer;
+import org.dockbox.hartshorn.inject.ComponentConstructorResolver;
 import org.dockbox.hartshorn.introspect.ViewContextAdapter;
 import org.dockbox.hartshorn.proxy.ProxyFactory;
 import org.dockbox.hartshorn.proxy.lookup.StateAwareProxyFactory;
@@ -95,7 +95,7 @@ public class ComponentFinalizingPostProcessor extends ComponentPostProcessor {
         TypeView<T> factoryType = context.environment().introspect(factory.type());
         // Ensure we use a non-default constructor if there is no default constructor to use
         if (!factoryType.isInterface() && factoryType.constructors().defaultConstructor().absent()) {
-            ConstructorView<? extends T> constructor = CyclingConstructorAnalyzer.create(context).findConstructor(factoryType)
+            ConstructorView<? extends T> constructor = ComponentConstructorResolver.create(context).findConstructor(factoryType)
                     .rethrow()
                     .orElseThrow(() -> new ApplicationException("No default or injectable constructor found for proxy factory " + factoryType.name()));
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AutoConfiguringDependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AutoConfiguringDependencyContext.java
@@ -16,13 +16,14 @@
 
 package org.dockbox.hartshorn.inject;
 
+import java.util.Set;
+
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.Scope;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
+import org.dockbox.hartshorn.inject.binding.IllegalScopeException;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.function.CheckedSupplier;
-
-import java.util.Set;
 
 public class AutoConfiguringDependencyContext<T> extends AbstractDependencyContext<T> {
 
@@ -40,7 +41,12 @@ public class AutoConfiguringDependencyContext<T> extends AbstractDependencyConte
         InstanceType instanceType = this.instanceType();
         function.priority(this.priority());
         if (this.scope() != Scope.DEFAULT_SCOPE.installableScopeType()) {
-            function.installTo(this.scope());
+            try {
+                function.installTo(this.scope());
+            }
+            catch (IllegalScopeException e) {
+                throw new ComponentConfigurationException("Could not configure binding for %s".formatted(this.componentKey()), e);
+            }
         }
         function.processAfterInitialization(this.processAfterInitialization());
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentConstructorResolver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentConstructorResolver.java
@@ -31,16 +31,16 @@ import org.dockbox.hartshorn.util.option.Attempt;
 import org.dockbox.hartshorn.util.option.Option;
 import org.jetbrains.annotations.Nullable;
 
-public final class CyclingConstructorAnalyzer {
+public final class ComponentConstructorResolver {
 
     private final ApplicationContext applicationContext;
 
-    private CyclingConstructorAnalyzer(ApplicationContext applicationContext) {
+    private ComponentConstructorResolver(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
     }
 
-    public static CyclingConstructorAnalyzer create(ApplicationContext applicationContext) {
-        return new CyclingConstructorAnalyzer(applicationContext);
+    public static ComponentConstructorResolver create(ApplicationContext applicationContext) {
+        return new ComponentConstructorResolver(applicationContext);
     }
 
     public <C> Attempt<ConstructorView<? extends C>, ? extends ApplicationException> findConstructor(TypeView<C> type) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentDependencyResolver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentDependencyResolver.java
@@ -16,6 +16,8 @@
 
 package org.dockbox.hartshorn.inject;
 
+import java.util.Set;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.inject.strategy.DependencyResolverUtils;
@@ -23,14 +25,12 @@ import org.dockbox.hartshorn.util.CollectionUtilities;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
-import java.util.Set;
-
 public class ComponentDependencyResolver extends AbstractContainerDependencyResolver {
 
     @Override
     protected <T> Set<DependencyContext<?>> resolveSingle(final DependencyDeclarationContext<T> componentContainer, final ApplicationContext applicationContext) throws DependencyResolutionException {
         final TypeView<?> type = componentContainer.type();
-        final ConstructorView<?> constructorView = CyclingConstructorAnalyzer.findConstructor(type)
+        final ConstructorView<?> constructorView = CyclingConstructorAnalyzer.create(applicationContext).findConstructor(type)
                 .mapError(DependencyResolutionException::new)
                 .rethrow()
                 .orNull();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentDependencyResolver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentDependencyResolver.java
@@ -30,7 +30,7 @@ public class ComponentDependencyResolver extends AbstractContainerDependencyReso
     @Override
     protected <T> Set<DependencyContext<?>> resolveSingle(final DependencyDeclarationContext<T> componentContainer, final ApplicationContext applicationContext) throws DependencyResolutionException {
         final TypeView<?> type = componentContainer.type();
-        final ConstructorView<?> constructorView = CyclingConstructorAnalyzer.create(applicationContext).findConstructor(type)
+        final ConstructorView<?> constructorView = ComponentConstructorResolver.create(applicationContext).findConstructor(type)
                 .mapError(DependencyResolutionException::new)
                 .rethrow()
                 .orNull();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComposedProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComposedProvider.java
@@ -16,13 +16,13 @@
 
 package org.dockbox.hartshorn.inject;
 
-import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.util.ApplicationException;
-import org.dockbox.hartshorn.util.option.Option;
-
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.option.Option;
 
 /**
  * A {@link Provider} of which the result can be mapped using a list of {@link Function}s. This
@@ -37,7 +37,7 @@ import java.util.function.Function;
  * @see Provider
  * @see ObjectContainer
  */
-public class ComposedProvider<T> implements Provider<T> {
+public final class ComposedProvider<T> implements Provider<T> {
 
     private final List<Function<ObjectContainer<T>, ObjectContainer<T>>> functions = new LinkedList<>();
     private final Provider<T> provider;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ConstructorDiscoveryList.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ConstructorDiscoveryList.java
@@ -1,0 +1,62 @@
+package org.dockbox.hartshorn.inject;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.dockbox.hartshorn.inject.ConstructorDiscoveryList.DiscoveredComponent;
+import org.dockbox.hartshorn.util.CollectionUtilities;
+import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.jetbrains.annotations.NotNull;
+
+public class ConstructorDiscoveryList implements Iterable<DiscoveredComponent> {
+
+    public static final ConstructorDiscoveryList EMPTY = new ConstructorDiscoveryList(List.of());
+
+    private final List<DiscoveredComponent> discoveredComponents;
+
+    public ConstructorDiscoveryList() {
+        this(new LinkedList<>());
+    }
+
+    public ConstructorDiscoveryList(List<DiscoveredComponent> discoveredComponents) {
+        this.discoveredComponents = discoveredComponents;
+    }
+
+    public void add(TypePathNode<?> node, ConstructorView<?> constructor) {
+        this.discoveredComponents.add(new DiscoveredComponent(node, constructor.declaredBy()));
+    }
+
+    public List<DiscoveredComponent> discoveredComponents() {
+        return CollectionUtilities.distinct(this.discoveredComponents);
+    }
+
+    public boolean isEmpty() {
+        return this.discoveredComponents.isEmpty();
+    }
+
+    public boolean contains(TypePathNode<?> pathNode) {
+        return this.discoveredComponents.stream().anyMatch(component -> component.node().equals(pathNode));
+    }
+
+    @NotNull
+    @Override
+    public Iterator<DiscoveredComponent> iterator() {
+        return this.discoveredComponents().iterator();
+    }
+
+    public DiscoveredComponent getOrigin() {
+        if (this.discoveredComponents.isEmpty()) {
+            return null;
+        }
+        return this.discoveredComponents.get(0);
+    }
+
+    public record DiscoveredComponent(TypePathNode<?> node, TypeView<?> actualType) {
+
+        public boolean fromBinding() {
+            return !node.type().is(actualType.type());
+        }
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ConstructorDiscoveryList.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ConstructorDiscoveryList.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.inject;
 
 import java.util.Iterator;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextDrivenProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextDrivenProvider.java
@@ -66,7 +66,7 @@ public class ContextDrivenProvider<C> implements TypeAwareProvider<C> {
     protected Option<? extends ConstructorView<? extends C>> optimalConstructor(ApplicationContext applicationContext) throws ApplicationException {
         TypeView<? extends C> typeView = applicationContext.environment().introspect(this.type());
         if (this.optimalConstructor == null) {
-            this.optimalConstructor = CyclingConstructorAnalyzer.create(applicationContext).findConstructor(typeView)
+            this.optimalConstructor = ComponentConstructorResolver.create(applicationContext).findConstructor(typeView)
                     .rethrow()
                     .orNull();
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextDrivenProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextDrivenProvider.java
@@ -39,7 +39,7 @@ import org.dockbox.hartshorn.util.option.Option;
  * @see SupplierProvider
  * @since 0.4.3
  */
-public class ContextDrivenProvider<C> implements Provider<C> {
+public class ContextDrivenProvider<C> implements TypeAwareProvider<C> {
 
     private final ComponentKey<? extends C> context;
     private ConstructorView<? extends C> optimalConstructor;
@@ -66,13 +66,14 @@ public class ContextDrivenProvider<C> implements Provider<C> {
     protected Option<? extends ConstructorView<? extends C>> optimalConstructor(ApplicationContext applicationContext) throws ApplicationException {
         TypeView<? extends C> typeView = applicationContext.environment().introspect(this.type());
         if (this.optimalConstructor == null) {
-            this.optimalConstructor = CyclingConstructorAnalyzer.findConstructor(typeView)
+            this.optimalConstructor = CyclingConstructorAnalyzer.create(applicationContext).findConstructor(typeView)
                     .rethrow()
                     .orNull();
         }
         return Option.of(this.optimalConstructor);
     }
 
+    @Override
     public Class<? extends C> type() {
         return this.context.type();
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/CyclicComponentException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/CyclicComponentException.java
@@ -16,17 +16,61 @@
 
 package org.dockbox.hartshorn.inject;
 
-import org.dockbox.hartshorn.util.ApplicationException;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import java.util.Iterator;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import org.dockbox.hartshorn.inject.ConstructorDiscoveryList.DiscoveredComponent;
+import org.dockbox.hartshorn.util.ApplicationException;
 
 public class CyclicComponentException extends ApplicationException {
-    public CyclicComponentException(final TypeView<?> type, final List<TypeView<?>> other) {
-        super("Cyclic dependency detected in constructor of %s. Cyclic dependency path: %s".formatted(
-                type.qualifiedName(),
-                other.stream().map(TypeView::name).collect(Collectors.joining(" -> "))
-        ));
+
+    private static final String CYCLE_TOP     = " ┌───┐\n";
+    private static final String CYCLE_NODE    = " ↑  %s\n";
+    private static final String CYCLE_BINDING = " |   ↓   ↳ Implemented by %s\n";
+    private static final String CYCLE_PATH    = " |   ↓\n";
+    private static final String CYCLE_BOTTOM  = " └───┘";
+
+    public CyclicComponentException(ConstructorDiscoveryList path) {
+        super(formatMessage(path));
+    }
+
+    /**
+     * Formats the given path into a human-readable string. A simple example:
+     * <pre>{@code
+     * Cyclic dependency detected in constructor of ConcreteComponentA. Complete dependency path:
+     *  ┌───┐
+     *  ↑  com.sample.ConcreteComponentA
+     *  |   ↓
+     *  ↑  com.sample.ConcreteComponentB
+     *  |   ↓
+     *  ↑  com.sample.AbstractComponentC
+     *  |   ↓   ↳ Implemented by com.sample.ConcreteComponentC
+     *  └───┘
+     *  }</pre>
+     * @param path the path to format
+     * @return the formatted string
+     */
+    private static String formatMessage(ConstructorDiscoveryList path) {
+        if (path.isEmpty()) {
+            throw new IllegalArgumentException("Path cannot be empty");
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(CYCLE_TOP);
+
+        for(Iterator<DiscoveredComponent> iterator = path.iterator(); iterator.hasNext(); ) {
+            DiscoveredComponent node = iterator.next();
+            builder.append(CYCLE_NODE.formatted(node.node().qualifiedName()));
+            if(node.fromBinding()) {
+                builder.append(CYCLE_BINDING.formatted(node.actualType().qualifiedName()));
+            }
+            else if (iterator.hasNext()) {
+                builder.append(CYCLE_PATH);
+            }
+        }
+        builder.append(CYCLE_BOTTOM);
+
+        DiscoveredComponent origin = path.getOrigin();
+        String typeName = origin.fromBinding() ? origin.actualType().name() : origin.node().qualifiedName();
+        return "Cyclic dependency detected in constructor of %s. Complete dependency path:\n%s".formatted(typeName, builder.toString());
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/LazySingletonProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/LazySingletonProvider.java
@@ -21,7 +21,7 @@ import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.function.CheckedSupplier;
 import org.dockbox.hartshorn.util.option.Option;
 
-public class LazySingletonProvider<T> implements Provider<T> {
+public class LazySingletonProvider<T> implements NonTypeAwareProvider<T> {
 
     private final CheckedSupplier<ObjectContainer<T>> supplier;
     private ObjectContainer<T> container;
@@ -37,4 +37,5 @@ public class LazySingletonProvider<T> implements Provider<T> {
         }
         return Option.of(this.container);
     }
+
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/NoSuchProviderException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/NoSuchProviderException.java
@@ -1,0 +1,27 @@
+package org.dockbox.hartshorn.inject;
+
+import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.util.ApplicationException;
+
+public class NoSuchProviderException extends ApplicationException {
+
+    public enum ProviderType {
+        TYPE_AWARE,
+        NON_TYPE_AWARE,
+        ANY,
+    }
+
+    public NoSuchProviderException(ComponentKey<?> componentKey) {
+        this(ProviderType.ANY, componentKey);
+    }
+
+    public NoSuchProviderException(ProviderType providerType, ComponentKey<?> componentKey) {
+        super("No %s found for component key '%s'".formatted(
+                switch(providerType) {
+                    case TYPE_AWARE -> "type-aware provider";
+                    case NON_TYPE_AWARE -> "non type-aware provider";
+                    case ANY -> "provider";
+                },
+                componentKey));
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/NoSuchProviderException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/NoSuchProviderException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.inject;
 
 import org.dockbox.hartshorn.component.ComponentKey;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/NonTypeAwareProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/NonTypeAwareProvider.java
@@ -1,0 +1,11 @@
+package org.dockbox.hartshorn.inject;
+
+/**
+ * A {@link Provider} that is not aware of the type it provides. This is useful when the type
+ * is not known at compile time, but only at runtime (e.g. in suppliers).
+ *
+ * @param <T> The type instance to provide.
+ */
+@FunctionalInterface
+public non-sealed interface NonTypeAwareProvider<T> extends Provider<T> {
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/NonTypeAwareProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/NonTypeAwareProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.inject;
 
 /**

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Provider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Provider.java
@@ -16,12 +16,12 @@
 
 package org.dockbox.hartshorn.inject;
 
+import java.util.function.Function;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.util.function.Function;
 
 /**
  * A provider is a class that can provide an instance of a {@link ComponentKey} binding. The
@@ -32,8 +32,7 @@ import java.util.function.Function;
  * @author Guus Lieben
  * @since 0.4.3
  */
-@FunctionalInterface
-public interface Provider<T> {
+public sealed interface Provider<T> permits TypeAwareProvider, NonTypeAwareProvider, ComposedProvider {
 
     /**
      * Provides an instance of the {@link ComponentKey} binding. The {@link ApplicationContext} can be used

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SingletonProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SingletonProvider.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.inject;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.util.option.Option;
 
-public class SingletonProvider<T> implements Provider<T> {
+public class SingletonProvider<T> implements NonTypeAwareProvider<T> {
 
     private final ObjectContainer<T> container;
 
@@ -31,4 +31,5 @@ public class SingletonProvider<T> implements Provider<T> {
     public Option<ObjectContainer<T>> provide(ApplicationContext context) {
         return Option.of(this.container);
     }
+
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SupplierProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SupplierProvider.java
@@ -16,13 +16,13 @@
 
 package org.dockbox.hartshorn.inject;
 
+import java.util.function.Supplier;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.function.CheckedSupplier;
 import org.dockbox.hartshorn.util.option.Attempt;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.util.function.Supplier;
 
 /**
  * A {@link Supplier} that is able to provide instances using the given {@link Supplier}. If the
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
  * @see ContextDrivenProvider
  * @since 0.4.3
  */
-public record SupplierProvider<C>(CheckedSupplier<C> supplier) implements Provider<C> {
+public record SupplierProvider<C>(CheckedSupplier<C> supplier) implements NonTypeAwareProvider<C> {
 
     @Override
     public Option<ObjectContainer<C>> provide(ApplicationContext context) throws ApplicationException {
@@ -45,4 +45,5 @@ public record SupplierProvider<C>(CheckedSupplier<C> supplier) implements Provid
                 ApplicationException.class
         ).rethrow();
     }
+
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/TypeAwareProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/TypeAwareProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.inject;
 
 public non-sealed interface TypeAwareProvider<T> extends Provider<T> {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/TypeAwareProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/TypeAwareProvider.java
@@ -1,0 +1,5 @@
+package org.dockbox.hartshorn.inject;
+
+public non-sealed interface TypeAwareProvider<T> extends Provider<T> {
+    Class<? extends T> type();
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/TypePathNode.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/TypePathNode.java
@@ -1,0 +1,11 @@
+package org.dockbox.hartshorn.inject;
+
+import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+
+public record TypePathNode<T>(TypeView<T> type, ComponentKey<T> componentKey) {
+
+    public String qualifiedName() {
+        return componentKey.qualifiedName(true);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/TypePathNode.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/TypePathNode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.inject;
 
 import org.dockbox.hartshorn.component.ComponentKey;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/Binder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/Binder.java
@@ -17,14 +17,54 @@
 package org.dockbox.hartshorn.inject.binding;
 
 import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.component.HierarchicalComponentProvider;
 
+/**
+ * A binder is used to bind types or keys to various targets, and is capable of importing existing
+ * {@link BindingHierarchy binding hierarchies}.
+ *
+ * <p>Binders may be delegated to other binders, and may be used to create new bindings or override
+ * existing bindings. Often, you should use {@link org.dockbox.hartshorn.application.context.ApplicationContext}
+ * to create new bindings, so it can delegate to the correct binders of the current context.
+ *
+ * @author Guus Lieben
+ * @since 0.4.1
+ *
+ * @see org.dockbox.hartshorn.application.context.ApplicationContext
+ */
 public interface Binder {
 
+    /**
+     * Open a new binding function for the given type. This will create a new binding function that
+     * will bind to the given type as an unnamed key in the default scope of the binder.
+     *
+     * @param type The type to bind to
+     * @return The binding function
+     * @param <C> The type of the binding
+     */
     default <C> BindingFunction<C> bind(final Class<C> type) {
         return this.bind(ComponentKey.of(type));
     }
 
+    /**
+     * Open a new binding function for the given key. This will create a new binding function that
+     * will bind to the given key. The key may be named or unnamed, and may contain a scope.
+     *
+     * @param key The key to bind to
+     * @return The binding function
+     * @param <C> The type of the binding
+     */
     <C> BindingFunction<C> bind(ComponentKey<C> key);
 
+    /**
+     * Imports the given hierarchy into the current binder. This will override any existing bindings
+     * in the current binder with the bindings from the given hierarchy. If you wish to keep both
+     * the existing and new bindings, obtain the active bindings from the current {@link HierarchicalComponentProvider}
+     * and merge them with {@link BindingHierarchy#merge(BindingHierarchy)}.
+     *
+     * @param hierarchy The hierarchy to import
+     * @return The binder
+     * @param <C> The type of the binding
+     */
     <C> Binder bind(BindingHierarchy<C> hierarchy);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingFunction.java
@@ -22,10 +22,34 @@ import org.dockbox.hartshorn.util.function.CheckedSupplier;
 
 public interface BindingFunction<T> {
 
-    BindingFunction<T> installTo(Class<? extends Scope> scope);
+    /**
+     * Binds the current function to the given scope.
+     *
+     * @param scope The scope to bind to
+     * @return The binding function
+     * @throws IllegalScopeException When the scope is not valid, or cannot be modified safely
+     */
+    BindingFunction<T> installTo(Class<? extends Scope> scope) throws IllegalScopeException;
 
+    /**
+     * Sets the priority of the binding. This will determine the order in which the binding is
+     * processed. The higher the priority, the earlier the binding is processed. It remains up
+     * to the {@link org.dockbox.hartshorn.component.ComponentProvider} to determine how to
+     * process the bindings.
+     *
+     * @param priority The priority to set
+     * @return The binding function
+     */
     BindingFunction<T> priority(int priority);
 
+    /**
+     * Sets whether the result of the binding should be processed after initialization. This
+     * will determine whether the result of the binding should be enhanced by
+     * {@link org.dockbox.hartshorn.component.processing.ComponentProcessor}s.
+     *
+     * @param processAfterInitialization Whether to process after initialization
+     * @return The binding function
+     */
     BindingFunction<T> processAfterInitialization(boolean processAfterInitialization);
 
     /**
@@ -46,6 +70,13 @@ public interface BindingFunction<T> {
      */
     Binder to(CheckedSupplier<T> supplier);
 
+    /**
+     * Binds to the given provider, this will call the provider every time it is
+     * requested.
+     *
+     * @param provider The provider to bind to
+     * @return The binder
+     */
     Binder to(Provider<T> provider);
 
     /**

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingHierarchy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingHierarchy.java
@@ -16,13 +16,13 @@
 
 package org.dockbox.hartshorn.inject.binding;
 
+import java.util.List;
+import java.util.Map.Entry;
+
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.context.ContextCarrier;
 import org.dockbox.hartshorn.inject.Provider;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.util.List;
-import java.util.Map.Entry;
 
 /**
  * A hierarchical representation of type providers. Each entry is represented by a {@link Entry}
@@ -102,6 +102,14 @@ public interface BindingHierarchy<C> extends Iterable<Entry<Integer, Provider<C>
      * @return The provider if it exists, or {@link Option#empty()}
      */
     Option<Provider<C>> get(int priority);
+
+    /**
+     * Gets the {@link Provider} with the highest priority. If no providers are registered, an
+     * {@link Option#empty()} will be returned.
+     *
+     * @return The provider with the highest priority, or {@link Option#empty()}.
+     */
+    Option<Provider<C>> highestPriority();
 
     /**
      * Gets the {@link ComponentKey} of the current hierarchy, containing a {@link Class}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ComponentInstanceFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ComponentInstanceFactory.java
@@ -21,7 +21,24 @@ import org.dockbox.hartshorn.inject.ObjectContainer;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.option.Option;
 
+/**
+ * A factory for creating component instances. This can be used by {@link Binder binders} to create instances
+ * of components when they are requested, but no custom provider is available.
+ *
+ * @author Guus Lieben
+ * @since 0.4.11
+ */
 public interface ComponentInstanceFactory {
 
+    /**
+     * Creates a new instance of the component identified by the given key. The key may be named or unnamed, and
+     * may contain a scope. Depending on the implementation, these attributes may be used to determine the
+     * instance that is created.
+     *
+     * @param key The key of the component to create
+     * @return The created instance
+     * @param <T> The type of the component
+     * @throws ApplicationException When the instance cannot be created
+     */
     <T> Option<ObjectContainer<T>> instantiate(ComponentKey<T> key) throws ApplicationException;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ConcurrentHashSingletonCache.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ConcurrentHashSingletonCache.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.util.IllegalModificationException;
+import org.dockbox.hartshorn.util.option.Option;
 
 /**
  * A singleton cache implementation that uses a {@link ConcurrentHashMap} to store
@@ -38,15 +39,15 @@ public class ConcurrentHashSingletonCache implements SingletonCache {
 
     @Override
     public <T> void put(ComponentKey<T> key, T instance) {
-        if (this.cache.containsKey(key)) {
+        if (this.cache.containsKey(key) && this.cache.get(key) != instance) {
             throw new IllegalModificationException("An instance is already stored for key '" + key + "'");
         }
         this.cache.put(key, instance);
     }
 
     @Override
-    public <T> T get(ComponentKey<T> key) {
-        return key.type().cast(this.cache.get(key));
+    public <T> Option<T> get(ComponentKey<T> key) {
+        return Option.of(key.type().cast(this.cache.get(key)));
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ConcurrentHashSingletonCache.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ConcurrentHashSingletonCache.java
@@ -16,17 +16,31 @@
 
 package org.dockbox.hartshorn.inject.binding;
 
-import org.dockbox.hartshorn.component.ComponentKey;
-
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.util.IllegalModificationException;
+
+/**
+ * A singleton cache implementation that uses a {@link ConcurrentHashMap} to store
+ * instances. This implementation is thread-safe.
+ *
+ * @author Guus Lieben
+ * @since 0.4.11
+ *
+ * @see SingletonCache
+ * @see ConcurrentHashMap
+ */
 public class ConcurrentHashSingletonCache implements SingletonCache {
 
     private final Map<ComponentKey<?>, Object> cache = new ConcurrentHashMap<>();
 
     @Override
     public <T> void put(ComponentKey<T> key, T instance) {
+        if (this.cache.containsKey(key)) {
+            throw new IllegalModificationException("An instance is already stored for key '" + key + "'");
+        }
         this.cache.put(key, instance);
     }
 
@@ -36,17 +50,8 @@ public class ConcurrentHashSingletonCache implements SingletonCache {
     }
 
     @Override
-    public <T> void remove(ComponentKey<T> key) {
-        this.cache.remove(key);
-    }
-
-    @Override
     public <T> boolean contains(ComponentKey<T> key) {
         return this.cache.containsKey(key);
     }
 
-    @Override
-    public <T> void clear() {
-        this.cache.clear();
-    }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ContextWrappedHierarchy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ContextWrappedHierarchy.java
@@ -16,16 +16,16 @@
 
 package org.dockbox.hartshorn.inject.binding;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.inject.Provider;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.function.Consumer;
 
 /**
  * A {@link ContextWrappedHierarchy} is a {@link BindingHierarchy} that wraps another {@link BindingHierarchy}
@@ -38,9 +38,10 @@ import java.util.function.Consumer;
  */
 public class ContextWrappedHierarchy<C> implements BindingHierarchy<C> {
 
-    private BindingHierarchy<C> real;
     private final ApplicationContext applicationContext;
     private final Consumer<BindingHierarchy<C>> onUpdate;
+
+    private BindingHierarchy<C> real;
 
     public ContextWrappedHierarchy(final BindingHierarchy<C> real, final ApplicationContext applicationContext, final Consumer<BindingHierarchy<C>> onUpdate) {
         this.real = real;
@@ -48,7 +49,10 @@ public class ContextWrappedHierarchy<C> implements BindingHierarchy<C> {
         this.onUpdate = onUpdate;
     }
 
-    public BindingHierarchy<C> real() {
+    /**
+     * @return The wrapped {@link BindingHierarchy}.
+     */
+    protected BindingHierarchy<C> real() {
         return this.real;
     }
 
@@ -94,6 +98,11 @@ public class ContextWrappedHierarchy<C> implements BindingHierarchy<C> {
     @Override
     public Option<Provider<C>> get(final int priority) {
         return this.real().get(priority);
+    }
+
+    @Override
+    public Option<Provider<C>> highestPriority() {
+        return this.real().highestPriority();
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
@@ -31,6 +31,18 @@ import org.dockbox.hartshorn.util.function.CheckedSupplier;
 import org.dockbox.hartshorn.util.option.Option;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * A {@link BindingFunction} that configures a {@link BindingHierarchy} for a specific key. The hierarchy is
+ * provided by the owning {@link Binder}.
+ *
+ * @param <T> The type of the component that is bound.
+ *
+ * @author Guus Lieben
+ * @since 0.4.1
+ *
+ * @see Binder
+ * @see BindingHierarchy
+ */
 public class HierarchyBindingFunction<T> implements BindingFunction<T> {
 
     private final BindingHierarchy<T> hierarchy;
@@ -82,9 +94,9 @@ public class HierarchyBindingFunction<T> implements BindingFunction<T> {
     }
 
     @Override
-    public BindingFunction<T> installTo(Class<? extends Scope> scope) {
+    public BindingFunction<T> installTo(Class<? extends Scope> scope) throws IllegalScopeException {
         if (this.scope != null && this.scope != Scope.DEFAULT_SCOPE && (!(this.scope instanceof ApplicationContext))) {
-            throw new IllegalModificationException("Cannot install binding to scope " + scope.getName() + " as the binding is already installed to scope " + this.scope.getClass().getName());
+            throw new IllegalScopeException("Cannot install binding to scope " + scope.getName() + " as the binding is already installed to scope " + this.scope.getClass().getName());
         }
         // Permitted, as default application scope may be expanded. Defined child scopes can not be expanded, so this is a safe check
         if (this.scope instanceof ApplicationContext && !ApplicationContext.class.isAssignableFrom(scope)) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/IllegalScopeException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/IllegalScopeException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.inject.binding;
 
 import org.dockbox.hartshorn.util.ApplicationException;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/IllegalScopeException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/IllegalScopeException.java
@@ -1,0 +1,23 @@
+package org.dockbox.hartshorn.inject.binding;
+
+import org.dockbox.hartshorn.util.ApplicationException;
+
+/**
+ * Thrown when a scope is not valid for a given binding. For example, when a singleton scope is installed
+ * on a binding that does not allow for singletons.
+ *
+ * @author Guus Lieben
+ * @since 0.5.0
+ *
+ * @see BindingFunction
+ */
+public class IllegalScopeException extends ApplicationException {
+
+    public IllegalScopeException(String message) {
+        super(message);
+    }
+
+    public IllegalScopeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/NativeBindingHierarchy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/NativeBindingHierarchy.java
@@ -16,13 +16,6 @@
 
 package org.dockbox.hartshorn.inject.binding;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.component.ComponentKey;
-import org.dockbox.hartshorn.inject.ContextDrivenProvider;
-import org.dockbox.hartshorn.inject.Provider;
-import org.dockbox.hartshorn.util.option.Option;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -30,6 +23,13 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.inject.ContextDrivenProvider;
+import org.dockbox.hartshorn.inject.Provider;
+import org.dockbox.hartshorn.util.option.Option;
 
 /**
  * The default implementation of the {@link BindingHierarchy} interface. This uses a specified {@link ComponentKey}
@@ -112,6 +112,11 @@ public class NativeBindingHierarchy<C> implements BindingHierarchy<C> {
     @Override
     public Option<Provider<C>> get(final int priority) {
         return Option.of(this.bindings.getOrDefault(priority, null));
+    }
+
+    @Override
+    public Option<Provider<C>> highestPriority() {
+        return Option.of(this.bindings.firstEntry()).map(Entry::getValue);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/SingletonCache.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/SingletonCache.java
@@ -17,17 +17,48 @@
 package org.dockbox.hartshorn.inject.binding;
 
 import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.util.IllegalModificationException;
+import org.dockbox.hartshorn.util.option.Option;
 
+/**
+ * A singleton cache is used to store singleton instances of components. This is used to
+ * prevent the creation of multiple instances of the same component, and improve tracking
+ * of the components that are currently active.
+ *
+ * @author Guus Lieben
+ * @since 0.4.11
+ */
 public interface SingletonCache {
 
-    <T> void put(ComponentKey<T> key, T instance);
+    /**
+     * Stores the given instance in the cache, using the given key. If an instance is already
+     * stored for the given key, the implementation may decide whether to replace the existing
+     * instance, or to throw an exception.
+     *
+     * @param key The key to store the instance under.
+     * @param instance The instance to store.
+     * @param <T> The type of the instance.
+     *
+     * @throws IllegalModificationException If an instance is already stored for the given key.
+     */
+    <T> void put(ComponentKey<T> key, T instance) throws IllegalModificationException;
 
-    <T> T get(ComponentKey<T> key);
+    /**
+     * Returns the instance stored in the cache for the given key. If no instance is stored
+     * for the given key, an empty {@link Option} is returned.
+     *
+     * @param key The key to retrieve the instance for.
+     * @return The instance stored in the cache for the given key, or an empty {@link Option}
+     * @param <T> The type of the instance.
+     */
+    <T> Option<T> get(ComponentKey<T> key);
 
-    <T> void remove(ComponentKey<T> key);
-
+    /**
+     * Returns {@code true} if an instance is stored in the cache for the given key.
+     *
+     * @param key The key to check.
+     * @return {@code true} if an instance is stored in the cache for the given key.
+     * @param <T> The type of the instance.
+     */
     <T> boolean contains(ComponentKey<T> key);
-
-    <T> void clear();
-
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/ContextParameterLoaderRule.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/ContextParameterLoaderRule.java
@@ -43,7 +43,9 @@ public class ContextParameterLoaderRule implements ParameterLoaderRule<Applicati
 
         final TypeView<? extends org.dockbox.hartshorn.context.Context> type = TypeUtils.adjustWildcards(parameter.type(), TypeView.class);
         ContextKey<? extends org.dockbox.hartshorn.context.Context> key = ContextKey.of(type.type());
-        if (StringUtilities.notEmpty(name)) key = key.mutable().name(name).build();
+        if (StringUtilities.notEmpty(name)) {
+            key = key.mutable().name(name).build();
+        }
 
         final Option<? extends org.dockbox.hartshorn.context.Context> out = applicationContext.first(key);
 

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
@@ -16,18 +16,24 @@
 
 package test.org.dockbox.hartshorn;
 
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.ComponentRequiredException;
 import org.dockbox.hartshorn.component.ComponentResolutionException;
 import org.dockbox.hartshorn.component.ContextualComponentPopulator;
 import org.dockbox.hartshorn.inject.ComponentInitializationException;
+import org.dockbox.hartshorn.inject.ConstructorDiscoveryList;
+import org.dockbox.hartshorn.inject.ConstructorDiscoveryList.DiscoveredComponent;
 import org.dockbox.hartshorn.inject.CyclicComponentException;
 import org.dockbox.hartshorn.inject.CyclingConstructorAnalyzer;
 import org.dockbox.hartshorn.inject.processing.UseContextInjection;
 import org.dockbox.hartshorn.proxy.Proxy;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.dockbox.hartshorn.testsuite.InjectTest;
+import org.dockbox.hartshorn.testsuite.TestBinding;
 import org.dockbox.hartshorn.testsuite.TestComponents;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
@@ -38,17 +44,20 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 
-import java.util.List;
-import java.util.stream.Stream;
-
 import jakarta.inject.Inject;
 import test.org.dockbox.hartshorn.boot.EmptyService;
+import test.org.dockbox.hartshorn.components.BoundCircularDependencyA;
+import test.org.dockbox.hartshorn.components.BoundCircularDependencyB;
 import test.org.dockbox.hartshorn.components.CircularConstructorA;
 import test.org.dockbox.hartshorn.components.CircularConstructorB;
 import test.org.dockbox.hartshorn.components.CircularDependencyA;
 import test.org.dockbox.hartshorn.components.CircularDependencyB;
 import test.org.dockbox.hartshorn.components.ComponentType;
 import test.org.dockbox.hartshorn.components.ContextInjectedType;
+import test.org.dockbox.hartshorn.components.ImplicitCircularDependencyA;
+import test.org.dockbox.hartshorn.components.ImplicitCircularDependencyB;
+import test.org.dockbox.hartshorn.components.InterfaceCircularDependencyA;
+import test.org.dockbox.hartshorn.components.InterfaceCircularDependencyB;
 import test.org.dockbox.hartshorn.components.LongCycles.LongCycleA;
 import test.org.dockbox.hartshorn.components.LongCycles.LongCycleB;
 import test.org.dockbox.hartshorn.components.LongCycles.LongCycleC;
@@ -124,7 +133,7 @@ public class ApplicationContextTests {
         final Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
-        Assertions.assertEquals("Hartshorn", provided.name());
+        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
     }
 
     @Test
@@ -137,7 +146,7 @@ public class ApplicationContextTests {
         final Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
-        Assertions.assertEquals("Hartshorn", provided.name());
+        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
     }
 
     @Test
@@ -149,7 +158,7 @@ public class ApplicationContextTests {
         final Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
-        Assertions.assertEquals("Hartshorn", provided.name());
+        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
     }
 
     @Test
@@ -162,7 +171,7 @@ public class ApplicationContextTests {
         final Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
-        Assertions.assertEquals("Hartshorn", provided.name());
+        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
     }
 
     @Test
@@ -174,7 +183,7 @@ public class ApplicationContextTests {
         final Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
-        Assertions.assertEquals("Hartshorn", provided.name());
+        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
     }
 
     @Test
@@ -187,7 +196,7 @@ public class ApplicationContextTests {
         final Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
-        Assertions.assertEquals("Hartshorn", provided.name());
+        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
     }
 
     @Test
@@ -223,7 +232,7 @@ public class ApplicationContextTests {
 
         new ContextualComponentPopulator(this.applicationContext).populate(populatedType);
         Assertions.assertNotNull(populatedType.sampleInterface());
-        Assertions.assertEquals("Hartshorn", populatedType.sampleInterface().name());
+        Assertions.assertEquals(SampleImplementation.NAME, populatedType.sampleInterface().name());
     }
 
     @Test
@@ -336,12 +345,12 @@ public class ApplicationContextTests {
 
     public static Stream<Arguments> circular() {
         return Stream.of(
-                Arguments.of(CircularConstructorA.class, new Class<?>[] {CircularConstructorA.class, CircularConstructorB.class, CircularConstructorA.class}),
-                Arguments.of(CircularConstructorB.class, new Class<?>[] {CircularConstructorB.class, CircularConstructorA.class, CircularConstructorB.class}),
-                Arguments.of(LongCycleA.class, new Class<?>[] {LongCycleA.class, LongCycleB.class, LongCycleC.class, LongCycleD.class, LongCycleA.class}),
-                Arguments.of(LongCycleB.class, new Class<?>[] {LongCycleB.class, LongCycleC.class, LongCycleD.class, LongCycleA.class, LongCycleB.class}),
-                Arguments.of(LongCycleC.class, new Class<?>[] {LongCycleC.class, LongCycleD.class, LongCycleA.class, LongCycleB.class, LongCycleC.class}),
-                Arguments.of(LongCycleD.class, new Class<?>[] {LongCycleD.class, LongCycleA.class, LongCycleB.class, LongCycleC.class, LongCycleD.class})
+                Arguments.of(CircularConstructorA.class, new Class<?>[] {CircularConstructorA.class, CircularConstructorB.class}),
+                Arguments.of(CircularConstructorB.class, new Class<?>[] {CircularConstructorB.class, CircularConstructorA.class}),
+                Arguments.of(LongCycleA.class, new Class<?>[] {LongCycleA.class, LongCycleB.class, LongCycleC.class, LongCycleD.class}),
+                Arguments.of(LongCycleB.class, new Class<?>[] {LongCycleB.class, LongCycleC.class, LongCycleD.class, LongCycleA.class}),
+                Arguments.of(LongCycleC.class, new Class<?>[] {LongCycleC.class, LongCycleD.class, LongCycleA.class, LongCycleB.class}),
+                Arguments.of(LongCycleD.class, new Class<?>[] {LongCycleD.class, LongCycleA.class, LongCycleB.class, LongCycleC.class})
         );
     }
 
@@ -351,14 +360,15 @@ public class ApplicationContextTests {
             CircularDependencyA.class,
             CircularDependencyB.class,
     })
-    void testCircularDependencyPathCanBeDetermined(final Class<?> type, final Class<?>... expected) {
-        final TypeView<?> typeView = this.applicationContext.environment().introspect(type);
-        final List<TypeView<?>> path = CyclingConstructorAnalyzer.findCyclicPath(typeView);
+    void testCircularDependencyPathCanBeDetermined(Class<?> type, Class<?>... expected) {
+        TypeView<?> typeView = this.applicationContext.environment().introspect(type);
+        ConstructorDiscoveryList path = CyclingConstructorAnalyzer.create(applicationContext).findCyclicPath(typeView);
         
         Assertions.assertNotNull(path);
-        Assertions.assertEquals(expected.length, path.size());
+        List<DiscoveredComponent> discoveredComponents = path.discoveredComponents();
+        Assertions.assertEquals(expected.length, discoveredComponents.size());
         for (int i = 0; i < expected.length; i++) {
-            Assertions.assertSame(expected[i], path.get(i).type());
+            Assertions.assertSame(expected[i], discoveredComponents.get(i).node().type().type());
         }
     }
 
@@ -375,6 +385,40 @@ public class ApplicationContextTests {
 
     @Test
     @TestComponents({SetterInjectedComponent.class, ComponentType.class})
+    void testCircularDependencyPathOnExplicitBoundTypeCanBeDetermined() {
+        TypeView<?> typeView = this.applicationContext.environment().introspect(InterfaceCircularDependencyA.class);
+        ConstructorDiscoveryList path = CyclingConstructorAnalyzer.create(applicationContext).findCyclicPath(typeView);
+        Assertions.assertNotNull(path);
+
+        List<DiscoveredComponent> discoveredComponents = path.discoveredComponents();
+        Assertions.assertEquals(3, discoveredComponents.size());
+        Assertions.assertSame(InterfaceCircularDependencyA.class, discoveredComponents.get(0).node().type().type());
+        Assertions.assertSame(BoundCircularDependencyB.class, discoveredComponents.get(1).node().type().type());
+        Assertions.assertSame(BoundCircularDependencyA.class, discoveredComponents.get(2).node().type().type());
+    }
+
+    @Test
+    @TestComponents(bindings = {
+            @TestBinding(type = InterfaceCircularDependencyA.class, implementation = ImplicitCircularDependencyA.class),
+            @TestBinding(type = InterfaceCircularDependencyB.class, implementation = ImplicitCircularDependencyB.class)
+    })
+    void testCircularDependencyPathOnImplicitBoundTypeCanBeDetermined() {
+        TypeView<?> typeView = this.applicationContext.environment().introspect(InterfaceCircularDependencyA.class);
+        ConstructorDiscoveryList path = CyclingConstructorAnalyzer.create(applicationContext).findCyclicPath(typeView);
+        Assertions.assertNotNull(path);
+
+        List<DiscoveredComponent> discoveredComponents = path.discoveredComponents();
+        Assertions.assertEquals(2, discoveredComponents.size());
+        DiscoveredComponent componentA = discoveredComponents.get(0);
+        Assertions.assertSame(InterfaceCircularDependencyA.class, componentA.node().type().type());
+        Assertions.assertSame(ImplicitCircularDependencyA.class, componentA.actualType().type());
+
+        DiscoveredComponent componentB = discoveredComponents.get(1);
+        Assertions.assertSame(InterfaceCircularDependencyB.class, componentB.node().type().type());
+        Assertions.assertSame(ImplicitCircularDependencyB.class, componentB.actualType().type());
+    }
+
+    @Test
     void testSetterInjectionWithRegularComponent() {
         final SetterInjectedComponent component = this.applicationContext.get(SetterInjectedComponent.class);
         Assertions.assertNotNull(component);

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
@@ -112,7 +112,7 @@ public class ApplicationContextTests {
 //    @HartshornTest(includeBasePackages = false, processors = DemoProxyDelegationPostProcessor.class)
 //    @TestComponents({AbstractProxy.class, ProxyProviders.class})
 //    void testMethodCanDelegateToImplementation() {
-//        final AbstractProxy abstractProxy = this.applicationContext.get(AbstractProxy.class);
+//        AbstractProxy abstractProxy = this.applicationContext.get(AbstractProxy.class);
 //        Assertions.assertEquals("concrete", abstractProxy.name());
 //    }
 //
@@ -120,17 +120,17 @@ public class ApplicationContextTests {
 //    @HartshornTest(includeBasePackages = false, processors = DemoProxyDelegationPostProcessor.class)
 //    @TestComponents({AbstractProxy.class, ProxyProviders.class})
 //    void testMethodOverrideDoesNotDelegateToImplementation() {
-//        final AbstractProxy abstractProxy = this.applicationContext.get(AbstractProxy.class);
+//        AbstractProxy abstractProxy = this.applicationContext.get(AbstractProxy.class);
 //        Assertions.assertEquals(21, abstractProxy.age());
 //    }
 
     @Test
     public void testStaticBindingCanBeProvided() {
         this.applicationContext.bind(SampleInterface.class).to(SampleImplementation.class);
-        final SampleInterface provided = this.applicationContext.get(SampleInterface.class);
+        SampleInterface provided = this.applicationContext.get(SampleInterface.class);
         Assertions.assertNotNull(provided);
 
-        final Class<? extends SampleInterface> providedClass = provided.getClass();
+        Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
         Assertions.assertEquals(SampleImplementation.NAME, provided.name());
@@ -138,12 +138,12 @@ public class ApplicationContextTests {
 
     @Test
     public void testStaticBindingWithMetaCanBeProvided() {
-        final ComponentKey<SampleInterface> key = ComponentKey.of(SampleInterface.class, "demo");
+        ComponentKey<SampleInterface> key = ComponentKey.of(SampleInterface.class, "demo");
         this.applicationContext.bind(key).to(SampleImplementation.class);
-        final SampleInterface provided = this.applicationContext.get(key);
+        SampleInterface provided = this.applicationContext.get(key);
         Assertions.assertNotNull(provided);
 
-        final Class<? extends SampleInterface> providedClass = provided.getClass();
+        Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
         Assertions.assertEquals(SampleImplementation.NAME, provided.name());
@@ -152,10 +152,10 @@ public class ApplicationContextTests {
     @Test
     public void testInstanceBindingCanBeProvided() {
         this.applicationContext.bind(SampleInterface.class).singleton(new SampleImplementation());
-        final SampleInterface provided = this.applicationContext.get(SampleInterface.class);
+        SampleInterface provided = this.applicationContext.get(SampleInterface.class);
         Assertions.assertNotNull(provided);
 
-        final Class<? extends SampleInterface> providedClass = provided.getClass();
+        Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
         Assertions.assertEquals(SampleImplementation.NAME, provided.name());
@@ -163,12 +163,12 @@ public class ApplicationContextTests {
 
     @Test
     public void testInstanceBindingWithMetaCanBeProvided() {
-        final ComponentKey<SampleInterface> key = ComponentKey.of(SampleInterface.class, "demo");
+        ComponentKey<SampleInterface> key = ComponentKey.of(SampleInterface.class, "demo");
         this.applicationContext.bind(key).singleton(new SampleImplementation());
-        final SampleInterface provided = this.applicationContext.get(key);
+        SampleInterface provided = this.applicationContext.get(key);
         Assertions.assertNotNull(provided);
 
-        final Class<? extends SampleInterface> providedClass = provided.getClass();
+        Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
         Assertions.assertEquals(SampleImplementation.NAME, provided.name());
@@ -177,10 +177,10 @@ public class ApplicationContextTests {
     @Test
     public void testProviderBindingCanBeProvided() {
         this.applicationContext.bind(SampleInterface.class).to(SampleImplementation::new);
-        final SampleInterface provided = this.applicationContext.get(SampleInterface.class);
+        SampleInterface provided = this.applicationContext.get(SampleInterface.class);
         Assertions.assertNotNull(provided);
 
-        final Class<? extends SampleInterface> providedClass = provided.getClass();
+        Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
         Assertions.assertEquals(SampleImplementation.NAME, provided.name());
@@ -188,46 +188,46 @@ public class ApplicationContextTests {
 
     @Test
     public void testProviderBindingWithMetaCanBeProvided() {
-        final ComponentKey<SampleInterface> key = ComponentKey.of(SampleInterface.class, "demo");
+        ComponentKey<SampleInterface> key = ComponentKey.of(SampleInterface.class, "demo");
         this.applicationContext.bind(key).to(SampleImplementation::new);
-        final SampleInterface provided = this.applicationContext.get(key);
+        SampleInterface provided = this.applicationContext.get(key);
         Assertions.assertNotNull(provided);
 
-        final Class<? extends SampleInterface> providedClass = provided.getClass();
+        Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleImplementation.class, providedClass);
 
         Assertions.assertEquals(SampleImplementation.NAME, provided.name());
     }
 
     @Test
-    @TestComponents(SampleProviders.class)
+    @TestComponents(components = SampleProviders.class)
     public void testScannedMetaBindingsCanBeProvided() {
 
         // Ensure that the binding is not bound to the default name
         Assertions.assertThrows(ComponentResolutionException.class, () -> this.applicationContext.get(SampleInterface.class));
 
-        final SampleInterface provided = this.applicationContext.get(ComponentKey.of(SampleInterface.class, "meta"));
+        SampleInterface provided = this.applicationContext.get(ComponentKey.of(SampleInterface.class, "meta"));
         Assertions.assertNotNull(provided);
 
-        final Class<? extends SampleInterface> providedClass = provided.getClass();
+        Class<? extends SampleInterface> providedClass = provided.getClass();
         Assertions.assertSame(SampleMetaAnnotatedImplementation.class, providedClass);
 
         Assertions.assertEquals("MetaAnnotatedHartshorn", provided.name());
     }
 
     @Test
-    @TestComponents(TypeWithEnabledInjectField.class)
+    @TestComponents(components = TypeWithEnabledInjectField.class)
     void testEnabledInjectDoesNotInjectTwice() {
-        final TypeWithEnabledInjectField instance = this.applicationContext.get(TypeWithEnabledInjectField.class);
+        TypeWithEnabledInjectField instance = this.applicationContext.get(TypeWithEnabledInjectField.class);
         Assertions.assertNotNull(instance);
         Assertions.assertNotNull(instance.singletonEnableable());
         Assertions.assertEquals(1, instance.singletonEnableable().enabled());
     }
 
     @Test
+    @TestComponents(bindings = @TestBinding(type = SampleInterface.class, implementation = SampleImplementation.class))
     public void testTypesCanBePopulated() {
-        this.applicationContext.bind(SampleInterface.class).to(SampleImplementation.class);
-        final PopulatedType populatedType = new PopulatedType();
+        PopulatedType populatedType = new PopulatedType();
         Assertions.assertNull(populatedType.sampleInterface());
 
         new ContextualComponentPopulator(this.applicationContext).populate(populatedType);
@@ -236,36 +236,48 @@ public class ApplicationContextTests {
     }
 
     @Test
-    @TestComponents(PopulatedType.class)
+    @TestComponents(
+            components = PopulatedType.class,
+            bindings = @TestBinding(type = SampleInterface.class, implementation = SampleImplementation.class)
+    )
     public void unboundTypesCanBeProvided() {
-        this.applicationContext.bind(SampleInterface.class).to(SampleImplementation.class);
-        final PopulatedType provided = this.applicationContext.get(PopulatedType.class);
+        PopulatedType provided = this.applicationContext.get(PopulatedType.class);
         Assertions.assertNotNull(provided);
         Assertions.assertNotNull(provided.sampleInterface());
     }
 
     @ParameterizedTest
     @MethodSource("providers")
-    @TestComponents({SampleFieldImplementation.class, SampleProviderService.class})
-    void testProvidersCanApply(final String meta, final String name, final boolean field, final String fieldMeta, final boolean singleton) {
+    @TestComponents(components = {SampleFieldImplementation.class, SampleProviderService.class})
+    void testProvidersCanApply(String meta, String name, boolean field, String fieldMeta, boolean singleton) {
         if (field) {
             if (fieldMeta == null) {this.applicationContext.bind(SampleField.class).to(SampleFieldImplementation.class);}
-            else this.applicationContext.bind(ComponentKey.of(SampleField.class, fieldMeta)).to(SampleFieldImplementation.class);
+            else {
+                this.applicationContext.bind(ComponentKey.of(SampleField.class, fieldMeta)).to(SampleFieldImplementation.class);
+            }
         }
 
-        final ProvidedInterface provided;
-        if (meta == null) provided = this.applicationContext.get(ProvidedInterface.class);
-        else provided = this.applicationContext.get(ComponentKey.of(ProvidedInterface.class, meta));
+        ProvidedInterface provided;
+        if (meta == null) {
+            provided = this.applicationContext.get(ProvidedInterface.class);
+        }
+        else {
+            provided = this.applicationContext.get(ComponentKey.of(ProvidedInterface.class, meta));
+        }
         Assertions.assertNotNull(provided);
 
-        final String actual = provided.name();
+        String actual = provided.name();
         Assertions.assertNotNull(name);
         Assertions.assertEquals(name, actual);
 
         if (singleton) {
-            final ProvidedInterface second;
-            if (meta == null) second = this.applicationContext.get(ProvidedInterface.class);
-            else second = this.applicationContext.get(ComponentKey.of(ProvidedInterface.class, meta));
+            ProvidedInterface second;
+            if (meta == null) {
+                second = this.applicationContext.get(ProvidedInterface.class);
+            }
+            else {
+                second = this.applicationContext.get(ComponentKey.of(ProvidedInterface.class, meta));
+            }
             Assertions.assertNotNull(second);
             Assertions.assertSame(provided, second);
         }
@@ -273,29 +285,35 @@ public class ApplicationContextTests {
 
     @Test
     void testContextFieldsAreInjected() {
-        this.applicationContext.add(new SampleContext("InjectedContext"));
+        String contextName = "InjectedContext";
+        this.applicationContext.add(new SampleContext(contextName));
+        
         ContextualComponentPopulator populator = new ContextualComponentPopulator(this.applicationContext);
-        final ContextInjectedType instance = populator.populate(new ContextInjectedType());
+        ContextInjectedType instance = populator.populate(new ContextInjectedType());
+        
         Assertions.assertNotNull(instance.context());
-        Assertions.assertEquals("InjectedContext", instance.context().name());
+        Assertions.assertEquals(contextName, instance.context().name());
     }
 
     @Test
     void testNamedContextFieldsAreInjected() {
-        this.applicationContext.add("another", new SampleContext("InjectedContext"));
+        String contextName = "InjectedContext";
+        this.applicationContext.add("another", new SampleContext(contextName));
+        
         ContextualComponentPopulator populator = new ContextualComponentPopulator(this.applicationContext);
-        final ContextInjectedType instance = populator.populate(new ContextInjectedType());
+        ContextInjectedType instance = populator.populate(new ContextInjectedType());
+        
         Assertions.assertNotNull(instance.anotherContext());
-        Assertions.assertEquals("InjectedContext", instance.anotherContext().name());
+        Assertions.assertEquals(contextName, instance.anotherContext().name());
     }
 
     @Test
-    @TestComponents(EmptyService.class)
+    @TestComponents(components = EmptyService.class)
     void servicesAreSingletonsByDefault() {
         Assertions.assertTrue(this.applicationContext.environment().singleton(EmptyService.class));
 
-        final EmptyService emptyService = this.applicationContext.get(EmptyService.class);
-        final EmptyService emptyService2 = this.applicationContext.get(EmptyService.class);
+        EmptyService emptyService = this.applicationContext.get(EmptyService.class);
+        EmptyService emptyService2 = this.applicationContext.get(EmptyService.class);
         Assertions.assertSame(emptyService, emptyService2);
     }
 
@@ -305,36 +323,36 @@ public class ApplicationContextTests {
     }
 
     @Test
-    @TestComponents(ComponentType.class)
+    @TestComponents(components = ComponentType.class)
     void testPermittedComponentsAreProxiedWhenRegularProvisionFails() {
-        final ComponentType instance = this.applicationContext.get(ComponentType.class);
+        ComponentType instance = this.applicationContext.get(ComponentType.class);
         Assertions.assertNotNull(instance);
         Assertions.assertTrue(this.applicationContext.environment().isProxy(instance));
     }
 
     @Test
-    @TestComponents(NonProxyComponentType.class)
+    @TestComponents(components = NonProxyComponentType.class)
     void testNonPermittedComponentsAreNotProxied() {
         Assertions.assertThrows(ComponentResolutionException.class, () -> this.applicationContext.get(NonProxyComponentType.class));
     }
 
     @Test
     void testFailingConstructorIsRethrown() {
-        final ComponentInitializationException exception = Assertions.assertThrows(ComponentInitializationException.class, () -> this.applicationContext.get(TypeWithFailingConstructor.class));
+        ComponentInitializationException exception = Assertions.assertThrows(ComponentInitializationException.class, () -> this.applicationContext.get(TypeWithFailingConstructor.class));
         Assertions.assertTrue(exception.getCause() instanceof ApplicationException);
 
-        final ApplicationException applicationException = (ApplicationException) exception.getCause();
+        ApplicationException applicationException = (ApplicationException) exception.getCause();
         Assertions.assertTrue(applicationException.getCause() instanceof IllegalStateException);
 
-        final IllegalStateException illegalStateException = (IllegalStateException) applicationException.getCause();
+        IllegalStateException illegalStateException = (IllegalStateException) applicationException.getCause();
         Assertions.assertEquals(TypeWithFailingConstructor.ERROR_MESSAGE, illegalStateException.getMessage());
     }
 
     @Test
-    @TestComponents({CircularDependencyA.class, CircularDependencyB.class})
+    @TestComponents(components = {CircularDependencyA.class, CircularDependencyB.class})
     void testCircularDependenciesAreCorrectOnFieldInject() {
-        final CircularDependencyA a = Assertions.assertDoesNotThrow(() -> this.applicationContext.get(CircularDependencyA.class));
-        final CircularDependencyB b = Assertions.assertDoesNotThrow(() -> this.applicationContext.get(CircularDependencyB.class));
+        CircularDependencyA a = Assertions.assertDoesNotThrow(() -> this.applicationContext.get(CircularDependencyA.class));
+        CircularDependencyB b = Assertions.assertDoesNotThrow(() -> this.applicationContext.get(CircularDependencyB.class));
 
         Assertions.assertNotNull(a);
         Assertions.assertNotNull(b);
@@ -356,7 +374,7 @@ public class ApplicationContextTests {
 
     @ParameterizedTest
     @MethodSource("circular")
-    @TestComponents({
+    @TestComponents(components = {
             CircularDependencyA.class,
             CircularDependencyB.class,
     })
@@ -374,17 +392,20 @@ public class ApplicationContextTests {
 
     @ParameterizedTest
     @MethodSource("circular")
-    @TestComponents({
+    @TestComponents(components = {
             CircularDependencyA.class,
             CircularDependencyB.class,
     })
-    void testExceptionIsThrownOnCyclicProvision(final Class<?> type, final Class<?>... path) {
-        final ComponentInitializationException exception = Assertions.assertThrows(ComponentInitializationException.class, () -> this.applicationContext.get(type));
+    void testExceptionIsThrownOnCyclicProvision(Class<?> type, Class<?>... path) {
+        ComponentInitializationException exception = Assertions.assertThrows(ComponentInitializationException.class, () -> this.applicationContext.get(type));
         Assertions.assertTrue(exception.getCause() instanceof CyclicComponentException);
     }
 
     @Test
-    @TestComponents({SetterInjectedComponent.class, ComponentType.class})
+    @TestComponents(bindings = {
+            @TestBinding(type = InterfaceCircularDependencyA.class, implementation = BoundCircularDependencyA.class),
+            @TestBinding(type = InterfaceCircularDependencyB.class, implementation = BoundCircularDependencyB.class)
+    })
     void testCircularDependencyPathOnExplicitBoundTypeCanBeDetermined() {
         TypeView<?> typeView = this.applicationContext.environment().introspect(InterfaceCircularDependencyA.class);
         ConstructorDiscoveryList path = CyclingConstructorAnalyzer.create(applicationContext).findCyclicPath(typeView);
@@ -419,55 +440,56 @@ public class ApplicationContextTests {
     }
 
     @Test
+    @TestComponents(components = {SetterInjectedComponent.class, ComponentType.class})
     void testSetterInjectionWithRegularComponent() {
-        final SetterInjectedComponent component = this.applicationContext.get(SetterInjectedComponent.class);
+        SetterInjectedComponent component = this.applicationContext.get(SetterInjectedComponent.class);
         Assertions.assertNotNull(component);
         Assertions.assertNotNull(component.component());
     }
 
     @Test
-    @TestComponents(SetterInjectedComponentWithAbsentBinding.class)
+    @TestComponents(components = SetterInjectedComponentWithAbsentBinding.class)
     void testSetterInjectionWithAbsentRequiredComponent() {
         Assertions.assertThrows(ComponentRequiredException.class, () -> this.applicationContext.get(SetterInjectedComponentWithAbsentBinding.class));
     }
 
     @Test
-    @TestComponents(SetterInjectedComponentWithNonRequiredAbsentBinding.class)
+    @TestComponents(components = SetterInjectedComponentWithNonRequiredAbsentBinding.class)
     void testSetterInjectionWithAbsentComponent() {
-        final var component = Assertions.assertDoesNotThrow(() -> this.applicationContext.get(SetterInjectedComponentWithNonRequiredAbsentBinding.class));
+        var component = Assertions.assertDoesNotThrow(() -> this.applicationContext.get(SetterInjectedComponentWithNonRequiredAbsentBinding.class));
         Assertions.assertNotNull(component);
         Assertions.assertNull(component.object());
     }
 
     @Test
-    @TestComponents({SetterInjectedComponent.class, ComponentType.class})
+    @TestComponents(components = {SetterInjectedComponent.class, ComponentType.class})
     void testSetterInjectionWithContext() {
-        final SampleContext sampleContext = new SampleContext("setter");
+        SampleContext sampleContext = new SampleContext("setter");
         this.applicationContext.add("setter", sampleContext);
-        final SetterInjectedComponent component = this.applicationContext.get(SetterInjectedComponent.class);
+        SetterInjectedComponent component = this.applicationContext.get(SetterInjectedComponent.class);
         Assertions.assertNotNull(component);
         Assertions.assertNotNull(component.context());
         Assertions.assertSame(sampleContext, component.context());
     }
 
     @InjectTest
-    void loggerCanBeInjected(final Logger logger) {
+    void loggerCanBeInjected(Logger logger) {
         Assertions.assertNotNull(logger);
     }
 
     @Test
     void testStringProvision() {
-        final ComponentKey<String> key = ComponentKey.of(String.class, "license");
+        ComponentKey<String> key = ComponentKey.of(String.class, "license");
         this.applicationContext.bind(key).singleton("MIT");
-        final String license = this.applicationContext.get(key);
+        String license = this.applicationContext.get(key);
         Assertions.assertEquals("MIT", license);
     }
 
     @Test
     @HartshornTest(includeBasePackages = false, processors = NonProcessableTypeProcessor.class)
-    @TestComponents(NonProcessableType.class)
+    @TestComponents(components = NonProcessableType.class)
     void testNonProcessableComponent() {
-        final NonProcessableType nonProcessableType = this.applicationContext.get(NonProcessableType.class);
+        NonProcessableType nonProcessableType = this.applicationContext.get(NonProcessableType.class);
         Assertions.assertNotNull(nonProcessableType);
         Assertions.assertNull(nonProcessableType.nonNullIfProcessed());
     }
@@ -477,11 +499,11 @@ public class ApplicationContextTests {
         this.applicationContext.bind(String.class).singleton("Hello world!");
         this.applicationContext.bind(String.class).priority(0).singleton("Hello modified world!");
 
-        final String binding = this.applicationContext.get(String.class);
+        String binding = this.applicationContext.get(String.class);
         Assertions.assertEquals("Hello modified world!", binding);
 
         this.applicationContext.bind(String.class).priority(-2).singleton("Hello low priority world!");
-        final String binding2 = this.applicationContext.get(String.class);
+        String binding2 = this.applicationContext.get(String.class);
         Assertions.assertEquals("Hello modified world!", binding2);
     }
 
@@ -490,32 +512,32 @@ public class ApplicationContextTests {
         this.applicationContext.bind(String.class).to(() -> "Hello world!");
         this.applicationContext.bind(String.class).priority(0).to(() -> "Hello modified world!");
 
-        final String binding = this.applicationContext.get(String.class);
+        String binding = this.applicationContext.get(String.class);
         Assertions.assertEquals("Hello modified world!", binding);
 
         this.applicationContext.bind(String.class).priority(-2).to(() -> "Hello low priority world!");
-        final String binding2 = this.applicationContext.get(String.class);
+        String binding2 = this.applicationContext.get(String.class);
         Assertions.assertEquals("Hello modified world!", binding2);
     }
 
     @Test
     void testFailureInComponentConstructorYieldsInitializationException() {
-        final ComponentInitializationException exception = Assertions.assertThrows(ComponentInitializationException.class, () -> this.applicationContext.get(ErrorInConstructorObject.class));
-        final Throwable cause = exception.getCause();
+        ComponentInitializationException exception = Assertions.assertThrows(ComponentInitializationException.class, () -> this.applicationContext.get(ErrorInConstructorObject.class));
+        Throwable cause = exception.getCause();
         Assertions.assertNotNull(cause);
         Assertions.assertTrue(cause instanceof ApplicationException);
 
-        final ApplicationException applicationException = (ApplicationException) cause;
+        ApplicationException applicationException = (ApplicationException) cause;
         Assertions.assertEquals("Failed to create instance of type " + ErrorInConstructorObject.class.getName(), applicationException.getMessage());
     }
 
     @Test
-    @TestComponents(ProviderService.class)
+    @TestComponents(components = ProviderService.class)
     void testProviderService() {
-        final ProviderService service = this.applicationContext.get(ProviderService.class);
+        ProviderService service = this.applicationContext.get(ProviderService.class);
         Assertions.assertNotNull(service);
         Assertions.assertTrue(service instanceof Proxy);
-        final SampleType type = service.get();
+        SampleType type = service.get();
         Assertions.assertNotNull(type);
     }
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
@@ -28,7 +28,7 @@ import org.dockbox.hartshorn.inject.ComponentInitializationException;
 import org.dockbox.hartshorn.inject.ConstructorDiscoveryList;
 import org.dockbox.hartshorn.inject.ConstructorDiscoveryList.DiscoveredComponent;
 import org.dockbox.hartshorn.inject.CyclicComponentException;
-import org.dockbox.hartshorn.inject.CyclingConstructorAnalyzer;
+import org.dockbox.hartshorn.inject.ComponentConstructorResolver;
 import org.dockbox.hartshorn.inject.processing.UseContextInjection;
 import org.dockbox.hartshorn.proxy.Proxy;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
@@ -380,7 +380,7 @@ public class ApplicationContextTests {
     })
     void testCircularDependencyPathCanBeDetermined(Class<?> type, Class<?>... expected) {
         TypeView<?> typeView = this.applicationContext.environment().introspect(type);
-        ConstructorDiscoveryList path = CyclingConstructorAnalyzer.create(applicationContext).findCyclicPath(typeView);
+        ConstructorDiscoveryList path = ComponentConstructorResolver.create(applicationContext).findCyclicPath(typeView);
         
         Assertions.assertNotNull(path);
         List<DiscoveredComponent> discoveredComponents = path.discoveredComponents();
@@ -408,7 +408,7 @@ public class ApplicationContextTests {
     })
     void testCircularDependencyPathOnExplicitBoundTypeCanBeDetermined() {
         TypeView<?> typeView = this.applicationContext.environment().introspect(InterfaceCircularDependencyA.class);
-        ConstructorDiscoveryList path = CyclingConstructorAnalyzer.create(applicationContext).findCyclicPath(typeView);
+        ConstructorDiscoveryList path = ComponentConstructorResolver.create(applicationContext).findCyclicPath(typeView);
         Assertions.assertNotNull(path);
 
         List<DiscoveredComponent> discoveredComponents = path.discoveredComponents();
@@ -425,7 +425,7 @@ public class ApplicationContextTests {
     })
     void testCircularDependencyPathOnImplicitBoundTypeCanBeDetermined() {
         TypeView<?> typeView = this.applicationContext.environment().introspect(InterfaceCircularDependencyA.class);
-        ConstructorDiscoveryList path = CyclingConstructorAnalyzer.create(applicationContext).findCyclicPath(typeView);
+        ConstructorDiscoveryList path = ComponentConstructorResolver.create(applicationContext).findCyclicPath(typeView);
         Assertions.assertNotNull(path);
 
         List<DiscoveredComponent> discoveredComponents = path.discoveredComponents();

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ContextAwareTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ContextAwareTests.java
@@ -33,7 +33,7 @@ public class ContextAwareTests {
     private ApplicationContext applicationContext;
 
     @Test
-    @TestComponents(SampleContextAwareType.class)
+    @TestComponents(components = SampleContextAwareType.class)
     void testApplicationContextIsBound() {
         final ApplicationContext applicationContext = this.applicationContext.get(ApplicationContext.class);
         Assertions.assertNotNull(applicationContext);

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ContextCarrierDelegationTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ContextCarrierDelegationTests.java
@@ -35,7 +35,7 @@ import test.org.dockbox.hartshorn.components.IDefaultContextCarrierService;
 public class ContextCarrierDelegationTests {
 
     @InjectTest
-    @TestComponents(ContextCarrierService.class)
+    @TestComponents(components = ContextCarrierService.class)
     void testContextCarrierDelegation(final ApplicationContext applicationContext) throws NoSuchMethodException {
         final ContextCarrierService service = applicationContext.get(ContextCarrierService.class);
         this.testDelegateAbsent(service);
@@ -43,7 +43,7 @@ public class ContextCarrierDelegationTests {
     }
 
     @InjectTest
-    @TestComponents(IDefaultContextCarrierService.class)
+    @TestComponents(components = IDefaultContextCarrierService.class)
     void testDefaultCarrierDelegation(final ApplicationContext applicationContext) throws NoSuchMethodException {
         final IDefaultContextCarrierService service = applicationContext.get(IDefaultContextCarrierService.class);
         this.testDelegateAbsent(service);
@@ -52,7 +52,7 @@ public class ContextCarrierDelegationTests {
     }
 
     @InjectTest
-    @TestComponents(IContextCarrierService.class)
+    @TestComponents(components = IContextCarrierService.class)
     void testCarrierDelegation(final ApplicationContext applicationContext) throws NoSuchMethodException {
         final IContextCarrierService service = applicationContext.get(IContextCarrierService.class);
 

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/BoundCircularDependencyA.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/BoundCircularDependencyA.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test.org.dockbox.hartshorn.components;
 
 import jakarta.inject.Inject;

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/BoundCircularDependencyA.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/BoundCircularDependencyA.java
@@ -1,0 +1,17 @@
+package test.org.dockbox.hartshorn.components;
+
+import jakarta.inject.Inject;
+
+public class BoundCircularDependencyA implements InterfaceCircularDependencyA {
+
+    private final BoundCircularDependencyB dependencyB;
+
+    @Inject
+    public BoundCircularDependencyA(BoundCircularDependencyB dependencyB) {
+        this.dependencyB = dependencyB;
+    }
+
+    public BoundCircularDependencyB dependencyB() {
+        return dependencyB;
+    }
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/BoundCircularDependencyB.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/BoundCircularDependencyB.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test.org.dockbox.hartshorn.components;
 
 import jakarta.inject.Inject;

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/BoundCircularDependencyB.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/BoundCircularDependencyB.java
@@ -1,0 +1,17 @@
+package test.org.dockbox.hartshorn.components;
+
+import jakarta.inject.Inject;
+
+public class BoundCircularDependencyB implements InterfaceCircularDependencyB {
+
+    private final BoundCircularDependencyA dependencyA;
+
+    @Inject
+    public BoundCircularDependencyB(BoundCircularDependencyA dependencyA) {
+        this.dependencyA = dependencyA;
+    }
+
+    public BoundCircularDependencyA dependencyA() {
+        return dependencyA;
+    }
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/ImplicitCircularDependencyA.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/ImplicitCircularDependencyA.java
@@ -1,0 +1,14 @@
+package test.org.dockbox.hartshorn.components;
+
+public class ImplicitCircularDependencyA implements InterfaceCircularDependencyA {
+
+    private final InterfaceCircularDependencyB dependencyB;
+
+    public ImplicitCircularDependencyA(InterfaceCircularDependencyB dependencyB) {
+        this.dependencyB = dependencyB;
+    }
+
+    public InterfaceCircularDependencyB dependencyB() {
+        return dependencyB;
+    }
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/ImplicitCircularDependencyA.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/ImplicitCircularDependencyA.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test.org.dockbox.hartshorn.components;
 
 public class ImplicitCircularDependencyA implements InterfaceCircularDependencyA {

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/ImplicitCircularDependencyB.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/ImplicitCircularDependencyB.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test.org.dockbox.hartshorn.components;
 
 public class ImplicitCircularDependencyB implements InterfaceCircularDependencyB {

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/ImplicitCircularDependencyB.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/ImplicitCircularDependencyB.java
@@ -1,0 +1,14 @@
+package test.org.dockbox.hartshorn.components;
+
+public class ImplicitCircularDependencyB implements InterfaceCircularDependencyB {
+
+    private final InterfaceCircularDependencyA dependencyA;
+
+    public ImplicitCircularDependencyB(InterfaceCircularDependencyA dependencyA) {
+        this.dependencyA = dependencyA;
+    }
+
+    public InterfaceCircularDependencyA dependencyA() {
+        return dependencyA;
+    }
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/InterfaceCircularDependencyA.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/InterfaceCircularDependencyA.java
@@ -1,0 +1,5 @@
+package test.org.dockbox.hartshorn.components;
+
+public interface InterfaceCircularDependencyA {
+
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/InterfaceCircularDependencyA.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/InterfaceCircularDependencyA.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test.org.dockbox.hartshorn.components;
 
 public interface InterfaceCircularDependencyA {

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/InterfaceCircularDependencyB.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/InterfaceCircularDependencyB.java
@@ -1,0 +1,5 @@
+package test.org.dockbox.hartshorn.components;
+
+public interface InterfaceCircularDependencyB {
+
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/InterfaceCircularDependencyB.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/InterfaceCircularDependencyB.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test.org.dockbox.hartshorn.components;
 
 public interface InterfaceCircularDependencyB {

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/SampleImplementation.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/SampleImplementation.java
@@ -16,9 +16,14 @@
 
 package test.org.dockbox.hartshorn.components;
 
+import org.dockbox.hartshorn.application.Hartshorn;
+
 public class SampleImplementation implements SampleInterface {
+
+    public static final String NAME = Hartshorn.PROJECT_NAME;
+
     @Override
     public String name() {
-        return "Hartshorn";
+        return NAME;
     }
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/contextual/StaticBindsTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/components/contextual/StaticBindsTests.java
@@ -76,7 +76,7 @@ public class StaticBindsTests {
     }
 
     @Test
-    @TestComponents(StaticAwareComponent.class)
+    @TestComponents(components = StaticAwareComponent.class)
     void testComponentInjectionWithoutExplicitCollection() {
         final StaticComponentCollector beanContext = this.applicationContext.first(StaticComponentContext.CONTEXT_KEY).get();
         beanContext.register("Foo", String.class, "names");
@@ -92,7 +92,7 @@ public class StaticBindsTests {
     }
 
     @Test
-    @TestComponents(StaticAwareComponent.class)
+    @TestComponents(components = StaticAwareComponent.class)
     void testComponentInjectionWithExplicitCollection() {
         final StaticComponentContext staticComponentContext = this.applicationContext.first(StaticComponentContext.CONTEXT_KEY).get();
         staticComponentContext.register(1, Integer.class, "ages");
@@ -109,7 +109,7 @@ public class StaticBindsTests {
     }
 
     @InjectTest
-    @TestComponents(StaticComponentService.class)
+    @TestComponents(components = StaticComponentService.class)
     void testApplicationHasBeanContext(final ApplicationContext applicationContext) {
         final Option<StaticComponentContext> beanContext = applicationContext.first(StaticComponentContext.CONTEXT_KEY);
         Assertions.assertTrue(beanContext.present());
@@ -119,7 +119,7 @@ public class StaticBindsTests {
     }
 
     @InjectTest
-    @TestComponents(StaticComponentService.class)
+    @TestComponents(components = StaticComponentService.class)
     void testBeansAreCollected(@Context final StaticComponentContext staticComponentContext) {
         final StaticComponentProvider staticComponentProvider = staticComponentContext.provider();
         final List<StaticComponent> staticComponents = staticComponentProvider.all(StaticComponent.class);
@@ -136,7 +136,7 @@ public class StaticBindsTests {
     }
 
     @InjectTest
-    @TestComponents({ StaticComponentService.class, TestStaticComponentObserver.class })
+    @TestComponents(components = { StaticComponentService.class, TestStaticComponentObserver.class })
     void testBeansAreObserved(final TestStaticComponentObserver observer) {
         final List<StaticComponent> beans = observer.components();
         Assertions.assertEquals(3, beans.size());

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/conditions/ConditionTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/conditions/ConditionTests.java
@@ -16,7 +16,6 @@
 
 package test.org.dockbox.hartshorn.conditions;
 
-import org.dockbox.hartshorn.application.ApplicationBuilder;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.condition.ActivatorCondition;
@@ -48,7 +47,7 @@ import java.util.stream.Stream;
 import jakarta.inject.Inject;
 
 @HartshornTest(includeBasePackages = false)
-@TestComponents(ConditionalProviders.class)
+@TestComponents(components = ConditionalProviders.class)
 @TestProperties({
         "--property.c=o",
         "--property.d=d",
@@ -88,7 +87,7 @@ public class ConditionTests {
 
     @ParameterizedTest
     @MethodSource("properties")
-    @TestComponents(ConditionalProviders.class)
+    @TestComponents(components = ConditionalProviders.class)
     void testPropertyConditions(final String name, final boolean present) {
         final ComponentKey<String> key = ComponentKey.builder(String.class).name(name).build();
         final BindingHierarchy<String> hierarchy = this.applicationContext.hierarchy(key);

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/ContextConfiguringComponentProcessorTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/ContextConfiguringComponentProcessorTests.java
@@ -40,7 +40,7 @@ public class ContextConfiguringComponentProcessorTests {
     }
 
     @InjectTest
-    @TestComponents(EmptyComponent.class)
+    @TestComponents(components = EmptyComponent.class)
     void testNonContextComponentIsProcessed(final ApplicationContext applicationContext) {
         final EmptyComponent emptyComponent = applicationContext.get(EmptyComponent.class);
 
@@ -54,7 +54,7 @@ public class ContextConfiguringComponentProcessorTests {
     }
 
     @InjectTest
-    @TestComponents(ContextComponent.class)
+    @TestComponents(components = ContextComponent.class)
     void testContextComponentIsProcessed(final ApplicationContext applicationContext) {
         final ContextComponent contextComponent = applicationContext.get(ContextComponent.class);
 

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scan/ActivatorScanningTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scan/ActivatorScanningTests.java
@@ -47,7 +47,7 @@ public class ActivatorScanningTests {
     }
 
     @InjectTest
-    @TestComponents(DemoProvider.class)
+    @TestComponents(components = DemoProvider.class)
     void testBindingsFromActivatorPrefixArePresent(final ApplicationContext applicationContext) {
         final Demo demo = applicationContext.get(Demo.class);
         Assertions.assertNotNull(demo);
@@ -56,7 +56,7 @@ public class ActivatorScanningTests {
     }
 
     @InjectTest
-    @TestComponents(DemoService.class)
+    @TestComponents(components = DemoService.class)
     void testServicesFromActivatorPrefixArePresent(final ApplicationContext applicationContext) {
         final DemoService demoService = applicationContext.get(DemoService.class);
         Assertions.assertNotNull(demoService);

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeBindingTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeBindingTests.java
@@ -78,7 +78,7 @@ public class ScopeBindingTests {
     }
 
     @Test
-    @TestComponents(ScopedBindingProvider.class)
+    @TestComponents(components = ScopedBindingProvider.class)
     void name() {
         final String applicationScope = this.applicationContext.get(String.class);
         final String scopedValue = this.applicationContext.get(ComponentKey.builder(String.class).scope(new SampleScope()).build());

--- a/hartshorn-i18n/src/test/java/test/org/dockbox/hartshorn/i18n/MessageTemplateServiceTests.java
+++ b/hartshorn-i18n/src/test/java/test/org/dockbox/hartshorn/i18n/MessageTemplateServiceTests.java
@@ -159,7 +159,7 @@ public class MessageTemplateServiceTests {
     }
 
     @InjectTest
-    @TestComponents(TranslationProviderService.class)
+    @TestComponents(components = TranslationProviderService.class)
     void testTranslationProvidersGetRegistered(final ApplicationContext applicationContext) {
         final TranslationService translationService = applicationContext.get(TranslationService.class);
         final Option<Message> message = translationService.get("lang.name");

--- a/hartshorn-i18n/src/test/java/test/org/dockbox/hartshorn/i18n/TranslationInjectModifierTests.java
+++ b/hartshorn-i18n/src/test/java/test/org/dockbox/hartshorn/i18n/TranslationInjectModifierTests.java
@@ -34,7 +34,7 @@ public class TranslationInjectModifierTests {
     private ApplicationContext applicationContext;
 
     @Test
-    @TestComponents(ITestResources.class)
+    @TestComponents(components = ITestResources.class)
     public void testResourceServiceIsProxied() {
         final ITestResources resources = this.applicationContext.get(ITestResources.class);
         final boolean proxy = this.applicationContext.environment().isProxy(resources);
@@ -42,7 +42,7 @@ public class TranslationInjectModifierTests {
     }
 
     @Test
-    @TestComponents(ITestResources.class)
+    @TestComponents(components = ITestResources.class)
     public void testResourceServiceReturnsValidResourceKey() {
         final ITestResources resources = this.applicationContext.get(ITestResources.class);
         final Message testEntry = resources.testEntry();
@@ -52,7 +52,7 @@ public class TranslationInjectModifierTests {
     }
 
     @Test
-    @TestComponents(ITestResources.class)
+    @TestComponents(components = ITestResources.class)
     public void testResourceServiceReturnsValidResourceValue() {
         final ITestResources resources = this.applicationContext.get(ITestResources.class);
         final Message testEntry = resources.testEntry();
@@ -62,7 +62,7 @@ public class TranslationInjectModifierTests {
     }
 
     @Test
-    @TestComponents(ITestResources.class)
+    @TestComponents(components = ITestResources.class)
     public void testResourceServiceFormatsParamResource() {
         final ITestResources resources = this.applicationContext.get(ITestResources.class);
         final Message testEntry = resources.parameterTestEntry("world");
@@ -72,7 +72,7 @@ public class TranslationInjectModifierTests {
     }
 
     @Test
-    @TestComponents(AbstractTestResources.class)
+    @TestComponents(components = AbstractTestResources.class)
     void testAbstractServiceAbstractMethodIsProxied() {
         final AbstractTestResources resources = this.applicationContext.get(AbstractTestResources.class);
         final Message testEntry = resources.abstractEntry();
@@ -82,7 +82,7 @@ public class TranslationInjectModifierTests {
     }
 
     @Test
-    @TestComponents(AbstractTestResources.class)
+    @TestComponents(components = AbstractTestResources.class)
     void testAbstractServiceConcreteMethodIsProxied() {
         final AbstractTestResources resources = this.applicationContext.get(AbstractTestResources.class);
         final Message testEntry = resources.concreteEntry();
@@ -92,7 +92,7 @@ public class TranslationInjectModifierTests {
     }
 
     @Test
-    @TestComponents(TestResources.class)
+    @TestComponents(components = TestResources.class)
     void testConcreteServiceMethodIsProxied() {
         final TestResources resources = this.applicationContext.get(TestResources.class);
         final Message testEntry = resources.testEntry();

--- a/hartshorn-proxy/hartshorn-proxy-cglib/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyConstructorFunction.java
+++ b/hartshorn-proxy/hartshorn-proxy-cglib/src/main/java/org/dockbox/hartshorn/proxy/cglib/CglibProxyConstructorFunction.java
@@ -16,11 +16,11 @@
 
 package org.dockbox.hartshorn.proxy.cglib;
 
-import net.sf.cglib.proxy.Enhancer;
+import java.lang.reflect.Constructor;
 
 import org.dockbox.hartshorn.proxy.ProxyConstructorFunction;
 
-import java.lang.reflect.Constructor;
+import net.sf.cglib.proxy.Enhancer;
 
 /**
  * @deprecated CGLib is not actively maintained, and commonly causes issues with Java 9+.
@@ -45,7 +45,7 @@ public class CglibProxyConstructorFunction<T> implements ProxyConstructorFunctio
     }
 
     @Override
-    public T create(final Constructor<T> constructor, final Object[] args) {
+    public T create(final Constructor<? extends T> constructor, final Object[] args) {
         final Class<?>[] parameterTypes = constructor.getParameterTypes();
         final Object instance = this.enhancer.create(parameterTypes, args);
         return this.type.cast(instance);

--- a/hartshorn-proxy/hartshorn-proxy-javassist/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistProxyConstructorFunction.java
+++ b/hartshorn-proxy/hartshorn-proxy-javassist/src/main/java/org/dockbox/hartshorn/proxy/javassist/JavassistProxyConstructorFunction.java
@@ -16,11 +16,11 @@
 
 package org.dockbox.hartshorn.proxy.javassist;
 
-import org.dockbox.hartshorn.proxy.ProxyConstructorFunction;
-import org.dockbox.hartshorn.util.ApplicationException;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+
+import org.dockbox.hartshorn.proxy.ProxyConstructorFunction;
+import org.dockbox.hartshorn.util.ApplicationException;
 
 import javassist.util.proxy.MethodHandler;
 import javassist.util.proxy.ProxyFactory;
@@ -47,7 +47,7 @@ public class JavassistProxyConstructorFunction<T> implements ProxyConstructorFun
     }
 
     @Override
-    public T create(final Constructor<T> constructor, final Object[] args) throws ApplicationException {
+    public T create(final Constructor<? extends T> constructor, final Object[] args) throws ApplicationException {
         try {
             final Class<?>[] parameterTypes = constructor.getParameterTypes();
             return this.type.cast(this.factory.create(parameterTypes, args, this.methodHandler));

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/DefaultProxyFactory.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/DefaultProxyFactory.java
@@ -16,6 +16,11 @@
 
 package org.dockbox.hartshorn.proxy;
 
+import java.lang.reflect.Constructor;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
 import org.dockbox.hartshorn.proxy.advice.registry.AdvisorRegistry;
 import org.dockbox.hartshorn.proxy.advice.registry.ConfigurationAdvisorRegistry;
 import org.dockbox.hartshorn.proxy.advice.registry.StateAwareAdvisorRegistry;
@@ -28,11 +33,6 @@ import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Attempt;
-
-import java.lang.reflect.Constructor;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 
 /**
  * The default implementation of {@link ProxyFactory}. This implementation is state-aware, as is suggested by its
@@ -142,15 +142,15 @@ public abstract class DefaultProxyFactory<T> implements StateAwareProxyFactory<T
     protected abstract Attempt<T, Throwable> createNewProxy() throws ApplicationException;
 
     @Override
-    public final Attempt<T, Throwable> proxy(final Constructor<T> constructor, final Object[] args) throws ApplicationException {
+    public final Attempt<T, Throwable> proxy(final Constructor<? extends T> constructor, final Object[] args) throws ApplicationException {
         this.validateConstraints();
         return this.createNewProxy(constructor, args);
     }
 
-    protected abstract Attempt<T, Throwable> createNewProxy(Constructor<T> constructor, Object[] args) throws ApplicationException;
+    protected abstract Attempt<T, Throwable> createNewProxy(Constructor<? extends T> constructor, Object[] args) throws ApplicationException;
 
     @Override
-    public final Attempt<T, Throwable> proxy(final ConstructorView<T> constructor, final Object[] args) throws ApplicationException {
+    public final Attempt<T, Throwable> proxy(final ConstructorView<? extends T> constructor, final Object[] args) throws ApplicationException {
         if (constructor.constructor().present()) {
             return this.proxy(constructor.constructor().get(), args);
         }

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/JDKInterfaceProxyFactory.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/JDKInterfaceProxyFactory.java
@@ -16,6 +16,9 @@
 
 package org.dockbox.hartshorn.proxy;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+
 import org.dockbox.hartshorn.proxy.advice.intercept.MethodInvokable;
 import org.dockbox.hartshorn.proxy.advice.intercept.ProxyAdvisorMethodInterceptor;
 import org.dockbox.hartshorn.proxy.advice.intercept.ProxyMethodInterceptor;
@@ -26,9 +29,6 @@ import org.dockbox.hartshorn.util.introspect.view.FieldView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Attempt;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationHandler;
 
 /**
  * A {@link ProxyFactory} implementation which uses the JDK {@link java.lang.reflect.Proxy} class to create proxies for
@@ -55,7 +55,7 @@ public abstract class JDKInterfaceProxyFactory<T> extends DefaultProxyFactory<T>
     }
 
     @Override
-    public Attempt<T, Throwable> createNewProxy(final Constructor<T> constructor, final Object[] args) throws ApplicationException {
+    public Attempt<T, Throwable> createNewProxy(final Constructor<? extends T> constructor, final Object[] args) throws ApplicationException {
         if (args.length != constructor.getParameterCount()) {
             throw new ApplicationException("Invalid number of arguments for constructor " + constructor);
         }
@@ -127,7 +127,7 @@ public abstract class JDKInterfaceProxyFactory<T> extends DefaultProxyFactory<T>
      * @return The proxy
      * @throws ApplicationException When the proxy cannot be created
      */
-    protected Attempt<T, Throwable> concreteOrAbstractProxy(final ProxyMethodInterceptor<T> interceptor, final Constructor<T> constructor, final Object[] args) throws ApplicationException {
+    protected Attempt<T, Throwable> concreteOrAbstractProxy(final ProxyMethodInterceptor<T> interceptor, final Constructor<? extends T> constructor, final Object[] args) throws ApplicationException {
         return this.createClassProxy(interceptor, enhancer -> enhancer.create(constructor, args));
     }
 

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyConstructorFunction.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyConstructorFunction.java
@@ -16,9 +16,9 @@
 
 package org.dockbox.hartshorn.proxy;
 
-import org.dockbox.hartshorn.util.ApplicationException;
-
 import java.lang.reflect.Constructor;
+
+import org.dockbox.hartshorn.util.ApplicationException;
 
 /**
  * A function that creates a proxy instance. This is used to allow for custom proxy implementations.
@@ -43,5 +43,5 @@ public interface ProxyConstructorFunction<T> {
      * @return The created proxy instance
      * @throws ApplicationException If the proxy instance could not be created
      */
-    T create(Constructor<T> constructor, Object[] args) throws ApplicationException;
+    T create(Constructor<? extends T> constructor, Object[] args) throws ApplicationException;
 }

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyFactory.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyFactory.java
@@ -16,16 +16,16 @@
 
 package org.dockbox.hartshorn.proxy;
 
-import org.dockbox.hartshorn.proxy.advice.registry.AdvisorRegistry;
-import org.dockbox.hartshorn.proxy.advice.intercept.MethodInterceptor;
-import org.dockbox.hartshorn.proxy.advice.intercept.MethodInterceptorContext;
-import org.dockbox.hartshorn.util.ApplicationException;
-import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
-import org.dockbox.hartshorn.util.option.Attempt;
-
 import java.lang.reflect.Constructor;
 import java.util.Set;
 import java.util.function.Consumer;
+
+import org.dockbox.hartshorn.proxy.advice.intercept.MethodInterceptor;
+import org.dockbox.hartshorn.proxy.advice.intercept.MethodInterceptorContext;
+import org.dockbox.hartshorn.proxy.advice.registry.AdvisorRegistry;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
+import org.dockbox.hartshorn.util.option.Attempt;
 
 /**
  * The entrypoint for creating proxy objects. This class is responsible for creating proxy objects for
@@ -245,9 +245,9 @@ public interface ProxyFactory<T> {
      * @return A proxy instance
      * @throws ApplicationException If the proxy could not be created
      */
-    Attempt<T, Throwable> proxy(ConstructorView<T> constructor, Object[] args) throws ApplicationException;
+    Attempt<T, Throwable> proxy(ConstructorView<? extends T> constructor, Object[] args) throws ApplicationException;
 
-    Attempt<T, Throwable> proxy(Constructor<T> constructor, Object[] args) throws ApplicationException;
+    Attempt<T, Throwable> proxy(Constructor<? extends T> constructor, Object[] args) throws ApplicationException;
 
     /**
      * Gets the type of the proxy. This will return the original type, and not a proxy type.

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/TestBinding.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/TestBinding.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.testsuite;
 
 import java.lang.annotation.Retention;

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/TestBinding.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/TestBinding.java
@@ -1,0 +1,10 @@
+package org.dockbox.hartshorn.testsuite;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestBinding {
+    Class<?> type();
+    Class<?> implementation();
+}

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/TestComponents.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/TestComponents.java
@@ -26,5 +26,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface TestComponents {
-    Class<?>[] value();
+    Class<?>[] components() default {};
+    TestBinding[] bindings() default {};
 }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/CollectionUtilities.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/CollectionUtilities.java
@@ -114,4 +114,8 @@ public final class CollectionUtilities {
             collection.forEach(consumer);
         }
     }
+
+    public static <T> List<T> distinct(List<T> collection) {
+        return collection.stream().distinct().toList();
+    }
 }


### PR DESCRIPTION
# Description
The `CyclingConstructorAnalyzer` checks for available constructors without verifying that the type is concrete, or even the final type which will be bound. For example, having an interface as a parameter, you'd get zero constructors even if the active binding for that interface has multiple.

https://github.com/Dockbox-OSS/Hartshorn/blob/6b532c535ea5b0d875289c10226f1c736b5a4390/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/CyclingConstructorAnalyzer.java#L68-L70

These changes allow us to use the `ApplicationContext` to access hierarchies to verify the prioritized binding, so we can properly get the optimal constructor and detect cyclic dependencies.

Note that not all providers are type aware, this has been made an element of the provider API, where a provider can be either a `NonTypeAwareProvider` or `TypeAwareProvider`. As long as the highest priority `Provider` is a `TypeAwareProvider`, we can get the required information for this binding.

Fixes #987

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)
- [x] Refactor (code changes that do not affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
