### PR TITLE
#1036 Dependency upgrade December 2023

### DIFF
--- a/hartshorn-assembly/parent/pom.parent.xml
+++ b/hartshorn-assembly/parent/pom.parent.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <!-- Keep in sync with hartshorn-bom -->
-        <groovy.version>4.0.15</groovy.version>
-        <kotlin.version>1.9.10</kotlin.version>
+        <groovy.version>4.0.16</groovy.version>
+        <kotlin.version>1.9.21</kotlin.version>
         <scala.version>3.3.1</scala.version>
     </properties>
 
@@ -215,6 +215,7 @@
                         <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
                         <version>${groovy.version}</version>
+                        <type>pom</type>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/hartshorn-bom/pom.xml
+++ b/hartshorn-bom/pom.xml
@@ -21,21 +21,21 @@
         <!-- Language support, keep in sync with module parent -->
         <groovy.version>4.0.16</groovy.version>
         <kotlin.version>1.9.21</kotlin.version>
-        <slf4j.version>2.0.9</slf4j.version>
+        <scala.version>3.3.1</scala.version>
 
         <!-- Versions in alphabetical order -->
         <compile-testing.version>0.21.0</compile-testing.version>
         <cglib.version>3.3.0</cglib.version>
-        <checker.version>3.40.0</checker.version>
+        <checker.version>3.42.0</checker.version>
         <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.16.0</jackson.version>
         <jakarta.annotations.version>2.1.1</jakarta.annotations.version>
         <jakarta.inject.version>2.0.1</jakarta.inject.version>
-        <javassist.version>3.29.2-GA</javassist.version>
+        <javassist.version>3.30.1-GA</javassist.version>
         <junit.version>5.10.1</junit.version>
-        <logback.version>1.4.13</logback.version>
-        <mockito.version>5.7.0</mockito.version>
-        <scala.version>3.3.1</scala.version>
+        <logback.version>1.4.14</logback.version>
+        <mockito.version>5.8.0</mockito.version>
+        <slf4j.version>2.0.9</slf4j.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Type of Change
- [x] Chore (changes to the build process or auxiliary tools)

### Description
Checker Framework 3.40.0 to 3.42.0
Javassist 3.29.2-GA to 3.30.1-GA
Logback 1.4.13 to 1.4.14
Mockito 5.7.0 to 5.8.0

### Checklist
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1036