### PR TITLE
#1029 Dependency upgrades November 2023

### DIFF
--- a/hartshorn-bom/pom.xml
+++ b/hartshorn-bom/pom.xml
@@ -19,23 +19,22 @@
 
     <properties>
         <!-- Language support, keep in sync with module parent -->
-        <groovy.version>4.0.15</groovy.version>
-        <kotlin.version>1.9.10</kotlin.version>
+        <groovy.version>4.0.16</groovy.version>
+        <kotlin.version>1.9.21</kotlin.version>
         <slf4j.version>2.0.9</slf4j.version>
 
         <!-- Versions in alphabetical order -->
-        <auto-service.version>1.1.1</auto-service.version>
         <compile-testing.version>0.21.0</compile-testing.version>
         <cglib.version>3.3.0</cglib.version>
-        <checker.version>3.39.0</checker.version>
+        <checker.version>3.40.0</checker.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <jackson.version>2.15.3</jackson.version>
+        <jackson.version>2.16.0</jackson.version>
         <jakarta.annotations.version>2.1.1</jakarta.annotations.version>
         <jakarta.inject.version>2.0.1</jakarta.inject.version>
         <javassist.version>3.29.2-GA</javassist.version>
-        <junit.version>5.10.0</junit.version>
-        <logback.version>1.4.11</logback.version>
-        <mockito.version>5.6.0</mockito.version>
+        <junit.version>5.10.1</junit.version>
+        <logback.version>1.4.13</logback.version>
+        <mockito.version>5.7.0</mockito.version>
         <scala.version>3.3.1</scala.version>
     </properties>
 
@@ -184,11 +183,6 @@
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
                 <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.auto.service</groupId>
-                <artifactId>auto-service</artifactId>
-                <version>${auto-service.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.testing.compile</groupId>

--- a/hartshorn-discovery/pom.xml
+++ b/hartshorn-discovery/pom.xml
@@ -21,12 +21,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.auto.service</groupId>
-            <artifactId>auto-service</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.testing.compile</groupId>
             <artifactId>compile-testing</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
### Type of Change
- [x] Chore (changes to the build process or auxiliary tools)

### Description
Updated:
* Groovy from 4.0.15 to 4.0.16
* Kotlin from 1.9.10 to 1.9.21
* Checker Framework from 3.39.0
* Jackson from 2.15.3 to 2.16.0
* JUnit from 5.10.0 to 5.10.1
* Logback from 1.4.11 to 1.4.13 (resolves [CVE-2023-6378](https://nvd.nist.gov/vuln/detail/CVE-2023-6378))
* Mockito from 5.6.0 to 5.7.0

Removes:
* AutoService 1.1.1 (unused)

### Related Issue
Closes #1029

See also #1032