### PR TITLE
#1004 Decode URLs obtained from URLClassLoader before resolving to files

### DIFF
--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
@@ -22,6 +22,8 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -108,7 +110,11 @@ public final class ClassPathScanner {
         for (URL url : classLoader.getURLs()) {
             if (url.getFile() != null && !url.getFile().isEmpty()) {
 
-                File file = new File(url.getFile());
+                // Physical files can have escaped characters in the URL representation. The simplest form of this is
+                // %20 instead of a space. This is not valid in a URI, so we need to decode the URL to get the correct
+                // file path.
+                String decodedUrl = URLDecoder.decode(url.getFile(), Charset.defaultCharset());
+                File file = new File(decodedUrl);
                 if (file.exists()) {
                     if (file.isDirectory()) {
                         this.processDirectoryResource(handler, classLoader, file);

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
@@ -72,16 +72,25 @@ public final class ClassPathScanner {
 
             try {
                 URL url = file.toURI().toURL();
-                this.classLoaders.add(new URLClassLoader(new URL[] { url }) {
-                    public String toString() {
-                        return super.toString() + " [url=" + url.toExternalForm() + "]";
-                    }
-                });
+                this.addUrlForScanning(url);
             }
             catch (MalformedURLException e) {
                 // Ignore
             }
         }
+        return this;
+    }
+
+    public ClassPathScanner addUrlForScanning(URL url) {
+        return this.addClassLoaderForScanning(new URLClassLoader(new URL[] { url }) {
+            public String toString() {
+                return super.toString() + " [url=" + url.toExternalForm() + "]";
+            }
+        });
+    }
+
+    public ClassPathScanner addClassLoaderForScanning(URLClassLoader classLoader) {
+        this.classLoaders.add(classLoader);
         return this;
     }
 

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/ClassPathScannerTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/ClassPathScannerTests.java
@@ -16,14 +16,16 @@
 
 package test.org.dockbox.hartshorn.introspect;
 
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
 import org.dockbox.hartshorn.util.introspect.scan.classpath.ClassPathScanner;
 import org.dockbox.hartshorn.util.introspect.scan.classpath.ClassPathWalkingException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.HashSet;
-import java.util.Set;
-
 import test.org.dockbox.hartshorn.introspect.types.ScanAnnotation;
 import test.org.dockbox.hartshorn.introspect.types.ScanClass;
 import test.org.dockbox.hartshorn.introspect.types.ScanClass.NonStaticInnerClass;
@@ -53,6 +55,18 @@ public class ClassPathScannerTests {
         Assertions.assertTrue(classes.contains(ScanEnum.class.getCanonicalName()));
         Assertions.assertTrue(classes.contains(ScanInterface.class.getCanonicalName()));
         Assertions.assertTrue(classes.contains(ScanRecord.class.getCanonicalName()));
+    }
+
+    @Test
+    void testCanScanWithEncodedCharacters() throws IOException, ClassPathWalkingException {
+        // Space is encoded as %20 in URLs, though we don't need to encode it here yet.
+        // Note that we use an empty directory here, so scanning will yield no results, but won't throw an exception either.
+        Path dummyFolder = Files.createTempDirectory("dummy folder");
+        dummyFolder.toFile().deleteOnExit();
+        URL url = dummyFolder.toUri().toURL();
+
+        ClassPathScanner scanner = Assertions.assertDoesNotThrow(() -> ClassPathScanner.create().addUrlForScanning(url));
+        scanner.scan(resource -> Assertions.fail("Should not have found any resources"));
     }
 
     private String resourceNameFromCanonicalName(String canonicalName) {


### PR DESCRIPTION
# Description
The ClassPathScanner currently lacks the capability to decode URLs acquired through URLClassLoaders. Consequently, when dealing with paths that contain encoded characters such as %20 for representing spaces, the scanner is unable to resolve them properly. This deficiency in URL decoding leads to a critical problem during the scanning process. This can lead to early failures during application startup.

https://github.com/Dockbox-OSS/Hartshorn/blob/d77839b5e71903feea7bd4d6db40fa6146d93d59/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java#L108-L111

These changes resolve this issue by applying a `URLDecoder` before resolving.

Fixes #1004

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
