### PR TITLE
#981 Update project to Java 21, #982 Update CI to Java 21

### DIFF
--- a/.github/workflows/build_modules.yml
+++ b/.github/workflows/build_modules.yml
@@ -4,31 +4,14 @@ on: pull_request
 
 jobs:
   buildSource:
-    name: Build all (source JDK)
+    name: Build all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up source JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - name: "Build (source JDK)"
-        run: mvn clean install -DskipTests -P ci,all
-  buildTarget:
-    needs: [buildSource]
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [18, 19]
-    name: Build all (target JDK ${{ matrix.java }})
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: temurin
-      - name: "Build (Java ${{ matrix.java }})"
         run: mvn clean install -DskipTests -P ci,all

--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - name: Prepare for dependency check
         run: mvn clean install -DskipTests -P ci,all

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - name: Check license headers
         run: mvn license:check -P ci,all

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up source JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - name: Run tests
         id: test
@@ -22,34 +22,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-    name: Unit tests (JDK 17, ${{ matrix.os }})
+    name: Unit tests (JDK 21, ${{ matrix.os }})
     runs-on: "${{ matrix.os }}"
     steps:
       - uses: actions/checkout@v3
       - name: Set up source JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - name: "Unit testing (OS: ${{ matrix.os }}, source JDK)"
-        run: mvn clean test -P ci,all
-        shell: bash
-  testTarget:
-    needs: [coverage]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [18, 19]
-    name: Unit tests (JDK ${{ matrix.java }}, ${{ matrix.os }})
-    runs-on: "${{ matrix.os }}"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: temurin
-      - name: "Unit testing (OS: ${{ matrix.os }}, Java: ${{ matrix.java }})"
         run: mvn clean test -P ci,all
         shell: bash

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <p align="center"><img alt="Hartshorn" src="./hartshorn-assembly/images/hartshorn-icon.png" height="125" /></p>
 <h1 align="center">Hartshorn Framework</h1>
 <p align="center">
-<img src="https://img.shields.io/badge/JDK%20source-17-438EAA?style=for-the-badge">
-<img src="https://img.shields.io/badge/JDK%20target-19-438EAA?style=for-the-badge">
+<img src="https://img.shields.io/badge/JDK-21-438EAA?style=for-the-badge">
 <img src="https://img.shields.io/github/v/release/Dockbox-OSS/Hartshorn?style=for-the-badge&color=438EAA">
 </p>
 
@@ -92,7 +91,7 @@ Once you've taken your first steps with Hartshorn, it's essential to expand your
 If you want to build Hartshorn yourself, either to access pre-release versions or to customize the framework, the guide below explains how to build usable JAR artifacts.
 
 > [!IMPORTANT]
-> Note that you will need a Java installation with JDK 17 or a more recent version for all platforms.
+> Note that you will need a Java installation with JDK 21 or a more recent version for all platforms.
 
 Hartshorn uses Maven to automate builds, performing several steps before and after a build has completed. To build all Hartshorn modules at once, run `mvn clean install` in the base directory. This will build all modules and run all tests. If you want to skip tests, you can use the `-DskipTests` flag.
 

--- a/hartshorn-assembly/parent/pom.parent.xml
+++ b/hartshorn-assembly/parent/pom.parent.xml
@@ -18,9 +18,9 @@
 
     <properties>
         <!-- Keep in sync with hartshorn-bom -->
-        <groovy.version>4.0.14</groovy.version>
+        <groovy.version>4.0.15</groovy.version>
         <kotlin.version>1.9.10</kotlin.version>
-        <scala.version>3.3.0</scala.version>
+        <scala.version>3.3.1</scala.version>
     </properties>
 
     <dependencyManagement>
@@ -88,7 +88,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -119,7 +119,7 @@
                 <version>3.11.0</version>
                 <configuration>
                     <release>${java.version}</release>
-                    <fork>true</fork>
+                    <fork>false</fork>
                     <encoding>UTF-8</encoding>
                     <compilerArgs>
                         <arg>-parameters</arg>

--- a/hartshorn-bom/pom.xml
+++ b/hartshorn-bom/pom.xml
@@ -19,24 +19,24 @@
 
     <properties>
         <!-- Language support, keep in sync with module parent -->
-        <groovy.version>4.0.14</groovy.version>
+        <groovy.version>4.0.15</groovy.version>
         <kotlin.version>1.9.10</kotlin.version>
-        <slf4j.version>2.0.7</slf4j.version>
+        <slf4j.version>2.0.9</slf4j.version>
 
         <!-- Versions in alphabetical order -->
         <auto-service.version>1.1.1</auto-service.version>
         <compile-testing.version>0.21.0</compile-testing.version>
         <cglib.version>3.3.0</cglib.version>
-        <checker.version>3.37.0</checker.version>
+        <checker.version>3.39.0</checker.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <jackson.version>2.15.2</jackson.version>
+        <jackson.version>2.15.3</jackson.version>
         <jakarta.annotations.version>2.1.1</jakarta.annotations.version>
         <jakarta.inject.version>2.0.1</jakarta.inject.version>
         <javassist.version>3.29.2-GA</javassist.version>
         <junit.version>5.10.0</junit.version>
         <logback.version>1.4.11</logback.version>
-        <mockito.version>5.2.0</mockito.version>
-        <scala.version>3.3.0</scala.version>
+        <mockito.version>5.6.0</mockito.version>
+        <scala.version>3.3.1</scala.version>
     </properties>
 
     <dependencyManagement>
@@ -156,7 +156,7 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
+                <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/hartshorn-discovery/src/main/java/org/dockbox/hartshorn/discovery/DiscoveryServiceProcessor.java
+++ b/hartshorn-discovery/src/main/java/org/dockbox/hartshorn/discovery/DiscoveryServiceProcessor.java
@@ -16,9 +16,7 @@
 
 package org.dockbox.hartshorn.discovery;
 
-import java.io.IOException;
-import java.io.Writer;
-import java.util.Set;
+import com.google.auto.service.AutoService;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Processor;
@@ -32,11 +30,13 @@ import javax.lang.model.type.MirroredTypeException;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
-
-import com.google.auto.service.AutoService;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Objects;
+import java.util.Set;
 
 @SupportedAnnotationTypes("org.dockbox.hartshorn.discovery.ServiceLoader")
-@SupportedSourceVersion(SourceVersion.RELEASE_17)
+@SupportedSourceVersion(SourceVersion.RELEASE_21)
 @AutoService(Processor.class)
 @SuppressWarnings("UseOfSystemOutOrSystemErr")
 public class DiscoveryServiceProcessor extends AbstractProcessor {
@@ -54,7 +54,7 @@ public class DiscoveryServiceProcessor extends AbstractProcessor {
             final TypeMirror implementationType = element.asType();
             final TypeMirror targetType = getTargetType(annotation);
 
-            final FileObject resource = this.createResource(targetType.toString());
+            final FileObject resource = this.createResource(Objects.requireNonNull(targetType).toString());
             if (resource == null) {
                 continue;
             }

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <hartshorn.version>0.5.0</hartshorn.version>
         <checkstyle.skip>false</checkstyle.skip>


### PR DESCRIPTION
# Description
Verifies compatibility and updates the project to Java 21. As this is the next LTS version, the minimum supported version for Hartshorn will be Java 21 going forward, until the next Java LTS release.

Fixes #981, #982

## Type of change
- [x] Chore (changes to the build process or auxiliary tools)

# How Has This Been Tested?
- [x] Unit testing
- [x] Integration testing
- [x] Other: CI compatibility

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
