### PR TITLE
#1006 Clarify incomplete deprecation notices

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ExceptionHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ExceptionHandler.java
@@ -59,8 +59,10 @@ public interface ExceptionHandler {
      * @param <T> The type of the exception.
      * @throws T The exception to throw.
      * @see <a href="https://blog.jooq.org/throw-checked-exceptions-like-runtime-exceptions-in-java/">Throw checked exceptions like runtime exceptions in Java</a>
+     *
+     * @deprecated Re-throwing checked exceptions as unchecked exceptions is not recommended. This method will be removed in a future release.
      */
-    @Deprecated
+    @Deprecated(since = "0.5.0", forRemoval = true)
     static <T extends Throwable, R> R unchecked(Throwable throwable) throws T {
         throw (T) throwable;
     }

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/advice/intercept/MethodInterceptorContext.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/advice/intercept/MethodInterceptorContext.java
@@ -16,6 +16,8 @@
 
 package org.dockbox.hartshorn.proxy.advice.intercept;
 
+import org.dockbox.hartshorn.proxy.advice.ProxyResultValidator;
+import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 
 import java.util.concurrent.Callable;
@@ -120,7 +122,12 @@ public class MethodInterceptorContext<T, R> {
         return this.result;
     }
 
-    @Deprecated
+    /**
+     * @deprecated interceptor results are automatically validated using the configured {@link ProxyResultValidator}. Use a
+     * {@link ConversionService} to convert the result if necessary, or compare against {@link #method() the active method's}
+     * {@link MethodView#returnType() return type}.
+     */
+    @Deprecated(forRemoval = true, since = "0.5.0")
     public R checkedCast(Object o) {
         if (this.method.returnType().isVoid()) {
             return null;

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/CollectionUtilities.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/CollectionUtilities.java
@@ -55,7 +55,7 @@ public final class CollectionUtilities {
      * @deprecated Use {@link Map#ofEntries(Entry...)} instead
      */
     @SafeVarargs
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "0.5.0")
     public static <K, V> Map<K, V> ofEntries(Entry<? extends K, ? extends V>... entries) {
         if (0 == entries.length) { // implicit null check of entries array
             return new HashMap<>();


### PR DESCRIPTION
# Description
Clarifies deprecations which previously didn't have any notice besides `@Deprecated` annotations.

Fixes #1006

## Type of change
- [x] Other: deprecation notices

# Checklist:
- [x] I have performed a self-review of my own code
- [x] Related issue number is linked in pull request title
