### PR TITLE
#1051 Configure capacity for supported collections

### DIFF
--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/CollectionDefaultValueProviderFactory.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/CollectionDefaultValueProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/CollectionDefaultValueProviderFactory.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/CollectionDefaultValueProviderFactory.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.convert.DefaultValueProvider;
 import org.dockbox.hartshorn.util.introspect.convert.DefaultValueProviderFactory;
+import org.dockbox.hartshorn.util.introspect.convert.support.collections.SimpleCollectionFactory;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.TypeParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
@@ -30,11 +31,11 @@ import org.dockbox.hartshorn.util.option.Option;
 public class CollectionDefaultValueProviderFactory implements DefaultValueProviderFactory<Collection<?>> {
 
     private final Introspector introspector;
-    private final CollectionFactory helperFactory;
+    private final SimpleCollectionFactory helperFactory;
 
     public CollectionDefaultValueProviderFactory(Introspector introspector) {
         this.introspector = introspector;
-        this.helperFactory = new CollectionFactory(introspector);
+        this.helperFactory = new SimpleCollectionFactory(introspector);
     }
 
     public <E, O extends Collection<E>> DefaultValueProvider<O> create(Class<O> targetType, Class<E> elementType) {
@@ -74,7 +75,7 @@ public class CollectionDefaultValueProviderFactory implements DefaultValueProvid
                 .map(Class.class::cast)
                 .orElse(Object.class);
 
-        return this.create((Class) targetType, (Class) componentType);
+        return this.create((Class) targetType, componentType);
     }
 
     public CollectionDefaultValueProviderFactory withDefaults() {

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/CollectionFactory.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/CollectionFactory.java
@@ -1,11 +1,58 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.util.introspect.convert.support.collections;
 
 import java.util.Collection;
+import org.dockbox.hartshorn.util.introspect.convert.DefaultValueProvider;
 
+/**
+ * A factory for creating collections of a given type, with a given element type. This is typically
+ * used to support {@link DefaultValueProvider}s for collections.
+ *
+ * @since 0.6.0
+ *
+ * @author Guus Lieben
+ */
 public interface CollectionFactory {
 
+    /**
+     * Creates a collection of the given type, with the given element type. The collection is
+     * guaranteed to be empty, and will have the default capacity for the collection type if
+     * applicable.
+     *
+     * @param targetType The type of the collection to create
+     * @param elementType The type of the elements in the collection
+     * @return The created collection
+     * @param <O> The type of the collection
+     * @param <E> The type of the elements in the collection
+     */
     <O extends Collection<E>, E> O createCollection(Class<O> targetType, Class<E> elementType);
 
+    /**
+     * Creates a collection of the given type, with the given element type. The collection is
+     * guaranteed to be empty, and will have (at least) the given capacity if applicable.
+     *
+     * @param targetType The type of the collection to create
+     * @param elementType The type of the elements in the collection
+     * @param length The capacity of the collection
+     * @return The created collection
+     * @param <O> The type of the collection
+     * @param <E> The type of the elements in the collection
+     */
     <O extends Collection<E>, E> O createCollection(Class<O> targetType, Class<E> elementType, int length);
 
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/CollectionFactory.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/CollectionFactory.java
@@ -1,0 +1,11 @@
+package org.dockbox.hartshorn.util.introspect.convert.support.collections;
+
+import java.util.Collection;
+
+public interface CollectionFactory {
+
+    <O extends Collection<E>, E> O createCollection(Class<O> targetType, Class<E> elementType);
+
+    <O extends Collection<E>, E> O createCollection(Class<O> targetType, Class<E> elementType, int length);
+
+}

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/CollectionProvider.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/CollectionProvider.java
@@ -1,10 +1,50 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.util.introspect.convert.support.collections;
 
 import java.util.Collection;
 
+/**
+ * A provider for creating collections of a given target type. This is typically used to support
+ * {@link org.dockbox.hartshorn.util.introspect.convert.DefaultValueProvider}s for collections.
+ *
+ * @param <T> The type of the collection
+ *
+ * @since 0.6.0
+ *
+ * @see CollectionFactory
+ *
+ * @author Guus Lieben
+ */
 public interface CollectionProvider<T extends Collection<?>> {
 
+    /**
+     * Creates an empty collection of the target type. The collection is guaranteed to be empty, and
+     * will have the default capacity for the collection type if applicable.
+     *
+     * @return The created collection
+     */
     T createEmpty();
 
+    /**
+     * Creates a collection of the target type, with (at least) the given capacity if applicable.
+     *
+     * @param capacity The capacity of the collection
+     * @return The created collection
+     */
     T createWithCapacity(int capacity);
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/CollectionProvider.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/CollectionProvider.java
@@ -1,0 +1,10 @@
+package org.dockbox.hartshorn.util.introspect.convert.support.collections;
+
+import java.util.Collection;
+
+public interface CollectionProvider<T extends Collection<?>> {
+
+    T createEmpty();
+
+    T createWithCapacity(int capacity);
+}

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/SimpleCollectionFactory.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/SimpleCollectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,15 @@ import org.dockbox.hartshorn.util.introspect.TypeConstructorsIntrospector;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.option.Option;
 
+/**
+ * Simple implementation of {@link CollectionFactory} that uses {@link CollectionProvider}s if possible, and
+ * otherwise will attempt to create collections using the default constructor or a constructor with a single
+ * int parameter (for capacity).
+ *
+ * @since 0.6.0
+ *
+ * @author Guus Lieben
+ */
 @SuppressWarnings("rawtypes")
 public class SimpleCollectionFactory implements CollectionFactory {
 

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/SupplierCollectionProvider.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/SupplierCollectionProvider.java
@@ -1,9 +1,38 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.util.introspect.convert.support.collections;
 
 import java.util.Collection;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
+/**
+ * A provider for creating collections of a given target type using a supplier for empty collections
+ * with the default capacity (if applicable), and an int function to create collections with a given
+ * capacity (if applicable).
+ *
+ * @param supplier The supplier to create empty collections
+ * @param capacityConstructor The constructor to create collections with a given capacity
+ * @param <T> The type of the collection
+ *
+ * @since 0.6.0
+ *
+ * @author Guus Lieben
+ */
 public record SupplierCollectionProvider<T extends Collection<?>>(
     Supplier<T> supplier,
     IntFunction<T> capacityConstructor

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/SupplierCollectionProvider.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/convert/support/collections/SupplierCollectionProvider.java
@@ -1,0 +1,21 @@
+package org.dockbox.hartshorn.util.introspect.convert.support.collections;
+
+import java.util.Collection;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+
+public record SupplierCollectionProvider<T extends Collection<?>>(
+    Supplier<T> supplier,
+    IntFunction<T> capacityConstructor
+) implements CollectionProvider<T> {
+
+    @Override
+    public T createEmpty() {
+        return this.supplier.get();
+    }
+
+    @Override
+    public T createWithCapacity(int capacity) {
+        return this.capacityConstructor.apply(capacity);
+    }
+}

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
@@ -16,11 +16,6 @@
 
 package test.org.dockbox.hartshorn.introspect.convert;
 
-import org.dockbox.hartshorn.util.introspect.Introspector;
-import org.dockbox.hartshorn.util.introspect.convert.support.CollectionFactory;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.beans.beancontext.BeanContext;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -32,35 +27,43 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.Vector;
+import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
+import org.dockbox.hartshorn.util.introspect.Introspector;
+import org.dockbox.hartshorn.util.introspect.convert.support.CollectionFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unchecked")
 public class CollectionFactoryTests {
 
     @Test
     public void testCreateCollectionWithArrayList() {
-        List<Integer> list = this.createDefaultFactory().createCollection(List.class, Integer.class, 10);
-        Assertions.assertTrue(list instanceof ArrayList);
+        List<Integer> list = this.createDefaultFactory().createCollection(List.class, Integer.class);
+        Assertions.assertInstanceOf(ArrayList.class, list);
         Assertions.assertEquals(list.size(), 0);
     }
 
     @Test
     public void testCreateCollectionWithHashSet() {
-        Set<String> set = this.createDefaultFactory().createCollection(Set.class, String.class, 5);
-        Assertions.assertTrue(set instanceof HashSet);
+        Set<String> set = this.createDefaultFactory().createCollection(Set.class, String.class);
+        Assertions.assertInstanceOf(HashSet.class, set);
         Assertions.assertEquals(set.size(), 0);
     }
 
     @Test
     public void testCreateCollectionWithTreeSet() {
-        SortedSet<Double> sortedSet = this.createDefaultFactory().createCollection(SortedSet.class, Double.class, 3);
-        Assertions.assertTrue(sortedSet instanceof TreeSet);
+        SortedSet<Double> sortedSet = this.createDefaultFactory().createCollection(SortedSet.class, Double.class);
+        Assertions.assertInstanceOf(TreeSet.class, sortedSet);
         Assertions.assertEquals(sortedSet.size(), 0);
     }
 
     @Test
     public void testCreateCollectionWithLinkedList() {
-        Queue<Boolean> queue = this.createDefaultFactory().createCollection(Queue.class, Boolean.class, 7);
-        Assertions.assertTrue(queue instanceof LinkedList);
+        Queue<Boolean> queue = this.createDefaultFactory().createCollection(Queue.class, Boolean.class);
+        Assertions.assertInstanceOf(LinkedList.class, queue);
         Assertions.assertEquals(queue.size(), 0);
     }
 
@@ -68,8 +71,18 @@ public class CollectionFactoryTests {
     public void testCreateCollectionWithEnumSet() {
         CollectionFactory factory = this.createFactory(EnumSet.class, () -> null);
         EnumSet<Color> enumSet = factory.createCollection(EnumSet.class, Color.class, 2);
-        Assertions.assertTrue(enumSet instanceof EnumSet);
+        Assertions.assertInstanceOf(EnumSet.class, enumSet);
         Assertions.assertEquals(enumSet.size(), 0);
+    }
+
+    @Test
+    public void testInitialCapacityIsConfigured() {
+        int initialCapacity = 23;
+        CollectionFactory factory = this.createFactory(Vector.class, Vector::new, Vector::new);
+        Vector<String> enumSet = factory.createCollection(Vector.class, String.class, initialCapacity);
+        Assertions.assertInstanceOf(Vector.class, enumSet);
+        Assertions.assertEquals(enumSet.size(), 0);
+        Assertions.assertEquals(enumSet.capacity(), initialCapacity);
     }
 
     @Test
@@ -82,12 +95,17 @@ public class CollectionFactoryTests {
     public void testCreateCollectionWithConcreteImplementation() {
         CollectionFactory factory = this.createFactory(LinkedList.class, LinkedList::new);
         List<Integer> list = factory.createCollection(LinkedList.class, Integer.class, 0);
-        Assertions.assertTrue(list instanceof LinkedList);
+        Assertions.assertInstanceOf(LinkedList.class, list);
         Assertions.assertEquals(list.size(), 0);
     }
-    
+
     private <T extends Collection<?>> CollectionFactory createFactory(Class<T> targetType, Supplier<T> constructor) {
         Introspector introspector = ConverterIntrospectionHelper.createIntrospectorForCollection(targetType, constructor);
+        return new CollectionFactory(introspector);
+    }
+
+    private <T extends Collection<?>> CollectionFactory createFactory(Class<T> targetType, Supplier<T> constructor, IntFunction<T> capacityConstructor) {
+        Introspector introspector = ConverterIntrospectionHelper.createIntrospectorForCollection(targetType, constructor, capacityConstructor);
         return new CollectionFactory(introspector);
     }
 

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
@@ -32,7 +32,8 @@ import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
 import org.dockbox.hartshorn.util.introspect.Introspector;
-import org.dockbox.hartshorn.util.introspect.convert.support.CollectionFactory;
+import org.dockbox.hartshorn.util.introspect.convert.support.collections.CollectionFactory;
+import org.dockbox.hartshorn.util.introspect.convert.support.collections.SimpleCollectionFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -101,16 +102,16 @@ public class CollectionFactoryTests {
 
     private <T extends Collection<?>> CollectionFactory createFactory(Class<T> targetType, Supplier<T> constructor) {
         Introspector introspector = ConverterIntrospectionHelper.createIntrospectorForCollection(targetType, constructor);
-        return new CollectionFactory(introspector);
+        return new SimpleCollectionFactory(introspector);
     }
 
     private <T extends Collection<?>> CollectionFactory createFactory(Class<T> targetType, Supplier<T> constructor, IntFunction<T> capacityConstructor) {
         Introspector introspector = ConverterIntrospectionHelper.createIntrospectorForCollection(targetType, constructor, capacityConstructor);
-        return new CollectionFactory(introspector);
+        return new SimpleCollectionFactory(introspector);
     }
 
     private CollectionFactory createDefaultFactory() {
-        return new CollectionFactory(null).withDefaults();
+        return new SimpleCollectionFactory(null).withDefaults();
     }
 
     enum Color {

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConverterIntrospectionHelper.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConverterIntrospectionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConverterIntrospectionHelper.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConverterIntrospectionHelper.java
@@ -19,6 +19,7 @@ package test.org.dockbox.hartshorn.introspect.convert;
 import java.lang.reflect.Constructor;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
 import org.dockbox.hartshorn.util.introspect.Introspector;
@@ -34,7 +35,27 @@ import org.mockito.Mockito;
 public class ConverterIntrospectionHelper {
 
     public static <T extends Collection<?>> Introspector createIntrospectorForCollection(Class<T> type, Supplier<T> supplier) {
+        return createIntrospectorForCollection(type, supplier, capacity -> Assertions.fail("Unexpected call to capacity constructor"));
+    }
+
+    public static <T extends Collection<?>> Introspector createIntrospectorForCollection(Class<T> type, Supplier<T> supplier, IntFunction<T> capacityConstructor) {
         TypeConstructorsIntrospector<T> constructors = Mockito.mock(TypeConstructorsIntrospector.class);
+        configureDefaultConstructor(type, supplier, constructors);
+        configureInitialCapacityConstructor(type, capacityConstructor, constructors);
+
+        TypeParametersIntrospector parametersIntrospector = Mockito.mock(TypeParametersIntrospector.class);
+        Mockito.when(parametersIntrospector.resolveInputFor(Collection.class)).thenReturn(new SimpleTypeParameterList(List.of()));
+
+        TypeView<T> typeView = Mockito.mock(TypeView.class);
+        Mockito.when(typeView.constructors()).thenReturn(constructors);
+        Mockito.when(typeView.typeParameters()).thenReturn(parametersIntrospector);
+
+        Introspector introspector = Mockito.mock(Introspector.class);
+        Mockito.when(introspector.introspect(type)).thenReturn(typeView);
+        return introspector;
+    }
+
+    private static <T extends Collection<?>> void configureDefaultConstructor(Class<T> type, Supplier<T> supplier, TypeConstructorsIntrospector<T> constructors) {
         try {
             Constructor<T> defaultConstructor = type.getConstructor();
             Assertions.assertNotNull(defaultConstructor);
@@ -53,17 +74,27 @@ public class ConverterIntrospectionHelper {
         catch (NoSuchMethodException e) {
             Mockito.when(constructors.defaultConstructor()).thenReturn(Option.empty());
         }
+    }
 
-        TypeParametersIntrospector parametersIntrospector = Mockito.mock(TypeParametersIntrospector.class);
-        Mockito.when(parametersIntrospector.resolveInputFor(Collection.class)).thenReturn(new SimpleTypeParameterList(List.of()));
+    private static <T extends Collection<?>> void configureInitialCapacityConstructor(Class<T> type, IntFunction<T> supplier, TypeConstructorsIntrospector<T> constructors) {
+        try {
+            Constructor<T> capacityConstructor = type.getConstructor(int.class);
+            Assertions.assertNotNull(capacityConstructor);
 
-        TypeView<T> typeView = Mockito.mock(TypeView.class);
-        Mockito.when(typeView.constructors()).thenReturn(constructors);
-        Mockito.when(typeView.typeParameters()).thenReturn(parametersIntrospector);
+            ConstructorView<T> constructorView = Mockito.mock(ConstructorView.class);
+            Mockito.when(constructorView.constructor()).thenReturn(Option.of(capacityConstructor));
+            try {
+                Mockito.when(constructorView.create(Mockito.anyInt())).thenAnswer(invocation -> Option.of(supplier.apply((int) invocation.getArguments()[0])));
+            }
+            catch (Throwable throwable) {
+                Assertions.fail("On-going stub yielded an unexpected exception", throwable);
+            }
 
-        Introspector introspector = Mockito.mock(Introspector.class);
-        Mockito.when(introspector.introspect(type)).thenReturn(typeView);
-        return introspector;
+            Mockito.when(constructors.withParameters(int.class)).thenReturn(Option.of(constructorView));
+        }
+        catch (NoSuchMethodException e) {
+            Mockito.when(constructors.withParameters(int.class)).thenReturn(Option.empty());
+        }
     }
 
     public static <T extends Collection<?>> Introspector createIntrospectorForCollection(Class<T> type) {


### PR DESCRIPTION
### Type of Change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)
- [x] Enhancement (non-breaking change that affects existing code)

### Description
The `CollectionFactory#createCollection` has an argument `length` to indicate the initial capacity of the collection. This argument was however never used. These changes resolve this, and add additional support for custom defaults to also be capacity aware if applicable.

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] I have added documentation that describes my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1051