### PR TITLE
#1017 Scope keys to replace plain types

### DIFF
--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/properties/StandardPropertyHolder.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/properties/StandardPropertyHolder.java
@@ -16,15 +16,6 @@
 
 package org.dockbox.hartshorn.config.properties;
 
-import org.dockbox.hartshorn.application.ApplicationPropertyHolder;
-import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.config.FileFormats;
-import org.dockbox.hartshorn.config.ObjectMapper;
-import org.dockbox.hartshorn.util.GenericType;
-import org.dockbox.hartshorn.util.StringUtilities;
-import org.dockbox.hartshorn.util.TypeUtils;
-import org.dockbox.hartshorn.util.option.Option;
-
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Collection;
@@ -34,6 +25,15 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.function.Function;
+
+import org.dockbox.hartshorn.application.ApplicationPropertyHolder;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.config.FileFormats;
+import org.dockbox.hartshorn.config.ObjectMapper;
+import org.dockbox.hartshorn.util.GenericType;
+import org.dockbox.hartshorn.util.StringUtilities;
+import org.dockbox.hartshorn.util.TypeUtils;
+import org.dockbox.hartshorn.util.option.Option;
 
 import jakarta.inject.Inject;
 
@@ -113,9 +113,9 @@ public class StandardPropertyHolder implements PropertyHolder {
             String part = split[i];
             if (i == split.length - 1) {
                 Object origin = current.get(part);
-                if (origin instanceof Map && patch instanceof Map) {
-                    Map<String, Object> adjustedOrigin = TypeUtils.adjustWildcards(origin, Map.class);
-                    Map<String, Object> adjustedPatch = TypeUtils.adjustWildcards(patch, Map.class);
+                if (origin instanceof Map<?, ?> originMap && patch instanceof Map<?, ?> patchMap) {
+                    Map<String, Object> adjustedOrigin = TypeUtils.adjustWildcards(originMap, Map.class);
+                    Map<String, Object> adjustedPatch = TypeUtils.adjustWildcards(patchMap, Map.class);
                     this.patchConfigurationMap(adjustedOrigin, adjustedPatch);
                     return;
                 }
@@ -128,7 +128,7 @@ public class StandardPropertyHolder implements PropertyHolder {
             if (!(current.get(part) instanceof Map)) {
                 current.put(part, this.createConfigurationMap());
             }
-            current = TypeUtils.adjustWildcards(current.get(part), Map.class);
+            current = TypeUtils.adjustWildcards((Map<?, ?>) current.get(part), Map.class);
         }
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
@@ -23,6 +23,7 @@ import org.dockbox.hartshorn.application.ExceptionHandler;
 import org.dockbox.hartshorn.application.environment.ApplicationEnvironment;
 import org.dockbox.hartshorn.component.HierarchicalComponentProvider;
 import org.dockbox.hartshorn.component.Scope;
+import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentProcessor;
 import org.dockbox.hartshorn.context.ApplicationAwareContext;
@@ -58,6 +59,8 @@ public interface ApplicationContext extends
         ActivatorHolder,
         Scope,
         AutoCloseable {
+
+    ScopeKey<ApplicationContext> SCOPE_KEY = ScopeKey.of(ApplicationContext.class);
 
     /**
      * Registers a component processor with the application context. The processor will be invoked when
@@ -95,8 +98,8 @@ public interface ApplicationContext extends
     boolean isClosed();
 
     @Override
-    default Class<? extends Scope> installableScopeType() {
-        return ApplicationContext.class;
+    default ScopeKey<ApplicationContext> installableScopeType() {
+        return SCOPE_KEY;
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.application.ApplicationBuilder;
 import org.dockbox.hartshorn.application.ApplicationPropertyHolder;
 import org.dockbox.hartshorn.application.ExceptionHandler;
 import org.dockbox.hartshorn.application.environment.ApplicationEnvironment;
+import org.dockbox.hartshorn.component.DirectScopeKey;
 import org.dockbox.hartshorn.component.HierarchicalComponentProvider;
 import org.dockbox.hartshorn.component.Scope;
 import org.dockbox.hartshorn.component.ScopeKey;
@@ -60,11 +61,15 @@ public interface ApplicationContext extends
         Scope,
         AutoCloseable {
 
-    ScopeKey<ApplicationContext> SCOPE_KEY = ScopeKey.of(ApplicationContext.class);
+    /**
+     * The scope key for the application context. This key is used to register the application context
+     * as a global scope.
+     */
+    ScopeKey<ApplicationContext> SCOPE_KEY = DirectScopeKey.of(ApplicationContext.class);
 
     /**
      * Registers a component processor with the application context. The processor will be invoked when
-     * a component is added to the application context.
+     * a component is loaded by the application context.
      *
      * @param processor The component processor to register.
      * @see ComponentProcessor
@@ -73,6 +78,14 @@ public interface ApplicationContext extends
      */
     void add(ComponentProcessor processor);
 
+    /**
+     * Registers a lazy-loaded component post-processor with the application context. The processor will be instantiated
+     * when it is first used. The processor will be invoked when a component is loaded by the application context.
+     *
+     * @param processor The component processor to register.
+     * @see ComponentProcessor
+     * @see org.dockbox.hartshorn.component.processing.ComponentPostProcessor
+     */
     void add(Class<? extends ComponentPostProcessor> processor);
 
     /**

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
@@ -65,7 +65,7 @@ public interface ApplicationContext extends
      * The scope key for the application context. This key is used to register the application context
      * as a global scope.
      */
-    ScopeKey<ApplicationContext> SCOPE_KEY = DirectScopeKey.of(ApplicationContext.class);
+    ScopeKey SCOPE_KEY = DirectScopeKey.of(ApplicationContext.class);
 
     /**
      * Registers a component processor with the application context. The processor will be invoked when
@@ -111,7 +111,7 @@ public interface ApplicationContext extends
     boolean isClosed();
 
     @Override
-    default ScopeKey<ApplicationContext> installableScopeType() {
+    default ScopeKey installableScopeType() {
         return SCOPE_KEY;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ContextClosedException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ContextClosedException.java
@@ -19,7 +19,17 @@ package org.dockbox.hartshorn.application.context;
 import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.util.ApplicationRuntimeException;
 
+/**
+ * An exception that is thrown when an attempt is made to close a context that is already closed.
+ *
+ * @see ApplicationContext#close()
+ *
+ * @since 0.4.12
+ *
+ * @author Guus Lieben
+ */
 public class ContextClosedException extends ApplicationRuntimeException {
+
     public ContextClosedException(Class<? extends Context> type) {
         super("Context (" + type.getSimpleName() + ") is already closed.");
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationBindingFunction.java
@@ -49,7 +49,7 @@ public class DelegatingApplicationBindingFunction<T> implements BindingFunction<
     }
 
     @Override
-    public BindingFunction<T> installTo(ScopeKey<?> scope) throws IllegalScopeException {
+    public BindingFunction<T> installTo(ScopeKey scope) throws IllegalScopeException {
         return this.delegate.installTo(scope);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationBindingFunction.java
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.application.context;
 
-import org.dockbox.hartshorn.component.Scope;
+import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.context.ContextCarrier;
 import org.dockbox.hartshorn.inject.Provider;
 import org.dockbox.hartshorn.inject.binding.Binder;
@@ -49,7 +49,7 @@ public class DelegatingApplicationBindingFunction<T> implements BindingFunction<
     }
 
     @Override
-    public BindingFunction<T> installTo(Class<? extends Scope> scope) throws IllegalScopeException {
+    public BindingFunction<T> installTo(ScopeKey<?> scope) throws IllegalScopeException {
         return this.delegate.installTo(scope);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/InvalidActivationSourceException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/InvalidActivationSourceException.java
@@ -18,6 +18,27 @@ package org.dockbox.hartshorn.application.context;
 
 import org.dockbox.hartshorn.util.ApplicationRuntimeException;
 
+/**
+ * An exception that is thrown when an attempt is made to use an invalid activator class
+ * for a new {@link ApplicationContext}. Typically, a class is considered valid when it
+ * is a class that is not:
+ * <ul>
+ *     <li>abstract</li>
+ *     <li>an interface</li>
+ *     <li>an array</li>
+ *     <li>a primitive</li>
+ *     <li>a local class</li>
+ *     <li>a member class</li>
+ *     <li>in a reserved package</li>
+ * </ul>
+ *
+ * <p>Note that specific {@link org.dockbox.hartshorn.application.ApplicationBuilder} implementations
+ * may have additional requirements for valid activator classes.
+ *
+ * @since 0.4.12
+ *
+ * @author Guus Lieben
+ */
 public class InvalidActivationSourceException extends ApplicationRuntimeException {
 
     public InvalidActivationSourceException(String message) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentKey.java
@@ -218,7 +218,7 @@ public final class ComponentKey<T> {
      */
     public String qualifiedName(boolean qualifyType) {
         String nameSuffix = StringUtilities.empty(this.name) ? "" : ":" + this.name;
-        String scopeName = this.scope.installableScopeType().getSimpleName();
+        String scopeName = this.scope.installableScopeType().name();
         String typeName = qualifyType ? this.type.type().getCanonicalName() : this.type.type().getSimpleName();
         return typeName + nameSuffix + " @ " + scopeName;
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentKey.java
@@ -331,7 +331,7 @@ public final class ComponentKey<T> {
             return copyProperties(builder(type));
         }
 
-        public <U> Builder<?> type(ParameterizableType type) {
+        public Builder<?> type(ParameterizableType type) {
             return copyProperties(builder(type));
         }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/DirectScopeKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/DirectScopeKey.java
@@ -24,13 +24,11 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
  * Simple implementation of a {@link ScopeKey}, to be used for direct implementations of
  * {@link Scope}. For {@link ScopeAdapter}s, use {@link ScopeAdapterKey} instead.
  *
- * @param <T> the type of the scope
- *
  * @since 0.5.0
  *
  * @author Guus Lieben
  */
-public class DirectScopeKey<T extends Scope> implements ScopeKey {
+public class DirectScopeKey implements ScopeKey {
 
     private final ParameterizableType scopeType;
 
@@ -59,8 +57,8 @@ public class DirectScopeKey<T extends Scope> implements ScopeKey {
      * @return a new {@link DirectScopeKey} instance
      * @param <T> the type of the scope
      */
-    public static <T extends Scope> DirectScopeKey<T> of(Class<T> scopeType) {
-        return new DirectScopeKey<>(ParameterizableType.create(scopeType));
+    public static <T extends Scope> DirectScopeKey of(Class<T> scopeType) {
+        return new DirectScopeKey(ParameterizableType.create(scopeType));
     }
 
     /**
@@ -71,8 +69,8 @@ public class DirectScopeKey<T extends Scope> implements ScopeKey {
      * @return a new {@link DirectScopeKey} instance
      * @param <T> the type of the scope
      */
-    public static <T extends Scope> DirectScopeKey<T> of(TypeView<T> scopeType) {
-        return new DirectScopeKey<>(ParameterizableType.create(scopeType));
+    public static <T extends Scope> DirectScopeKey of(TypeView<T> scopeType) {
+        return new DirectScopeKey(ParameterizableType.create(scopeType));
     }
 
     /**
@@ -82,9 +80,9 @@ public class DirectScopeKey<T extends Scope> implements ScopeKey {
      * @param scopeType the type of the scope
      * @return a new {@link DirectScopeKey} instance
      */
-    public static DirectScopeKey<?> of(ParameterizableType scopeType) {
+    public static DirectScopeKey of(ParameterizableType scopeType) {
         // Note that type is not checked here, as constructor already does this.
-        return new DirectScopeKey<>(scopeType);
+        return new DirectScopeKey(scopeType);
     }
 
     @Override
@@ -92,7 +90,7 @@ public class DirectScopeKey<T extends Scope> implements ScopeKey {
         if(this == object) {
             return true;
         }
-        if(!(object instanceof DirectScopeKey<?> scopeKey)) {
+        if(!(object instanceof DirectScopeKey scopeKey)) {
             return false;
         }
         return Objects.equals(this.scopeType, scopeKey.scopeType);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/DirectScopeKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/DirectScopeKey.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.component;
+
+import java.util.Objects;
+import org.dockbox.hartshorn.util.introspect.ParameterizableType;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+
+/**
+ * Simple implementation of a {@link ScopeKey}, to be used for direct implementations of
+ * {@link Scope}. For {@link ScopeAdapter}s, use {@link ScopeAdapterKey} instead.
+ *
+ * @param <T> the type of the scope
+ *
+ * @since 0.5.0
+ *
+ * @author Guus Lieben
+ */
+public class DirectScopeKey<T extends Scope> implements ScopeKey<T> {
+
+    private final ParameterizableType scopeType;
+
+    protected DirectScopeKey(ParameterizableType scopeType) {
+        if (!Scope.class.isAssignableFrom(scopeType.type())) {
+            throw new IllegalArgumentException("Scope type must be a subtype of Scope");
+        }
+        this.scopeType = scopeType;
+    }
+
+    @Override
+    public String name() {
+        return this.scopeType.toString();
+    }
+
+    @Override
+    public ParameterizableType scopeType() {
+        return this.scopeType;
+    }
+
+    /**
+     * Creates a new {@link DirectScopeKey} for the given type. This is a convenience method that allows for
+     * the creation of a key without having to specify type parameters.
+     *
+     * @param scopeType the type of the scope
+     * @return a new {@link DirectScopeKey} instance
+     * @param <T> the type of the scope
+     */
+    public static <T extends Scope> DirectScopeKey<T> of(Class<T> scopeType) {
+        return new DirectScopeKey<>(ParameterizableType.create(scopeType));
+    }
+
+    /**
+     * Creates a new {@link DirectScopeKey} for the given type. This is a convenience method that allows for
+     * the creation of a key from existing type metadata.
+     *
+     * @param scopeType the type of the scope
+     * @return a new {@link DirectScopeKey} instance
+     * @param <T> the type of the scope
+     */
+    public static <T extends Scope> DirectScopeKey<T> of(TypeView<T> scopeType) {
+        return new DirectScopeKey<>(ParameterizableType.create(scopeType));
+    }
+
+    /**
+     * Creates a new {@link DirectScopeKey} for the given type. This is a convenience method that allows for
+     * the creation of a key from existing type metadata.
+     *
+     * @param scopeType the type of the scope
+     * @return a new {@link DirectScopeKey} instance
+     */
+    public static DirectScopeKey<?> of(ParameterizableType scopeType) {
+        // Note that type is not checked here, as constructor already does this.
+        return new DirectScopeKey<>(scopeType);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if(this == object) {
+            return true;
+        }
+        if(!(object instanceof DirectScopeKey<?> scopeKey)) {
+            return false;
+        }
+        return Objects.equals(this.scopeType, scopeKey.scopeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.scopeType);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/DirectScopeKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/DirectScopeKey.java
@@ -30,7 +30,7 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
  *
  * @author Guus Lieben
  */
-public class DirectScopeKey<T extends Scope> implements ScopeKey<T> {
+public class DirectScopeKey<T extends Scope> implements ScopeKey {
 
     private final ParameterizableType scopeType;
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/Scope.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/Scope.java
@@ -47,7 +47,7 @@ package org.dockbox.hartshorn.component;
 @FunctionalInterface
 public interface Scope {
 
-    ScopeKey<Scope> DEFAULT_SCOPE_KEY = DirectScopeKey.of(Scope.class);
+    ScopeKey DEFAULT_SCOPE_KEY = DirectScopeKey.of(Scope.class);
 
     /**
      * A common standard scope for applications. Internally this will refer to
@@ -62,6 +62,6 @@ public interface Scope {
      *
      * @return The type of the scope, or a parent scope.
      */
-    ScopeKey<?> installableScopeType();
+    ScopeKey installableScopeType();
 
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/Scope.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/Scope.java
@@ -47,7 +47,7 @@ package org.dockbox.hartshorn.component;
 @FunctionalInterface
 public interface Scope {
 
-    ScopeKey<Scope> DEFAULT_SCOPE_KEY = ScopeKey.of(Scope.class);
+    ScopeKey<Scope> DEFAULT_SCOPE_KEY = DirectScopeKey.of(Scope.class);
 
     /**
      * A common standard scope for applications. Internally this will refer to

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/Scope.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/Scope.java
@@ -47,11 +47,13 @@ package org.dockbox.hartshorn.component;
 @FunctionalInterface
 public interface Scope {
 
+    ScopeKey<Scope> DEFAULT_SCOPE_KEY = ScopeKey.of(Scope.class);
+
     /**
      * A common standard scope for applications. Internally this will refer to
      * the active {@link org.dockbox.hartshorn.application.context.ApplicationContext}.
      */
-    Scope DEFAULT_SCOPE = () -> Scope.class;
+    Scope DEFAULT_SCOPE = () -> DEFAULT_SCOPE_KEY;
 
     /**
      * The type of the scope, or a parent scope. This is used to determine which
@@ -60,6 +62,6 @@ public interface Scope {
      *
      * @return The type of the scope, or a parent scope.
      */
-    Class<? extends Scope> installableScopeType();
+    ScopeKey<?> installableScopeType();
 
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapter.java
@@ -63,7 +63,7 @@ public class ScopeAdapter<T> implements Scope {
     }
 
     @Override
-    public ScopeAdapterKey<T> installableScopeType() {
+    public ScopeAdapterKey installableScopeType() {
         return ScopeAdapterKey.of(this);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapter.java
@@ -22,9 +22,9 @@ import org.dockbox.hartshorn.util.introspect.ParameterizableType;
 public class ScopeAdapter<T> implements Scope {
 
     private final T adaptee;
-    private final ParameterizableType<T> adapteeType;
+    private final ParameterizableType adapteeType;
 
-    protected ScopeAdapter(T adaptee, ParameterizableType<T> adapteeType) {
+    protected ScopeAdapter(T adaptee, ParameterizableType adapteeType) {
         this.adaptee = adaptee;
         this.adapteeType = adapteeType;
     }
@@ -33,12 +33,16 @@ public class ScopeAdapter<T> implements Scope {
         return this.adaptee;
     }
 
-    public ParameterizableType<T> adapteeType() {
+    public ParameterizableType adapteeType() {
         return this.adapteeType;
     }
 
-    public static <T> ScopeAdapter<T> of(T adaptee, ParameterizableType<T> type) {
+    public static <T> ScopeAdapter<T> of(T adaptee, ParameterizableType type) {
         return new ScopeAdapter<>(adaptee, type);
+    }
+
+    public static <T> ScopeAdapter<T> of(T adaptee) {
+        return new ScopeAdapter<>(adaptee, ParameterizableType.create(adaptee.getClass()));
     }
 
     @Override
@@ -59,7 +63,7 @@ public class ScopeAdapter<T> implements Scope {
     }
 
     @Override
-    public ScopeKey<ScopeAdapter<T>> installableScopeType() {
+    public ScopeAdapterKey<T> installableScopeType() {
         return ScopeAdapterKey.of(this);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapter.java
@@ -17,21 +17,28 @@
 package org.dockbox.hartshorn.component;
 
 import java.util.Objects;
+import org.dockbox.hartshorn.util.introspect.ParameterizableType;
 
 public class ScopeAdapter<T> implements Scope {
 
     private final T adaptee;
+    private final ParameterizableType<T> adapteeType;
 
-    protected ScopeAdapter(T adaptee) {
+    protected ScopeAdapter(T adaptee, ParameterizableType<T> adapteeType) {
         this.adaptee = adaptee;
+        this.adapteeType = adapteeType;
     }
 
     public T adaptee() {
         return this.adaptee;
     }
 
-    public static <T> ScopeAdapter<T> of(T adaptee) {
-        return new ScopeAdapter<>(adaptee);
+    public ParameterizableType<T> adapteeType() {
+        return this.adapteeType;
+    }
+
+    public static <T> ScopeAdapter<T> of(T adaptee, ParameterizableType<T> type) {
+        return new ScopeAdapter<>(adaptee, type);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapterKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapterKey.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.component;
+
+import java.util.Objects;
+
+import org.dockbox.hartshorn.util.TypeUtils;
+
+public class ScopeAdapterKey<T> extends ScopeKey<ScopeAdapter<T>> {
+
+    private final Class<T> adapteeType;
+
+    protected ScopeAdapterKey(Class<ScopeAdapter<T>> type, Class<T> adapteeType) {
+        super(type);
+        this.adapteeType = adapteeType;
+    }
+
+    public Class<T> adapteeType() {
+        return adapteeType;
+    }
+
+    public static <T> ScopeAdapterKey<T> of(ScopeAdapter<T> adapter) {
+        Class<ScopeAdapter<T>> adapterType = TypeUtils.adjustWildcards(adapter.getClass(), Class.class);
+        Class<T> adapteeType = TypeUtils.adjustWildcards(adapter.adaptee().getClass(), Class.class);
+        return new ScopeAdapterKey<>(adapterType, adapteeType);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if(this == object) {
+            return true;
+        }
+        if(!(object instanceof ScopeAdapterKey<?> that)) {
+            return false;
+        }
+        if(!super.equals(object)) {
+            return false;
+        }
+        return Objects.equals(adapteeType, that.adapteeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), adapteeType);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapterKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapterKey.java
@@ -34,7 +34,7 @@ import org.dockbox.hartshorn.util.introspect.ParameterizableType;
  *
  * @author Guus Lieben
  */
-public class ScopeAdapterKey<T> implements ScopeKey<ScopeAdapter<T>> {
+public class ScopeAdapterKey<T> implements ScopeKey {
 
     private final ParameterizableType adapterType;
     private final ParameterizableType adapteeType;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapterKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapterKey.java
@@ -25,8 +25,6 @@ import org.dockbox.hartshorn.util.introspect.ParameterizableType;
  * Specialized {@link ScopeKey} for {@link ScopeAdapter} instances. This tracks both the adaptee type
  * and the scope adapter type.
  *
- * @param <T> the adaptee type
- *
  * @see ScopeAdapter
  * @see ScopeKey
  *
@@ -34,7 +32,7 @@ import org.dockbox.hartshorn.util.introspect.ParameterizableType;
  *
  * @author Guus Lieben
  */
-public class ScopeAdapterKey<T> implements ScopeKey {
+public class ScopeAdapterKey implements ScopeKey {
 
     private final ParameterizableType adapterType;
     private final ParameterizableType adapteeType;
@@ -57,14 +55,14 @@ public class ScopeAdapterKey<T> implements ScopeKey {
      * @return the key
      * @param <T> the adaptee type
      */
-    public static <T> ScopeAdapterKey<T> of(ScopeAdapter<T> adapter) {
+    public static <T> ScopeAdapterKey of(ScopeAdapter<T> adapter) {
         ParameterizableType adapteeType = adapter.adapteeType();
         ParameterizableType adapterType = ParameterizableType.builder(ScopeAdapter.class).parameters(adapteeType).build();
-        return new ScopeAdapterKey<>(TypeUtils.adjustWildcards(adapterType, ParameterizableType.class));
+        return new ScopeAdapterKey(TypeUtils.adjustWildcards(adapterType, ParameterizableType.class));
     }
 
-    public static ScopeAdapterKey<?> of(ParameterizableType type) {
-        return new ScopeAdapterKey<>(type);
+    public static ScopeAdapterKey of(ParameterizableType type) {
+        return new ScopeAdapterKey(type);
     }
 
     /**
@@ -93,7 +91,7 @@ public class ScopeAdapterKey<T> implements ScopeKey {
         if(this == object) {
             return true;
         }
-        if(!(object instanceof ScopeAdapterKey<?> that)) {
+        if(!(object instanceof ScopeAdapterKey that)) {
             return false;
         }
         // Note that adapterType already contains adaptee type, so no need to check that separately

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapterKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAdapterKey.java
@@ -16,26 +16,57 @@
 
 package org.dockbox.hartshorn.component;
 
+import java.util.List;
 import java.util.Objects;
-
 import org.dockbox.hartshorn.util.TypeUtils;
+import org.dockbox.hartshorn.util.introspect.ParameterizableType;
 
+/**
+ * Specialized {@link ScopeKey} for {@link ScopeAdapter} instances. This tracks both the adaptee type
+ * and the scope adapter type.
+ *
+ * @param <T> the adaptee type
+ *
+ * @see ScopeAdapter
+ * @see ScopeKey
+ *
+ * @since 0.5.0
+ *
+ * @author Guus Lieben
+ */
 public class ScopeAdapterKey<T> extends ScopeKey<ScopeAdapter<T>> {
 
-    private final Class<T> adapteeType;
+    private final ParameterizableType<T> adapteeType;
 
-    protected ScopeAdapterKey(Class<ScopeAdapter<T>> type, Class<T> adapteeType) {
+    protected ScopeAdapterKey(ParameterizableType<ScopeAdapter<T>> type, ParameterizableType<T> adapteeType) {
         super(type);
         this.adapteeType = adapteeType;
     }
 
-    public Class<T> adapteeType() {
-        return adapteeType;
+    /**
+     * Returns the type of the adaptee. This contains the full type information, including any type
+     * parameters. This is not the type of the scope itself, but of the instance that is wrapped by
+     * the adapter.
+     *
+     * @return the type of the adaptee
+     */
+    public ParameterizableType<T> adapteeType() {
+        return this.adapteeType;
     }
 
+    /**
+     * Creates a new key for the given adapter. The adaptee type is derived from the adapter.
+     *
+     * @param adapter the adapter to create a key for
+     * @return the key
+     * @param <T> the adaptee type
+     */
     public static <T> ScopeAdapterKey<T> of(ScopeAdapter<T> adapter) {
-        Class<ScopeAdapter<T>> adapterType = TypeUtils.adjustWildcards(adapter.getClass(), Class.class);
-        Class<T> adapteeType = TypeUtils.adjustWildcards(adapter.adaptee().getClass(), Class.class);
+        ParameterizableType<T> adapteeType = adapter.adapteeType();
+        ParameterizableType<ScopeAdapter<T>> adapterType = TypeUtils.adjustWildcards(
+            new ParameterizableType<>(ScopeAdapter.class, List.of(adapteeType)),
+            ParameterizableType.class
+        );
         return new ScopeAdapterKey<>(adapterType, adapteeType);
     }
 
@@ -50,11 +81,11 @@ public class ScopeAdapterKey<T> extends ScopeKey<ScopeAdapter<T>> {
         if(!super.equals(object)) {
             return false;
         }
-        return Objects.equals(adapteeType, that.adapteeType);
+        return Objects.equals(this.adapteeType, that.adapteeType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), adapteeType);
+        return Objects.hash(super.hashCode(), this.adapteeType);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeKey.java
@@ -1,33 +1,17 @@
-/*
- * Copyright 2019-2023 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.dockbox.hartshorn.component;
 
-import java.util.Objects;
 import org.dockbox.hartshorn.util.introspect.ParameterizableType;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
 /**
  * A key that can be used to identify a {@link Scope}. This contains the required metadata to
  * identify a scope, and can be used to manage scoped components in a {@link ScopeAwareComponentProvider}.
  *
  * <p>Scope keys contain a {@link ParameterizableType} that describes the type of the scope. This type can
- * be parameterized. Therefore, key instances differentiate between e.g. {@code TypeScope<String>} and {@code TypeScope<Integer>}.
+ * be parameterized. Therefore, key instances differentiate between e.g. {@code TypeScope<String>} and
+ * {@code TypeScope<Integer>}.
  *
- * <p>Keys are always immutable.
+ * <p>Keys are always immutable. Specific implementations may choose to provide utility builders or factories,
+ * but should never allow the final {@link ScopeKey} to be mutable.
  *
  * @see ScopeAwareComponentProvider
  * @see Scope
@@ -38,13 +22,7 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
  *
  * @author Guus Lieben
  */
-public class ScopeKey<T extends Scope> {
-
-    private final ParameterizableType<T> scopeType;
-
-    protected ScopeKey(ParameterizableType<T> scopeType) {
-        this.scopeType = scopeType;
-    }
+public interface ScopeKey<T extends Scope> {
 
     /**
      * Returns the name of the scope type. This is the simple name of the type, without any package
@@ -52,9 +30,7 @@ public class ScopeKey<T extends Scope> {
      *
      * @return the name of the scope type
      */
-    public String name() {
-        return this.scopeType.toString();
-    }
+    String name();
 
     /**
      * Returns the type of the scope. This contains the full type information, including any type
@@ -62,59 +38,5 @@ public class ScopeKey<T extends Scope> {
      *
      * @return the type of the scope
      */
-    public ParameterizableType<T> scopeType() {
-        return this.scopeType;
-    }
-
-    /**
-     * Creates a new {@link ScopeKey} for the given type. This is a convenience method that allows for
-     * the creation of a key without having to specify type parameters.
-     *
-     * @param scopeType the type of the scope
-     * @return a new {@link ScopeKey} instance
-     * @param <T> the type of the scope
-     */
-    public static <T extends Scope> ScopeKey<T> of(Class<T> scopeType) {
-        return new ScopeKey<>(new ParameterizableType<>(scopeType));
-    }
-
-    /**
-     * Creates a new {@link ScopeKey} for the given type. This is a convenience method that allows for
-     * the creation of a key from existing type metadata.
-     *
-     * @param scopeType the type of the scope
-     * @return a new {@link ScopeKey} instance
-     * @param <T> the type of the scope
-     */
-    public static <T extends Scope> ScopeKey<T> of(TypeView<T> scopeType) {
-        return new ScopeKey<>(new ParameterizableType<>(scopeType));
-    }
-
-    /**
-     * Creates a new {@link ScopeKey} for the given type. This is a convenience method that allows for
-     * the creation of a key from existing type metadata.
-     *
-     * @param scopeType the type of the scope
-     * @return a new {@link ScopeKey} instance
-     * @param <T> the type of the scope
-     */
-    public static <T extends Scope> ScopeKey<T> of(ParameterizableType<T> scopeType) {
-        return new ScopeKey<>(scopeType);
-    }
-
-    @Override
-    public boolean equals(Object object) {
-        if(this == object) {
-            return true;
-        }
-        if(!(object instanceof ScopeKey<?> scopeKey)) {
-            return false;
-        }
-        return Objects.equals(this.scopeType, scopeKey.scopeType);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.scopeType);
-    }
+    ParameterizableType scopeType();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeKey.java
@@ -17,24 +17,88 @@
 package org.dockbox.hartshorn.component;
 
 import java.util.Objects;
+import org.dockbox.hartshorn.util.introspect.ParameterizableType;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
+/**
+ * A key that can be used to identify a {@link Scope}. This contains the required metadata to
+ * identify a scope, and can be used to manage scoped components in a {@link ScopeAwareComponentProvider}.
+ *
+ * <p>Scope keys contain a {@link ParameterizableType} that describes the type of the scope. This type can
+ * be parameterized. Therefore, key instances differentiate between e.g. {@code TypeScope<String>} and {@code TypeScope<Integer>}.
+ *
+ * <p>Keys are always immutable.
+ *
+ * @see ScopeAwareComponentProvider
+ * @see Scope
+ *
+ * @param <T> the type of the scope
+ *
+ * @since 0.5.0
+ *
+ * @author Guus Lieben
+ */
 public class ScopeKey<T extends Scope> {
 
-    private final Class<T> scopeType;
+    private final ParameterizableType<T> scopeType;
 
-    protected ScopeKey(Class<T> scopeType) {
+    protected ScopeKey(ParameterizableType<T> scopeType) {
         this.scopeType = scopeType;
     }
 
+    /**
+     * Returns the name of the scope type. This is the simple name of the type, without any package
+     * information, but including any type parameters.
+     *
+     * @return the name of the scope type
+     */
     public String name() {
-        return this.scopeType.getSimpleName();
+        return this.scopeType.toString();
     }
 
-    public Class<T> scopeType() {
+    /**
+     * Returns the type of the scope. This contains the full type information, including any type
+     * parameters.
+     *
+     * @return the type of the scope
+     */
+    public ParameterizableType<T> scopeType() {
         return this.scopeType;
     }
 
+    /**
+     * Creates a new {@link ScopeKey} for the given type. This is a convenience method that allows for
+     * the creation of a key without having to specify type parameters.
+     *
+     * @param scopeType the type of the scope
+     * @return a new {@link ScopeKey} instance
+     * @param <T> the type of the scope
+     */
     public static <T extends Scope> ScopeKey<T> of(Class<T> scopeType) {
+        return new ScopeKey<>(new ParameterizableType<>(scopeType));
+    }
+
+    /**
+     * Creates a new {@link ScopeKey} for the given type. This is a convenience method that allows for
+     * the creation of a key from existing type metadata.
+     *
+     * @param scopeType the type of the scope
+     * @return a new {@link ScopeKey} instance
+     * @param <T> the type of the scope
+     */
+    public static <T extends Scope> ScopeKey<T> of(TypeView<T> scopeType) {
+        return new ScopeKey<>(new ParameterizableType<>(scopeType));
+    }
+
+    /**
+     * Creates a new {@link ScopeKey} for the given type. This is a convenience method that allows for
+     * the creation of a key from existing type metadata.
+     *
+     * @param scopeType the type of the scope
+     * @return a new {@link ScopeKey} instance
+     * @param <T> the type of the scope
+     */
+    public static <T extends Scope> ScopeKey<T> of(ParameterizableType<T> scopeType) {
         return new ScopeKey<>(scopeType);
     }
 
@@ -46,11 +110,11 @@ public class ScopeKey<T extends Scope> {
         if(!(object instanceof ScopeKey<?> scopeKey)) {
             return false;
         }
-        return Objects.equals(scopeType, scopeKey.scopeType);
+        return Objects.equals(this.scopeType, scopeKey.scopeType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(scopeType);
+        return Objects.hash(this.scopeType);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeKey.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.component;
 
 import org.dockbox.hartshorn.util.introspect.ParameterizableType;
@@ -16,13 +32,11 @@ import org.dockbox.hartshorn.util.introspect.ParameterizableType;
  * @see ScopeAwareComponentProvider
  * @see Scope
  *
- * @param <T> the type of the scope
- *
  * @since 0.5.0
  *
  * @author Guus Lieben
  */
-public interface ScopeKey<T extends Scope> {
+public interface ScopeKey {
 
     /**
      * Returns the name of the scope type. This is the simple name of the type, without any package

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeKey.java
@@ -18,41 +18,39 @@ package org.dockbox.hartshorn.component;
 
 import java.util.Objects;
 
-public class ScopeAdapter<T> implements Scope {
+public class ScopeKey<T extends Scope> {
 
-    private final T adaptee;
+    private final Class<T> scopeType;
 
-    protected ScopeAdapter(T adaptee) {
-        this.adaptee = adaptee;
+    protected ScopeKey(Class<T> scopeType) {
+        this.scopeType = scopeType;
     }
 
-    public T adaptee() {
-        return this.adaptee;
+    public String name() {
+        return this.scopeType.getSimpleName();
     }
 
-    public static <T> ScopeAdapter<T> of(T adaptee) {
-        return new ScopeAdapter<>(adaptee);
+    public Class<T> scopeType() {
+        return this.scopeType;
+    }
+
+    public static <T extends Scope> ScopeKey<T> of(Class<T> scopeType) {
+        return new ScopeKey<>(scopeType);
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (this == other) {
+    public boolean equals(Object object) {
+        if(this == object) {
             return true;
         }
-        if (other == null || this.getClass() != other.getClass()) {
+        if(!(object instanceof ScopeKey<?> scopeKey)) {
             return false;
         }
-        ScopeAdapter<?> adapter = (ScopeAdapter<?>) other;
-        return this.adaptee.equals(adapter.adaptee);
+        return Objects.equals(scopeType, scopeKey.scopeType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.adaptee);
-    }
-
-    @Override
-    public ScopeKey<ScopeAdapter<T>> installableScopeType() {
-        return ScopeAdapterKey.of(this);
+        return Objects.hash(scopeType);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeModuleContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeModuleContext.java
@@ -33,14 +33,14 @@ import jakarta.inject.Inject;
 @InstallIfAbsent
 public class ScopeModuleContext extends DefaultApplicationAwareContext {
 
-    private final MultiMap<ScopeKey<?>, BindingHierarchy<?>> scopeModules = new ConcurrentSetMultiMap<>();
+    private final MultiMap<ScopeKey, BindingHierarchy<?>> scopeModules = new ConcurrentSetMultiMap<>();
 
     @Inject
     public ScopeModuleContext(ApplicationContext applicationContext) {
         super(applicationContext);
     }
 
-    public <T> BindingHierarchy<T> hierarchy(ScopeKey<?> scope, ComponentKey<T> key) {
+    public <T> BindingHierarchy<T> hierarchy(ScopeKey scope, ComponentKey<T> key) {
         BindingHierarchy<?> bindingHierarchy = this.scopeModules.get(scope).stream()
                 .filter(hierarchy -> hierarchy.key().equals(key))
                 .findFirst()
@@ -53,7 +53,7 @@ public class ScopeModuleContext extends DefaultApplicationAwareContext {
         return TypeUtils.adjustWildcards(bindingHierarchy, BindingHierarchy.class);
     }
 
-    public Collection<BindingHierarchy<?>> hierarchies(ScopeKey<?> type) {
+    public Collection<BindingHierarchy<?>> hierarchies(ScopeKey type) {
         if (type == Scope.DEFAULT_SCOPE_KEY) {
             return Collections.emptyList();
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeModuleContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeModuleContext.java
@@ -33,14 +33,14 @@ import jakarta.inject.Inject;
 @InstallIfAbsent
 public class ScopeModuleContext extends DefaultApplicationAwareContext {
 
-    private final MultiMap<Class<? extends Scope>, BindingHierarchy<?>> scopeModules = new ConcurrentSetMultiMap<>();
+    private final MultiMap<ScopeKey<?>, BindingHierarchy<?>> scopeModules = new ConcurrentSetMultiMap<>();
 
     @Inject
     public ScopeModuleContext(ApplicationContext applicationContext) {
         super(applicationContext);
     }
 
-    public <T> BindingHierarchy<T> hierarchy(Class<? extends Scope> scope, ComponentKey<T> key) {
+    public <T> BindingHierarchy<T> hierarchy(ScopeKey<?> scope, ComponentKey<T> key) {
         BindingHierarchy<?> bindingHierarchy = this.scopeModules.get(scope).stream()
                 .filter(hierarchy -> hierarchy.key().equals(key))
                 .findFirst()
@@ -53,8 +53,8 @@ public class ScopeModuleContext extends DefaultApplicationAwareContext {
         return TypeUtils.adjustWildcards(bindingHierarchy, BindingHierarchy.class);
     }
 
-    public Collection<BindingHierarchy<?>> hierarchies(Class<? extends Scope> type) {
-        if (type == Scope.class) {
+    public Collection<BindingHierarchy<?>> hierarchies(ScopeKey<?> type) {
+        if (type == Scope.DEFAULT_SCOPE_KEY) {
             return Collections.emptyList();
         }
         return this.scopeModules.get(type);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentPostProcessor.java
@@ -166,8 +166,8 @@ public abstract non-sealed class ComponentPostProcessor implements ComponentProc
                                                  T instance, T modified) {
         if (instance != modified) {
             boolean ok = false;
-            if (modified instanceof Proxy) {
-                Proxy<T> proxy = TypeUtils.adjustWildcards(modified, Proxy.class);
+            if (modified instanceof Proxy<?> modifiedProxy) {
+                Proxy<T> proxy = TypeUtils.adjustWildcards(modifiedProxy, Proxy.class);
                 ok = proxy.manager().delegate().orNull() == instance;
             }
             if (!ok) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AbstractDependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AbstractDependencyContext.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.inject;
 
 import java.util.Set;
 import org.dockbox.hartshorn.component.ComponentKey;
-import org.dockbox.hartshorn.component.Scope;
+import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
 
@@ -38,15 +38,15 @@ import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
 public abstract class AbstractDependencyContext<T> implements DependencyContext<T> {
 
     private final ComponentKey<T> componentKey;
-    private final Class<? extends Scope> scope;
     private final DependencyMap dependencies;
+    private final ScopeKey<?> scope;
     private final int priority;
 
     private boolean lazy;
     private boolean singleton;
     private boolean processAfterInitialization = true;
 
-    protected AbstractDependencyContext(ComponentKey<T> componentKey, DependencyMap dependencies, Class<? extends Scope> scope, int priority) {
+    protected AbstractDependencyContext(ComponentKey<T> componentKey, DependencyMap dependencies, ScopeKey<?> scope, int priority) {
         this.componentKey = componentKey;
         this.dependencies = dependencies;
         this.scope = scope;
@@ -119,7 +119,7 @@ public abstract class AbstractDependencyContext<T> implements DependencyContext<
     }
 
     @Override
-    public Class<? extends Scope> scope() {
+    public ScopeKey<?> scope() {
         return this.scope;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AbstractDependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AbstractDependencyContext.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.inject;
 
 import java.util.Set;
+
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.component.processing.Binds;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AbstractDependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AbstractDependencyContext.java
@@ -40,14 +40,14 @@ public abstract class AbstractDependencyContext<T> implements DependencyContext<
 
     private final ComponentKey<T> componentKey;
     private final DependencyMap dependencies;
-    private final ScopeKey<?> scope;
+    private final ScopeKey scope;
     private final int priority;
 
     private boolean lazy;
     private boolean singleton;
     private boolean processAfterInitialization = true;
 
-    protected AbstractDependencyContext(ComponentKey<T> componentKey, DependencyMap dependencies, ScopeKey<?> scope, int priority) {
+    protected AbstractDependencyContext(ComponentKey<T> componentKey, DependencyMap dependencies, ScopeKey scope, int priority) {
         this.componentKey = componentKey;
         this.dependencies = dependencies;
         this.scope = scope;
@@ -120,7 +120,7 @@ public abstract class AbstractDependencyContext<T> implements DependencyContext<
     }
 
     @Override
-    public ScopeKey<?> scope() {
+    public ScopeKey scope() {
         return this.scope;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AutoConfiguringDependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AutoConfiguringDependencyContext.java
@@ -49,7 +49,7 @@ public class AutoConfiguringDependencyContext<T> extends AbstractDependencyConte
     private final View view;
 
     public AutoConfiguringDependencyContext(ComponentKey<T> componentKey, DependencyMap dependencies,
-                                            ScopeKey<?> scope, int priority,
+                                            ScopeKey scope, int priority,
                                             CheckedSupplier<T> supplier, View view) {
         super(componentKey, dependencies, scope, priority);
         this.supplier = supplier;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AutoConfiguringDependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AutoConfiguringDependencyContext.java
@@ -16,9 +16,9 @@
 
 package org.dockbox.hartshorn.inject;
 
-
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.Scope;
+import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
 import org.dockbox.hartshorn.inject.binding.IllegalScopeException;
 import org.dockbox.hartshorn.util.ApplicationException;
@@ -48,11 +48,9 @@ public class AutoConfiguringDependencyContext<T> extends AbstractDependencyConte
     private final CheckedSupplier<T> supplier;
     private final View view;
 
-    public AutoConfiguringDependencyContext(
-            ComponentKey<T> componentKey, DependencyMap dependencies,
-            Class<? extends Scope> scope, int priority,
-            CheckedSupplier<T> supplier, View view
-    ) {
+    public AutoConfiguringDependencyContext(ComponentKey<T> componentKey, DependencyMap dependencies,
+                                            ScopeKey<?> scope, int priority,
+                                            CheckedSupplier<T> supplier, View view) {
         super(componentKey, dependencies, scope, priority);
         this.supplier = supplier;
         this.view = view;
@@ -62,7 +60,7 @@ public class AutoConfiguringDependencyContext<T> extends AbstractDependencyConte
     public void configure(BindingFunction<T> function) throws ComponentConfigurationException {
         InstanceType instanceType = this.instanceType();
         function.priority(this.priority());
-        if (this.scope() != Scope.DEFAULT_SCOPE.installableScopeType()) {
+        if (!this.scope().equals(Scope.DEFAULT_SCOPE.installableScopeType())) {
             try {
                 function.installTo(this.scope());
             }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentKeyDependencyDeclarationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentKeyDependencyDeclarationContext.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.inject;
 
 import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
@@ -27,7 +28,7 @@ public class ComponentKeyDependencyDeclarationContext<T> implements DependencyDe
 
     public ComponentKeyDependencyDeclarationContext(Introspector introspector, ComponentKey<T> key) {
         this.key = key;
-        this.type = introspector.introspect(key.parameterizedType());
+        this.type = TypeUtils.adjustWildcards(introspector.introspect(key.parameterizedType()), TypeView.class);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/DependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/DependencyContext.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.Scope;
+import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
 import org.dockbox.hartshorn.util.introspect.view.View;
 
@@ -89,7 +90,7 @@ public interface DependencyContext<T> {
      *
      * @see Scope
      */
-    Class<? extends Scope> scope();
+    ScopeKey<?> scope();
 
     /**
      * Returns whether the dependency is a singleton. The implementation may decide whether

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/DependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/DependencyContext.java
@@ -90,7 +90,7 @@ public interface DependencyContext<T> {
      *
      * @see Scope
      */
-    ScopeKey<?> scope();
+    ScopeKey scope();
 
     /**
      * Returns whether the dependency is a singleton. The implementation may decide whether

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ManagedComponentDependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ManagedComponentDependencyContext.java
@@ -77,7 +77,7 @@ public class ManagedComponentDependencyContext<T> implements DependencyContext<T
     }
 
     @Override
-    public ScopeKey<?> scope() {
+    public ScopeKey scope() {
         return Scope.DEFAULT_SCOPE_KEY;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ManagedComponentDependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ManagedComponentDependencyContext.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.ComponentLocator;
 import org.dockbox.hartshorn.component.Scope;
+import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.View;
@@ -76,8 +77,8 @@ public class ManagedComponentDependencyContext<T> implements DependencyContext<T
     }
 
     @Override
-    public Class<? extends Scope> scope() {
-        return Scope.DEFAULT_SCOPE.installableScopeType();
+    public ScopeKey<?> scope() {
+        return Scope.DEFAULT_SCOPE_KEY;
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingFunction.java
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.inject.binding;
 
-import org.dockbox.hartshorn.component.Scope;
+import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.inject.Provider;
 import org.dockbox.hartshorn.util.function.CheckedSupplier;
 
@@ -29,7 +29,7 @@ public interface BindingFunction<T> {
      * @return The binding function
      * @throws IllegalScopeException When the scope is not valid, or cannot be modified safely
      */
-    BindingFunction<T> installTo(Class<? extends Scope> scope) throws IllegalScopeException;
+    BindingFunction<T> installTo(ScopeKey<?> scope) throws IllegalScopeException;
 
     /**
      * Sets the priority of the binding. This will determine the order in which the binding is

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingFunction.java
@@ -29,7 +29,7 @@ public interface BindingFunction<T> {
      * @return The binding function
      * @throws IllegalScopeException When the scope is not valid, or cannot be modified safely
      */
-    BindingFunction<T> installTo(ScopeKey<?> scope) throws IllegalScopeException;
+    BindingFunction<T> installTo(ScopeKey scope) throws IllegalScopeException;
 
     /**
      * Sets the priority of the binding. This will determine the order in which the binding is

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ContextWrappedHierarchy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ContextWrappedHierarchy.java
@@ -36,7 +36,7 @@ import org.dockbox.hartshorn.util.option.Option;
  * @author Guus Lieben
  * @since 0.4.3
  */
-public class ContextWrappedHierarchy<C> implements BindingHierarchy<C> {
+public class ContextWrappedHierarchy<C> implements PrunableBindingHierarchy<C> {
 
     private final ApplicationContext applicationContext;
     private final Consumer<BindingHierarchy<C>> onUpdate;
@@ -130,5 +130,29 @@ public class ContextWrappedHierarchy<C> implements BindingHierarchy<C> {
     @Override
     public String toString() {
         return this.real().toString();
+    }
+
+    @Override
+    public boolean prune(int priority) {
+        if (this.real() instanceof PrunableBindingHierarchy<C> prunableBindingHierarchy) {
+            return prunableBindingHierarchy.prune(priority);
+        }
+        return false;
+    }
+
+    @Override
+    public int pruneAbove(int priority) {
+        if (this.real() instanceof PrunableBindingHierarchy<C> prunableBindingHierarchy) {
+            return prunableBindingHierarchy.pruneAbove(priority);
+        }
+        return 0;
+    }
+
+    @Override
+    public int pruneBelow(int priority) {
+        if (this.real() instanceof PrunableBindingHierarchy<C> prunableBindingHierarchy) {
+            return prunableBindingHierarchy.pruneBelow(priority);
+        }
+        return 0;
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
@@ -53,7 +53,7 @@ public class HierarchyBindingFunction<T> implements BindingFunction<T> {
     private final ScopeModuleContext moduleContext;
     private Scope scope;
 
-    private ScopeKey<?> scopeModule;
+    private ScopeKey scopeModule;
     private int priority = -1;
     private boolean processAfterInitialization = true;
 
@@ -95,7 +95,7 @@ public class HierarchyBindingFunction<T> implements BindingFunction<T> {
     }
 
     @Override
-    public BindingFunction<T> installTo(ScopeKey<?> scope) throws IllegalScopeException {
+    public BindingFunction<T> installTo(ScopeKey scope) throws IllegalScopeException {
         if (this.scope != null && this.scope != Scope.DEFAULT_SCOPE && (!(this.scope instanceof ApplicationContext))) {
             throw new IllegalScopeException("Cannot install binding to scope " + scope.name() + " as the binding is already installed to scope " + this.scope.installableScopeType().name());
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
@@ -18,6 +18,7 @@ package org.dockbox.hartshorn.inject.binding;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.util.IllegalModificationException;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.Scope;
@@ -52,7 +53,7 @@ public class HierarchyBindingFunction<T> implements BindingFunction<T> {
     private final ScopeModuleContext moduleContext;
     private Scope scope;
 
-    private Class<? extends Scope> scopeModule;
+    private ScopeKey<?> scopeModule;
     private int priority = -1;
     private boolean processAfterInitialization = true;
 
@@ -94,12 +95,12 @@ public class HierarchyBindingFunction<T> implements BindingFunction<T> {
     }
 
     @Override
-    public BindingFunction<T> installTo(Class<? extends Scope> scope) throws IllegalScopeException {
+    public BindingFunction<T> installTo(ScopeKey<?> scope) throws IllegalScopeException {
         if (this.scope != null && this.scope != Scope.DEFAULT_SCOPE && (!(this.scope instanceof ApplicationContext))) {
-            throw new IllegalScopeException("Cannot install binding to scope " + scope.getName() + " as the binding is already installed to scope " + this.scope.getClass().getName());
+            throw new IllegalScopeException("Cannot install binding to scope " + scope.name() + " as the binding is already installed to scope " + this.scope.getClass().getName());
         }
         // Permitted, as default application scope may be expanded. Defined child scopes can not be expanded, so this is a safe check
-        if (this.scope instanceof ApplicationContext && !ApplicationContext.class.isAssignableFrom(scope)) {
+        if (this.scope instanceof ApplicationContext && !ApplicationContext.class.isAssignableFrom(scope.scopeType())) {
             this.scope = null;
         }
         this.scopeModule = scope;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
@@ -97,10 +97,10 @@ public class HierarchyBindingFunction<T> implements BindingFunction<T> {
     @Override
     public BindingFunction<T> installTo(ScopeKey<?> scope) throws IllegalScopeException {
         if (this.scope != null && this.scope != Scope.DEFAULT_SCOPE && (!(this.scope instanceof ApplicationContext))) {
-            throw new IllegalScopeException("Cannot install binding to scope " + scope.name() + " as the binding is already installed to scope " + this.scope.getClass().getName());
+            throw new IllegalScopeException("Cannot install binding to scope " + scope.name() + " as the binding is already installed to scope " + this.scope.installableScopeType().name());
         }
         // Permitted, as default application scope may be expanded. Defined child scopes can not be expanded, so this is a safe check
-        if (this.scope instanceof ApplicationContext && !ApplicationContext.class.isAssignableFrom(scope.scopeType())) {
+        if (this.scope instanceof ApplicationContext && !ApplicationContext.class.isAssignableFrom(scope.scopeType().type())) {
             this.scope = null;
         }
         this.scopeModule = scope;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/NativeBindingHierarchy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/NativeBindingHierarchy.java
@@ -40,7 +40,7 @@ import org.dockbox.hartshorn.util.option.Option;
  * @since 0.4.3
  * @see BindingHierarchy
  */
-public class NativeBindingHierarchy<C> implements BindingHierarchy<C> {
+public class NativeBindingHierarchy<C> implements PrunableBindingHierarchy<C> {
 
     private final ComponentKey<C> key;
     private final ApplicationContext applicationContext;
@@ -152,5 +152,32 @@ public class NativeBindingHierarchy<C> implements BindingHierarchy<C> {
     @Override
     public Iterator<Entry<Integer, Provider<C>>> iterator() {
         return this.bindings.entrySet().iterator();
+    }
+
+    @Override
+    public boolean prune(int priority) {
+        return this.bindings.remove(priority) != null;
+    }
+
+    @Override
+    public int pruneAbove(int priority) {
+        int count = 0;
+        for (Entry<Integer, Provider<C>> entry : this.bindings.entrySet()) {
+            if (entry.getKey() > priority && this.prune(entry.getKey())) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public int pruneBelow(int priority) {
+        int count = 0;
+        for (Entry<Integer, Provider<C>> entry : this.bindings.entrySet()) {
+            if (entry.getKey() < priority && this.prune(entry.getKey())) {
+                count++;
+            }
+        }
+        return count;
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/PrunableBindingHierarchy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/PrunableBindingHierarchy.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.binding;
+
+/**
+ * A binding hierarchy that allows pruning of bindings based on priority. This is useful for
+ * bindings that are added to the hierarchy at runtime, and need to be removed at runtime as well.
+ *
+ * @param <T> The type of type {@code T} that the hierarchy is for.
+ *
+ * @author Guus Lieben
+ * @since 0.5.0
+ *
+ * @see BindingHierarchy
+ */
+public interface PrunableBindingHierarchy<T> extends BindingHierarchy<T> {
+
+    /**
+     * Removes the provider with the given priority from the hierarchy. If no provider with the
+     * given priority exists, nothing happens.
+     *
+     * @param priority The priority of the provider to remove.
+     * @return {@code true} if a provider was removed, {@code false} otherwise.
+     */
+    boolean prune(int priority);
+
+    /**
+     * Removes all providers with a priority higher than the given priority. If no providers with
+     * a higher priority exist, nothing happens.
+     *
+     * @param priority The priority to prune above.
+     * @return The amount of providers that were removed.
+     */
+    int pruneAbove(int priority);
+
+    /**
+     * Removes all providers with a priority lower than the given priority. If no providers with
+     * a lower priority exist, nothing happens.
+     *
+     * @param priority The priority to prune below.
+     * @return The amount of providers that were removed.
+     */
+    int pruneBelow(int priority);
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/StaticComponentPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/StaticComponentPostProcessor.java
@@ -16,20 +16,20 @@
 
 package org.dockbox.hartshorn.inject.processing;
 
+import java.util.Collection;
+import java.util.List;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
-import org.dockbox.hartshorn.util.introspect.ParameterizableType;
 import org.dockbox.hartshorn.component.contextual.StaticComponentContext;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
+import org.dockbox.hartshorn.util.introspect.ParameterizableType;
 import org.dockbox.hartshorn.util.introspect.TypeParameterList;
 import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
 import org.dockbox.hartshorn.util.introspect.view.TypeParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
-
-import java.util.Collection;
-import java.util.List;
 
 public class StaticComponentPostProcessor extends ComponentPostProcessor {
 
@@ -40,8 +40,8 @@ public class StaticComponentPostProcessor extends ComponentPostProcessor {
 
         if (Collection.class.isAssignableFrom(componentKey.type())) {
             TypeView<T> componentType = context.environment().introspector().introspect(componentKey.type());
-            List<ParameterizableType<?>> parameters = componentKey.parameterizedType().parameters();
-            ParameterizableType<?> elementType;
+            List<ParameterizableType> parameters = componentKey.parameterizedType().parameters();
+            ParameterizableType elementType;
             if(parameters.size() == 1) {
                 elementType = parameters.get(0);
             }
@@ -50,7 +50,7 @@ public class StaticComponentPostProcessor extends ComponentPostProcessor {
                         .resolveInputFor(Collection.class);
                 TypeParameterView parameterView = collectionParameters.atIndex(0)
                         .orElseThrow(() -> new IllegalArgumentException(String.format("Cannot determine collection type for %s", componentKey.type())));
-                elementType = new ParameterizableType<>(parameterView.resolvedType().get());
+                elementType = ParameterizableType.create(parameterView.resolvedType().get());
             }
 
             ComponentKey<?> elementKey = ComponentKey.builder(elementType)

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/MethodInstanceBindingStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/MethodInstanceBindingStrategy.java
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.InstallTo;
 import org.dockbox.hartshorn.component.Scope;
+import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.inject.AutoConfiguringDependencyContext;
 import org.dockbox.hartshorn.inject.ComponentInitializationException;
@@ -62,7 +63,7 @@ public class MethodInstanceBindingStrategy implements BindingStrategy {
     private <T> DependencyContext<T> resolveInstanceBinding(MethodView<?, T> bindsMethod, Binds bindingDecorator, ApplicationContext applicationContext) {
         ComponentKey<T> componentKey = this.constructInstanceComponentKey(bindsMethod, bindingDecorator);
         Set<ComponentKey<?>> dependencies = DependencyResolverUtils.resolveDependencies(bindsMethod);
-        Class<? extends Scope> scope = this.resolveComponentScope(bindsMethod);
+        ScopeKey<?> scope = this.resolveComponentScope(bindsMethod);
         int priority = bindingDecorator.priority();
 
         ViewContextAdapter contextAdapter = new IntrospectionViewContextAdapter(applicationContext);
@@ -89,10 +90,10 @@ public class MethodInstanceBindingStrategy implements BindingStrategy {
                 || applicationContext.environment().singleton(componentKey.type());
     }
 
-    private Class<? extends Scope> resolveComponentScope(MethodView<?, ?> bindsMethod) {
+    private ScopeKey<?> resolveComponentScope(MethodView<?, ?> bindsMethod) {
         Option<InstallTo> installToCandidate = bindsMethod.annotations().get(InstallTo.class);
         return installToCandidate.present()
-                ? installToCandidate.get().value()
+                ? ScopeKey.of(installToCandidate.get().value())
                 : Scope.DEFAULT_SCOPE.installableScopeType();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/MethodInstanceBindingStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/MethodInstanceBindingStrategy.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.component.DirectScopeKey;
 import org.dockbox.hartshorn.component.InstallTo;
 import org.dockbox.hartshorn.component.Scope;
 import org.dockbox.hartshorn.component.ScopeKey;
@@ -93,7 +94,7 @@ public class MethodInstanceBindingStrategy implements BindingStrategy {
     private ScopeKey<?> resolveComponentScope(MethodView<?, ?> bindsMethod) {
         Option<InstallTo> installToCandidate = bindsMethod.annotations().get(InstallTo.class);
         return installToCandidate.present()
-                ? ScopeKey.of(installToCandidate.get().value())
+                ? DirectScopeKey.of(installToCandidate.get().value())
                 : Scope.DEFAULT_SCOPE.installableScopeType();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/MethodInstanceBindingStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/MethodInstanceBindingStrategy.java
@@ -64,7 +64,7 @@ public class MethodInstanceBindingStrategy implements BindingStrategy {
     private <T> DependencyContext<T> resolveInstanceBinding(MethodView<?, T> bindsMethod, Binds bindingDecorator, ApplicationContext applicationContext) {
         ComponentKey<T> componentKey = this.constructInstanceComponentKey(bindsMethod, bindingDecorator);
         Set<ComponentKey<?>> dependencies = DependencyResolverUtils.resolveDependencies(bindsMethod);
-        ScopeKey<?> scope = this.resolveComponentScope(bindsMethod);
+        ScopeKey scope = this.resolveComponentScope(bindsMethod);
         int priority = bindingDecorator.priority();
 
         ViewContextAdapter contextAdapter = new IntrospectionViewContextAdapter(applicationContext);
@@ -91,7 +91,7 @@ public class MethodInstanceBindingStrategy implements BindingStrategy {
                 || applicationContext.environment().singleton(componentKey.type());
     }
 
-    private ScopeKey<?> resolveComponentScope(MethodView<?, ?> bindsMethod) {
+    private ScopeKey resolveComponentScope(MethodView<?, ?> bindsMethod) {
         Option<InstallTo> installToCandidate = bindsMethod.annotations().get(InstallTo.class);
         return installToCandidate.present()
                 ? DirectScopeKey.of(installToCandidate.get().value())

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/IntrospectionViewContextAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/IntrospectionViewContextAdapter.java
@@ -97,24 +97,20 @@ public class IntrospectionViewContextAdapter implements ViewContextAdapter {
 
     @Override
     public <T> Attempt<T, Throwable> load(GenericTypeView<T> element) {
-        if (element instanceof TypeView<?> typeView) {
-            ComponentKey<T> key = this.key(TypeUtils.adjustWildcards(typeView.type(), Class.class));
-            return Attempt.of(this.applicationContext().get(key));
-        }
-        else if (element instanceof FieldView<?, ?> fieldView) {
-            return this.load(TypeUtils.adjustWildcards(fieldView, FieldView.class));
-        }
-        else if (element instanceof MethodView<?, ?> methodView) {
-            return this.invoke(TypeUtils.adjustWildcards(methodView, MethodView.class));
-        }
-        else if (element instanceof ConstructorView<?> constructorView) {
-            return this.create(TypeUtils.adjustWildcards(constructorView, ConstructorView.class));
-        }
-        else if (element instanceof ParameterView<?> parameterView) {
-            ComponentKey<T> key = this.key(TypeUtils.adjustWildcards(parameterView.type().type(), Class.class));
-            return Attempt.of(this.applicationContext().get(key));
-        }
-        return Attempt.of(new IllegalArgumentException("Unsupported element type: " + element.getClass().getName()));
+        return switch(element) {
+            case TypeView<?> typeView -> {
+                ComponentKey<T> key = this.key(TypeUtils.adjustWildcards(typeView.type(), Class.class));
+                yield Attempt.of(this.applicationContext().get(key));
+            }
+            case FieldView<?, ?> fieldView -> this.load(TypeUtils.adjustWildcards(fieldView, FieldView.class));
+            case MethodView<?, ?> methodView -> this.invoke(TypeUtils.adjustWildcards(methodView, MethodView.class));
+            case ConstructorView<?> constructorView -> this.create(TypeUtils.adjustWildcards(constructorView, ConstructorView.class));
+            case ParameterView<?> parameterView -> {
+                ComponentKey<T> key = this.key(TypeUtils.adjustWildcards(parameterView.type().type(), Class.class));
+                yield Attempt.of(this.applicationContext().get(key));
+            }
+            default -> Attempt.of(new IllegalArgumentException("Unsupported element type: " + element.getClass().getName()));
+        };
     }
 
     @Override

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeBindingTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeBindingTests.java
@@ -16,7 +16,6 @@
 
 package test.org.dockbox.hartshorn.scope;
 
-import jakarta.inject.Inject;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.Scope;
@@ -26,6 +25,8 @@ import org.dockbox.hartshorn.testsuite.TestComponents;
 import org.dockbox.hartshorn.util.introspect.ParameterizableType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import jakarta.inject.Inject;
 import test.org.dockbox.hartshorn.scope.ScopedBindingProvider.SampleScope;
 
 @HartshornTest
@@ -47,7 +48,7 @@ public class ScopeBindingTests {
 
     @Test
     void testScopeBindingIsNotAccessibleFromApplication() {
-        Scope scope = ScopeAdapter.of(new Object(), new ParameterizableType<>(Object.class));
+        Scope scope = ScopeAdapter.of(new Object(), ParameterizableType.create(Object.class));
         ComponentKey<String> key = ComponentKey.builder(String.class)
                 .scope(scope)
                 .build();
@@ -68,7 +69,7 @@ public class ScopeBindingTests {
     void testApplicationBindingIsAccessibleFromScope() {
         this.applicationContext.bind(String.class).singleton("test");
 
-        Scope scope = ScopeAdapter.of(new Object(), new ParameterizableType<>(Object.class));
+        Scope scope = ScopeAdapter.of(new Object(), ParameterizableType.create(Object.class));
         ComponentKey<String> key = ComponentKey.builder(String.class)
                 .scope(scope)
                 .build();

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeBindingTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeBindingTests.java
@@ -16,16 +16,16 @@
 
 package test.org.dockbox.hartshorn.scope;
 
+import jakarta.inject.Inject;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.Scope;
 import org.dockbox.hartshorn.component.ScopeAdapter;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.dockbox.hartshorn.testsuite.TestComponents;
+import org.dockbox.hartshorn.util.introspect.ParameterizableType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import jakarta.inject.Inject;
 import test.org.dockbox.hartshorn.scope.ScopedBindingProvider.SampleScope;
 
 @HartshornTest
@@ -47,7 +47,7 @@ public class ScopeBindingTests {
 
     @Test
     void testScopeBindingIsNotAccessibleFromApplication() {
-        Scope scope = ScopeAdapter.of(new Object());
+        Scope scope = ScopeAdapter.of(new Object(), new ParameterizableType<>(Object.class));
         ComponentKey<String> key = ComponentKey.builder(String.class)
                 .scope(scope)
                 .build();
@@ -68,7 +68,7 @@ public class ScopeBindingTests {
     void testApplicationBindingIsAccessibleFromScope() {
         this.applicationContext.bind(String.class).singleton("test");
 
-        Scope scope = ScopeAdapter.of(new Object());
+        Scope scope = ScopeAdapter.of(new Object(), new ParameterizableType<>(Object.class));
         ComponentKey<String> key = ComponentKey.builder(String.class)
                 .scope(scope)
                 .build();

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeKeyTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeKeyTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test.org.dockbox.hartshorn.scope;
 
 import org.dockbox.hartshorn.component.Scope;
@@ -18,14 +34,14 @@ public class ScopeKeyTests {
                 .parameters(parameterType)
                 .build();
 
-        ScopeKey<?> scopeKey = DirectScopeKey.of(parameterizedType);
+        ScopeKey scopeKey = DirectScopeKey.of(parameterizedType);
         Assertions.assertEquals(parameterizedType, scopeKey.scopeType());
     }
 
     @Test
     void testRawScopeKeysEqual() {
-        ScopeKey<?> scopeKey1 = DirectScopeKey.of(Scope.class);
-        ScopeKey<?> scopeKey2 = DirectScopeKey.of(Scope.class);
+        ScopeKey scopeKey1 = DirectScopeKey.of(Scope.class);
+        ScopeKey scopeKey2 = DirectScopeKey.of(Scope.class);
         Assertions.assertEquals(scopeKey1, scopeKey2);
     }
 
@@ -36,8 +52,8 @@ public class ScopeKeyTests {
                 .parameters(parameterType)
                 .build();
 
-        ScopeKey<?> scopeKey1 = DirectScopeKey.of(parameterizedType);
-        ScopeKey<?> scopeKey2 = DirectScopeKey.of(parameterizedType);
+        ScopeKey scopeKey1 = DirectScopeKey.of(parameterizedType);
+        ScopeKey scopeKey2 = DirectScopeKey.of(parameterizedType);
         Assertions.assertEquals(scopeKey1, scopeKey2);
     }
 

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeKeyTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeKeyTests.java
@@ -77,7 +77,7 @@ public class ScopeKeyTests {
             ParameterizableType type = ParameterizableType.builder(ScopeAdapter.class)
                     .parameters(ParameterizableType.create(String.class))
                     .build();
-            ScopeAdapterKey<?> scopeAdapterKey = ScopeAdapterKey.of(type);
+            ScopeAdapterKey scopeAdapterKey = ScopeAdapterKey.of(type);
             Assertions.assertNotNull(scopeAdapterKey);
         });
     }
@@ -85,10 +85,10 @@ public class ScopeKeyTests {
     @Test
     void testScopeAdapterKeysOfSameTypeEqual() {
         ScopeAdapter<Object> adapter1 = ScopeAdapter.of(new Object());
-        ScopeAdapterKey<Object> key1 = ScopeAdapterKey.of(adapter1);
+        ScopeAdapterKey key1 = ScopeAdapterKey.of(adapter1);
 
         ScopeAdapter<Object> adapter2 = ScopeAdapter.of(new Object());
-        ScopeAdapterKey<Object> key2 = ScopeAdapterKey.of(adapter2);
+        ScopeAdapterKey key2 = ScopeAdapterKey.of(adapter2);
 
         Assertions.assertNotEquals(adapter1, adapter2);
         Assertions.assertEquals(key1, key2);

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeKeyTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopeKeyTests.java
@@ -1,0 +1,80 @@
+package test.org.dockbox.hartshorn.scope;
+
+import org.dockbox.hartshorn.component.Scope;
+import org.dockbox.hartshorn.component.ScopeAdapter;
+import org.dockbox.hartshorn.component.ScopeAdapterKey;
+import org.dockbox.hartshorn.component.DirectScopeKey;
+import org.dockbox.hartshorn.component.ScopeKey;
+import org.dockbox.hartshorn.util.introspect.ParameterizableType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ScopeKeyTests {
+
+    @Test
+    void testScopeKeyTypeKeepsParameters() {
+        ParameterizableType parameterType = ParameterizableType.create(String.class);
+        ParameterizableType parameterizedType = ParameterizableType.builder(ScopeAdapter.class)
+                .parameters(parameterType)
+                .build();
+
+        ScopeKey<?> scopeKey = DirectScopeKey.of(parameterizedType);
+        Assertions.assertEquals(parameterizedType, scopeKey.scopeType());
+    }
+
+    @Test
+    void testRawScopeKeysEqual() {
+        ScopeKey<?> scopeKey1 = DirectScopeKey.of(Scope.class);
+        ScopeKey<?> scopeKey2 = DirectScopeKey.of(Scope.class);
+        Assertions.assertEquals(scopeKey1, scopeKey2);
+    }
+
+    @Test
+    void testParameterizedScopeKeysEqual() {
+        ParameterizableType parameterType = ParameterizableType.create(String.class);
+        ParameterizableType parameterizedType = ParameterizableType.builder(ScopeAdapter.class)
+                .parameters(parameterType)
+                .build();
+
+        ScopeKey<?> scopeKey1 = DirectScopeKey.of(parameterizedType);
+        ScopeKey<?> scopeKey2 = DirectScopeKey.of(parameterizedType);
+        Assertions.assertEquals(scopeKey1, scopeKey2);
+    }
+
+    @Test
+    void testCreateFromParameterizedTypeRequiresScopeType() {
+        ParameterizableType parameterType = ParameterizableType.create(String.class);
+        ParameterizableType parameterizedType = ParameterizableType.builder(ScopeAdapter.class)
+                .parameters(parameterType)
+                .build();
+
+        Assertions.assertDoesNotThrow(() -> DirectScopeKey.of(parameterizedType));
+        // String not a scope type
+        Assertions.assertThrows(IllegalArgumentException.class, () -> DirectScopeKey.of(parameterType));
+    }
+
+    @Test
+    void testScopeAdapterKeyParameterizableTypeRequiresScopeAdapter() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ScopeAdapterKey.of(ParameterizableType.create(String.class)));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ScopeAdapterKey.of(ParameterizableType.create(Scope.class)));
+        Assertions.assertDoesNotThrow(() -> {
+            ParameterizableType type = ParameterizableType.builder(ScopeAdapter.class)
+                    .parameters(ParameterizableType.create(String.class))
+                    .build();
+            ScopeAdapterKey<?> scopeAdapterKey = ScopeAdapterKey.of(type);
+            Assertions.assertNotNull(scopeAdapterKey);
+        });
+    }
+
+    @Test
+    void testScopeAdapterKeysOfSameTypeEqual() {
+        ScopeAdapter<Object> adapter1 = ScopeAdapter.of(new Object());
+        ScopeAdapterKey<Object> key1 = ScopeAdapterKey.of(adapter1);
+
+        ScopeAdapter<Object> adapter2 = ScopeAdapter.of(new Object());
+        ScopeAdapterKey<Object> key2 = ScopeAdapterKey.of(adapter2);
+
+        Assertions.assertNotEquals(adapter1, adapter2);
+        Assertions.assertEquals(key1, key2);
+    }
+}

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopedBindingProvider.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopedBindingProvider.java
@@ -18,6 +18,7 @@ package test.org.dockbox.hartshorn.scope;
 
 import org.dockbox.hartshorn.component.InstallTo;
 import org.dockbox.hartshorn.component.Scope;
+import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.component.processing.Binds;
 
@@ -33,8 +34,8 @@ public class ScopedBindingProvider {
     public static class SampleScope implements Scope {
 
         @Override
-        public Class<? extends Scope> installableScopeType() {
-            return SampleScope.class;
+        public ScopeKey<SampleScope> installableScopeType() {
+            return ScopeKey.of(SampleScope.class);
         }
     }
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopedBindingProvider.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopedBindingProvider.java
@@ -35,7 +35,7 @@ public class ScopedBindingProvider {
     public static class SampleScope implements Scope {
 
         @Override
-        public ScopeKey<SampleScope> installableScopeType() {
+        public ScopeKey installableScopeType() {
             return DirectScopeKey.of(SampleScope.class);
         }
     }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopedBindingProvider.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scope/ScopedBindingProvider.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.scope;
 
+import org.dockbox.hartshorn.component.DirectScopeKey;
 import org.dockbox.hartshorn.component.InstallTo;
 import org.dockbox.hartshorn.component.Scope;
 import org.dockbox.hartshorn.component.ScopeKey;
@@ -35,7 +36,7 @@ public class ScopedBindingProvider {
 
         @Override
         public ScopeKey<SampleScope> installableScopeType() {
-            return ScopeKey.of(SampleScope.class);
+            return DirectScopeKey.of(SampleScope.class);
         }
     }
 }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AbstractNativeModule.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/modules/AbstractNativeModule.java
@@ -16,6 +16,9 @@
 
 package org.dockbox.hartshorn.hsl.modules;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.dockbox.hartshorn.hsl.ast.statement.NativeFunctionStatement;
 import org.dockbox.hartshorn.hsl.ast.statement.ParametricExecutableStatement.Parameter;
 import org.dockbox.hartshorn.hsl.interpreter.Interpreter;
@@ -31,9 +34,6 @@ import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.ParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Represents one or more Java methods that can be called from an HSL runtime. The methods
@@ -71,7 +71,8 @@ public abstract class AbstractNativeModule implements NativeModule {
     @Override
     public Object call(Token at, Interpreter interpreter, NativeFunctionStatement function, List<Object> arguments) throws NativeExecutionException {
         try {
-            TypeView<Object> type = TypeUtils.adjustWildcards(this.applicationContext().environment().introspector().introspect(this.moduleClass()), TypeView.class);
+            TypeView<?> typeView = this.applicationContext().environment().introspector().introspect(this.moduleClass());
+            TypeView<Object> type = TypeUtils.adjustWildcards(typeView, TypeView.class);
             MethodView<Object, ?> method;
             if (function.method() == null) {
                 String functionName = function.name().lexeme();

--- a/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionIntrospector.java
+++ b/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionIntrospector.java
@@ -147,8 +147,8 @@ public class ReflectionIntrospector implements BatchCapableIntrospector {
     }
 
     @Override
-    public <T> TypeView<T> introspect(ParameterizableType<T> type) {
-        return (TypeView<T>) this.introspect(type.asParameterizedType());
+    public TypeView<?> introspect(ParameterizableType type) {
+        return this.introspect(type.asParameterizedType());
     }
 
     @Override

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/Introspector.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/Introspector.java
@@ -59,7 +59,7 @@ public interface Introspector extends ReferenceIntrospector {
 
     TypeView<?> introspect(ParameterizedType type);
 
-    <T> TypeView<T> introspect(ParameterizableType<T> type);
+    TypeView<?> introspect(ParameterizableType type);
 
     <T> TypeView<T> introspect(GenericType<T> type);
 

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ParameterizableParameterizedTypeWrapper.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ParameterizableParameterizedTypeWrapper.java
@@ -23,7 +23,6 @@ import java.util.Objects;
  * A wrapper for {@link ParameterizableType} to be used as a {@link ParameterizedType}, that allows for easy introspection.
  *
  * @param type the parameterized type to wrap
- * @param <T> the type of the parameterized type
  *
  * @see ParameterizableType
  *
@@ -31,7 +30,7 @@ import java.util.Objects;
  *
  * @author Guus Lieben
  */
-record ParameterizableParameterizedTypeWrapper<T>(ParameterizableType<T> type) implements ParameterizedType {
+record ParameterizableParameterizedTypeWrapper(ParameterizableType type) implements ParameterizedType {
 
     @Override
     public java.lang.reflect.Type[] getActualTypeArguments() {
@@ -55,7 +54,7 @@ record ParameterizableParameterizedTypeWrapper<T>(ParameterizableType<T> type) i
         if(this == object) {
             return true;
         }
-        if(!(object instanceof ParameterizableParameterizedTypeWrapper<?> that)) {
+        if(!(object instanceof ParameterizableParameterizedTypeWrapper that)) {
             return false;
         }
         return Objects.equals(this.type, that.type);

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ParameterizableType.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ParameterizableType.java
@@ -66,8 +66,10 @@ public final class ParameterizableType {
         List<ParameterizableType> parameters = type.typeParameters().allInput()
                 .asList()
                 .stream()
-                .flatMap(parameter -> parameter.resolvedType().stream())
-                .map(ParameterizableType::create)
+                .map(parameter -> parameter.resolvedType()
+                    .map(ParameterizableType::create)
+                    .orElseGet(() -> ParameterizableType.create(Object.class))
+                )
                 .collect(Collectors.toList());
         return builder(type.type()).parameters(parameters);
     }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ParameterizableType.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ParameterizableType.java
@@ -31,8 +31,6 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
  * <p>{@link ParameterizableType}s can be introspected with {@link Introspector introspectors}, retaining
  * complete type information.
  *
- * @param <T> the type of the parameterized type
- *
  * @see TypeView
  * @see Introspector
  * @see ParameterizedType
@@ -42,45 +40,36 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
  *
  * @author Guus Lieben
  */
-public class ParameterizableType<T> {
+public final class ParameterizableType {
 
-    private final Class<T> type;
-    private List<ParameterizableType<?>> parameters;
+    private final Class<?> type;
+    private final List<ParameterizableType> parameters;
 
-    public ParameterizableType(Class<T> type, List<ParameterizableType<?>> parameters) {
+    private ParameterizableType(Class<?> type, List<ParameterizableType> parameters) {
         this.type = type;
         this.parameters = parameters;
     }
 
-    public ParameterizableType(Class<T> type) {
-        this(type, List.of());
+    public static ParameterizableType create(Class<?> type) {
+        return builder(type).build();
     }
 
-    public ParameterizableType(TypeView<T> type) {
-        this.type = type.type();
-        this.parameters = type.typeParameters().allInput()
+    public static ParameterizableType create(TypeView<?> type) {
+        return builder(type).build();
+    }
+
+    public static Builder builder(Class<?> type) {
+        return new Builder(type);
+    }
+
+    public static Builder builder(TypeView<?> type) {
+        List<ParameterizableType> parameters = type.typeParameters().allInput()
                 .asList()
                 .stream()
                 .flatMap(parameter -> parameter.resolvedType().stream())
-                .map(ParameterizableType::new)
+                .map(ParameterizableType::create)
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * Sets the parameters of this type, overriding all existing parameters. The number of parameters must
-     * match the number of type parameters of the type. If the type has no type parameters, the given
-     * parameters must be empty.
-     *
-     * @param parameters the new parameters
-     *
-     * @throws IllegalArgumentException if the number of parameters does not match the number of type parameters
-     */
-    public void parameters(List<ParameterizableType<?>> parameters) {
-        int expectedSize = this.type().getTypeParameters().length;
-        if(parameters.size() != expectedSize) {
-            throw new IllegalArgumentException("Expected " + expectedSize + " parameters, but got " + parameters.size());
-        }
-        this.parameters = parameters;
+        return builder(type.type()).parameters(parameters);
     }
 
     /**
@@ -89,7 +78,7 @@ public class ParameterizableType<T> {
      *
      * @return the type of this parameterized type
      */
-    public Class<T> type() {
+    public Class<?> type() {
         return this.type;
     }
 
@@ -99,7 +88,7 @@ public class ParameterizableType<T> {
      *
      * @return the parameters of this parameterized type
      */
-    public List<ParameterizableType<?>> parameters() {
+    public List<ParameterizableType> parameters() {
         return List.copyOf(this.parameters);
     }
 
@@ -110,7 +99,7 @@ public class ParameterizableType<T> {
      * @return a {@link ParameterizedType} representation of this parameterized type
      */
     public ParameterizedType asParameterizedType() {
-        return new ParameterizableParameterizedTypeWrapper<>(this);
+        return new ParameterizableParameterizedTypeWrapper(this);
     }
 
     @Override
@@ -121,7 +110,7 @@ public class ParameterizableType<T> {
         if(o == null || this.getClass() != o.getClass()) {
             return false;
         }
-        ParameterizableType<?> that = (ParameterizableType<?>) o;
+        ParameterizableType that = (ParameterizableType) o;
         return Objects.equals(this.type, that.type) && Objects.equals(this.parameters, that.parameters);
     }
 
@@ -136,5 +125,41 @@ public class ParameterizableType<T> {
                 .map(ParameterizableType::toString)
                 .collect(Collectors.joining(", "));
         return this.type.getSimpleName() + (parameters.isEmpty() ? "" : "<" + parameters + ">");
+    }
+
+    public static class Builder {
+
+        private final Class<?> type;
+        private List<ParameterizableType> parameters = List.of();
+
+        public Builder(Class<?> type) {
+            this.type = type;
+        }
+
+        /**
+         * Sets the parameters of this type, overriding all existing parameters. The number of parameters must
+         * match the number of type parameters of the type. If the type has no type parameters, the given
+         * parameters must be empty.
+         *
+         * @param parameters the new parameters
+         *
+         * @throws IllegalArgumentException if the number of parameters does not match the number of type parameters
+         */
+        public Builder parameters(List<ParameterizableType> parameters) {
+            int expectedSize = this.type.getTypeParameters().length;
+            if(parameters.size() != expectedSize) {
+                throw new IllegalArgumentException("Expected " + expectedSize + " parameters, but got " + parameters.size());
+            }
+            this.parameters = parameters;
+            return this;
+        }
+
+        public Builder parameters(ParameterizableType... parameters) {
+            return this.parameters(List.of(parameters));
+        }
+
+        public ParameterizableType build() {
+            return new ParameterizableType(this.type, this.parameters);
+        }
     }
 }

--- a/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
+++ b/hartshorn-introspect/src/testFixtures/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
@@ -519,10 +519,12 @@ public abstract class IntrospectorTests {
 
     @Test
     void testParameterizableTypeCanBeIntrospected() {
-        ParameterizableType<String> argumentType = new ParameterizableType<>(String.class);
-        ParameterizableType<List> collectionType = new ParameterizableType<>(List.class, List.of(argumentType));
+        ParameterizableType argumentType = ParameterizableType.create(String.class);
+        ParameterizableType collectionType = ParameterizableType.builder(List.class)
+                .parameters(argumentType)
+                .build();
 
-        TypeView<List> typeView = introspector().introspect(collectionType);
+        TypeView<?> typeView = introspector().introspect(collectionType);
         Assertions.assertTrue(typeView.is(List.class));
         Assertions.assertEquals(1, typeView.typeParameters().allInput().count());
 

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/AbstractProxyOrchestrator.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/AbstractProxyOrchestrator.java
@@ -60,8 +60,8 @@ public abstract class AbstractProxyOrchestrator implements ProxyOrchestrator {
 
     @Override
     public <T> Option<ProxyManager<T>> manager(T instance) {
-        if (instance instanceof Proxy) {
-            Proxy<T> proxy = TypeUtils.adjustWildcards(instance, Proxy.class);
+        if (instance instanceof Proxy<?> proxyInstance) {
+            Proxy<T> proxy = TypeUtils.adjustWildcards(proxyInstance, Proxy.class);
             return Option.of(proxy.manager());
         }
         return Option.empty();

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/TypeUtils.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/TypeUtils.java
@@ -114,13 +114,12 @@ public class TypeUtils {
         return PRIMITIVE_WRAPPERS.get(primitive) == targetClass;
     }
 
-    public static <InstanceType, KeyType extends InstanceType, AdjustedType extends KeyType> AdjustedType adjustWildcards(InstanceType obj, Class<KeyType> type) {
+    public static <InstanceType extends KeyType, KeyType, AdjustedType extends KeyType> AdjustedType adjustWildcards(InstanceType obj, Class<KeyType> type) {
         if (obj == null) {
             return null;
         }
-        if (type.isAssignableFrom(obj.getClass()))
+        if (type.isAssignableFrom(obj.getClass())) {
             //noinspection unchecked
-        {
             return (AdjustedType) obj;
         }
         throw new IllegalArgumentException("Cannot adjust wildcards for " + obj.getClass().getName() + " to " + type.getName());
@@ -134,7 +133,7 @@ public class TypeUtils {
         Object instance = Proxy.newProxyInstance(annotationType.getClassLoader(),
                 new Class[]{ annotationType },
                 new MapBackedAnnotationInvocationHandler(annotationType, values == null ? Collections.emptyMap() : values));
-        return adjustWildcards(instance, annotationType);
+        return annotationType.cast(instance);
     }
 
     public static Stream<Integer> stream(int[] array) {

--- a/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/UtilitiesTests.java
+++ b/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/UtilitiesTests.java
@@ -16,6 +16,13 @@
 
 package test.org.dockbox.hartshorn.util;
 
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.dockbox.hartshorn.util.CollectionUtilities;
 import org.dockbox.hartshorn.util.NotPrimitiveException;
 import org.dockbox.hartshorn.util.StringUtilities;
@@ -27,15 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Stream;
 
 public class UtilitiesTests {
 

--- a/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/UtilitiesTests.java
+++ b/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/UtilitiesTests.java
@@ -283,18 +283,6 @@ public class UtilitiesTests {
     }
 
     @Test
-    void testInvalidWildcardAdjustment() {
-        List<?> list = Arrays.asList("one", "two", "three");
-        Assertions.assertThrows(IllegalArgumentException.class, () -> TypeUtils.adjustWildcards(list, Set.class));
-    }
-
-    @Test
-    void testWildcardAdjustmentDoesNotAdjustChild() {
-        List<?> list = Arrays.asList("one", "two", "three");
-        Assertions.assertThrows(IllegalArgumentException.class, () -> TypeUtils.adjustWildcards(list, ArrayList.class));
-    }
-
-    @Test
     void testWildcardAdjustmentDoesAdjustParent() {
         List<?> list = Arrays.asList("one", "two", "three");
         List<String> adjusted = Assertions.assertDoesNotThrow(() -> TypeUtils.adjustWildcards(list, Collection.class));


### PR DESCRIPTION
### Type of Change
- [x] Enhancement (non-breaking change that affects existing code)

### Description
In several locations we have long preferred explicit composite key types over `Class`-only identifiers. One location where we have not done this is for `Scope`s. As such, scopes appear rather primitive, even while being an important core element to switch IoC providers dynamically.

Scopes are expected to become increasingly complex objects as more modules are developed. A primary example of this is the expected web session support once Hartshorn Web is re-developed. As such, these changes define a key type for scopes, which can adapt to the complexity of scopes as they are expanded over time.

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] I have added documentation that describes my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1017

### Additional Notes
Follows up on draft #1014 
