### PR TITLE
#1010 Disable deprecated fields and executables members of Populate in favor of Populate.Type arguments

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Populate.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Populate.java
@@ -20,14 +20,16 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.dockbox.hartshorn.component.ComponentPopulator;
 
 /**
  * Indicates that the values of fields and executables should be automatically populated
  * by {@link org.dockbox.hartshorn.component.ComponentPopulator}s. Note that this annotation
- * is typically not required, as populating is enabled only if fields or executables are
- * explicitly marked as injectable.
+ * is typically not required, however {@link ComponentPopulator}s can decide to either not
+ * populate at all if this annotation is absent, or to populate all targets by default.
  *
- * <p>If the value of {@link #fields()} is {@code true}, all fields will be populated.
+ * <p>Population targets can be specified by using the {@link Populate#value()} attribute. By
+ * default, nothing is populated. All targets are therefore opt-in when using this annotation.
  *
  * @author Guus Lieben
  * @since 0.4.9

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Populate.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Populate.java
@@ -41,21 +41,21 @@ public @interface Populate {
      *
      * @return The types of values that should be populated.
      */
-    Type[] value() default {};
+    Type[] value();
 
     /**
      * @deprecated since 0.5.0, for removal in 0.6.0. Use {@link #value()} instead.
      * @return {@code true} if fields should be populated, {@code false} otherwise.
      */
     @Deprecated(since = "0.5.0", forRemoval = true)
-    boolean fields() default true;
+    boolean fields() default false;
 
     /**
      * @deprecated since 0.5.0, for removal in 0.6.0. Use {@link #value()} instead.
      * @return {@code true} if executables (e.g. methods) should be populated, {@code false} otherwise.
      */
     @Deprecated(since = "0.5.0", forRemoval = true)
-    boolean executables() default true;
+    boolean executables() default false;
 
     /**
      * Types of elements that can be populated. Used as a value for {@link Populate#value()}.

--- a/hartshorn-core/src/testFixtures/java/org/dockbox/hartshorn/testsuite/HartshornTest.java
+++ b/hartshorn-core/src/testFixtures/java/org/dockbox/hartshorn/testsuite/HartshornTest.java
@@ -47,7 +47,7 @@ import jakarta.inject.Inject;
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(HartshornLifecycleExtension.class)
 @Extends(Populate.class)
-@Populate(executables = false)
+@Populate(Populate.Type.FIELDS)
 public @interface HartshornTest {
 
     /**


### PR DESCRIPTION
### Type of Change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

### Description
In #992 we introduced `Populate.Type` to indicate which targets should be included in population phases. `#fields` and `#executables` were marked for deprecation at the same time. However, these properties have not been disabled by default, thus leaving them enabled by default. As a result, `#value` does not take top priority, which can be confusing.

The following changes were made:
* Require `#value`, removing its default `{}` value
* Change `#fields` and `#executables` to be disabled by default

### How the Changes Have Been Tested
Existing tests cover expected behavior.

### Checklist
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] I have added documentation that describes my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1010
