### PR TITLE
#1012 Include all root directories when scanning virtual filesystems

### DIFF
--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
@@ -143,7 +143,9 @@ public final class ClassPathScanner {
             throws ClassPathWalkingException {
         try {
             FileSystem fileSystem = FileSystems.newFileSystem(Paths.get(url.toURI()), (ClassLoader) null);
-            Files.walkFileTree(fileSystem.getRootDirectories().iterator().next(), new JarFileWalker(this, handler, classLoader));
+            for(Path rootDirectory : fileSystem.getRootDirectories()) {
+                Files.walkFileTree(rootDirectory, new JarFileWalker(this, handler, classLoader));
+            }
         }
         catch (IOException | URISyntaxException e) {
             throw new ClassPathWalkingException("Error while scanning jar file " + jarFile, e);


### PR DESCRIPTION
### Type of Change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

### Description
Ensures all root directories are included when scanning filesystems discovered through URI scanning.

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1012