### PR TITLE
#1065 Allow access to `InjectionPoint` from providers

### DIFF
--- a/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/ConfigurationManagerTests.java
+++ b/hartshorn-config/src/testFixtures/java/test/org/dockbox/hartshorn/config/ConfigurationManagerTests.java
@@ -28,6 +28,7 @@ import org.dockbox.hartshorn.config.ObjectMapper;
 import org.dockbox.hartshorn.config.ObjectMappingException;
 import org.dockbox.hartshorn.config.annotations.UseConfigurations;
 import org.dockbox.hartshorn.config.properties.PropertyHolder;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.dockbox.hartshorn.testsuite.TestComponents;
 import org.junit.jupiter.api.Assertions;
@@ -120,7 +121,11 @@ public abstract class ConfigurationManagerTests {
                     fs: "This is a value"
                     """);
 
-        ComponentProcessingContext<DemoFSConfiguration> processingContext = new ComponentProcessingContext<>(this.applicationContext, ComponentKey.of(DemoFSConfiguration.class), null, false);
+        ComponentProcessingContext<DemoFSConfiguration> processingContext = new ComponentProcessingContext<>(
+                this.applicationContext,
+                ComponentRequestContext.createForComponent(),
+                ComponentKey.of(DemoFSConfiguration.class),
+                null, false);
         new ConfigurationServicePreProcessor().process(this.applicationContext, processingContext);
 
         DemoFSConfiguration configuration = this.applicationContext.get(DemoFSConfiguration.class);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ContextualEnvironmentBinderConfiguration.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ContextualEnvironmentBinderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ContextualEnvironmentBinderConfiguration.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ContextualEnvironmentBinderConfiguration.java
@@ -32,7 +32,6 @@ import org.dockbox.hartshorn.proxy.ProxyOrchestrator;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.ProxyLookup;
 import org.dockbox.hartshorn.util.introspect.annotations.AnnotationLookup;
-import org.slf4j.Logger;
 
 /**
  * The default {@link EnvironmentBinderConfiguration} used by the {@link DelegatingApplicationContext}. This configuration
@@ -87,9 +86,6 @@ public class ContextualEnvironmentBinderConfiguration implements EnvironmentBind
         if (environment instanceof ObservableApplicationEnvironment observableEnvironment) {
             binder.bind(LifecycleObservable.class).singleton(observableEnvironment);
         }
-
-        // Dynamic components
-        binder.bind(Logger.class).to(environment.applicationContext()::log);
 
         // Custom default bindings. Runs last to allow for modification of default bindings.
         configurer.configure(binder);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
@@ -39,6 +39,7 @@ import org.dockbox.hartshorn.component.ScopeAwareComponentProvider;
 import org.dockbox.hartshorn.component.TypeReferenceLookupComponentLocator;
 import org.dockbox.hartshorn.context.DefaultApplicationAwareContext;
 import org.dockbox.hartshorn.context.ModifiableContextCarrier;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.binding.Binder;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
@@ -179,8 +180,8 @@ public abstract class DelegatingApplicationContext extends DefaultApplicationAwa
     }
 
     @Override
-    public <T> T get(ComponentKey<T> key) {
-        return this.componentProvider.get(key);
+    public <T> T get(ComponentKey<T> key, ComponentRequestContext requestContext) {
+        return this.componentProvider.get(key, requestContext);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/SimpleApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/SimpleApplicationContext.java
@@ -33,6 +33,7 @@ import org.dockbox.hartshorn.component.processing.ComponentProcessor;
 import org.dockbox.hartshorn.component.processing.ExitingComponentProcessor;
 import org.dockbox.hartshorn.inject.ComponentContainerDependencyDeclarationContext;
 import org.dockbox.hartshorn.inject.ComponentInitializationException;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.DependencyDeclarationContext;
 import org.dockbox.hartshorn.inject.DependencyResolutionException;
 import org.dockbox.hartshorn.inject.PostProcessorDependencyDeclarationContext;
@@ -188,8 +189,11 @@ public class SimpleApplicationContext extends DelegatingApplicationContext imple
     private void processStandaloneComponent(ComponentContainer<?> container, ComponentPreProcessor serviceProcessor) {
         TypeView<?> service = container.type();
         ComponentKey<?> key = ComponentKey.of(service.type());
-        ComponentProcessingContext<?> context = new ComponentProcessingContext<>(this, key, null, container.permitsProxying());
         this.log().debug("Processing component %s with registered processor %s".formatted(container.id(), serviceProcessor.getClass().getSimpleName()));
+        ComponentProcessingContext<?> context = new ComponentProcessingContext<>(
+                this, ComponentRequestContext.createForComponent(),
+                key, null, container.permitsProxying()
+        );
         serviceProcessor.process(context);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ApplicationConfiguration.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ApplicationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ApplicationConfiguration.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ApplicationConfiguration.java
@@ -17,19 +17,22 @@
 package org.dockbox.hartshorn.component;
 
 import org.dockbox.hartshorn.application.UseBootstrap;
-import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
+import org.dockbox.hartshorn.component.populate.inject.InjectionPoint;
 import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.inject.Strict;
 import org.dockbox.hartshorn.inject.binding.collection.ComponentCollection;
-import org.dockbox.hartshorn.logging.LogExclude;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.ConverterFactory;
 import org.dockbox.hartshorn.util.introspect.convert.GenericConverter;
 import org.dockbox.hartshorn.util.introspect.convert.StandardConversionService;
+import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
+import org.dockbox.hartshorn.util.introspect.view.FieldView;
+import org.dockbox.hartshorn.util.introspect.view.ParameterView;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.inject.Singleton;
 
@@ -42,12 +45,17 @@ import jakarta.inject.Singleton;
  */
 @Configuration
 @RequiresActivator(UseBootstrap.class)
-@LogExclude
 public class ApplicationConfiguration {
 
     @Binds
-    public Logger logger(ApplicationContext context) {
-        return context.log();
+    public Logger logger(InjectionPoint injectionPoint) {
+        Class<?> declaringType = switch(injectionPoint.injectionPoint()) {
+            case ExecutableElementView<?> executableElementView -> executableElementView.declaredBy().type();
+            case FieldView<?, ?> fieldView -> fieldView.declaredBy().type();
+            case ParameterView<?> parameterView -> parameterView.declaredBy().declaredBy().type();
+            default -> throw new IllegalStateException("Unexpected value: " + injectionPoint.injectionPoint());
+        };
+        return LoggerFactory.getLogger(declaringType);
     }
 
     @Binds
@@ -59,7 +67,7 @@ public class ApplicationConfiguration {
             @Strict(false) ComponentCollection<Converter<?, ?>> converters
     ) {
         StandardConversionService service = new StandardConversionService(introspector).withDefaults();
-        
+
         genericConverters.forEach(service::addConverter);
         converterFactories.forEach(service::addConverterFactory);
         converters.forEach(service::addConverter);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentKey.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.component;
 import java.util.Objects;
 import java.util.Set;
 
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.HighestPriorityProviderSelectionStrategy;
 import org.dockbox.hartshorn.inject.ProviderSelectionStrategy;
 import org.dockbox.hartshorn.inject.binding.collection.ComponentCollection;
@@ -40,6 +41,7 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
  * <p>Keys are immutable, to build a new key based on an existing key, use {@link #mutable()}.
  *
  * @see ComponentProvider#get(ComponentKey)
+ * @see ComponentProvider#get(ComponentKey, ComponentRequestContext)
  * @see ComponentKey#builder(Class)
  *
  * @param <T> the type of the component

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentProvider.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.component;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 
 /**
  * A component provider is a class that is capable of providing components. Components are identified using
@@ -43,10 +44,15 @@ public interface ComponentProvider {
     /**
      * Returns the component for the given key.
      * @param key The key of the component to return.
+     * @param requestContext The context in which the component is requested.
      * @param <T> The type of the component to return.
      * @return The component for the given key.
      */
-    <T> T get(ComponentKey<T> key);
+    <T> T get(ComponentKey<T> key, ComponentRequestContext requestContext);
+
+    default <T> T get(ComponentKey<T> key) {
+        return get(key, ComponentRequestContext.createForComponent());
+    }
 
     /**
      * Returns the component for the given type and name metadata. If {@code named} is null, the given

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentProvider.java
@@ -42,26 +42,52 @@ import org.dockbox.hartshorn.inject.ComponentRequestContext;
 public interface ComponentProvider {
 
     /**
-     * Returns the component for the given key.
+     * Returns the component for the given key, using the request context to determine the
+     * use case for the component. The request context may be used to provide additional
+     * information to the provider, such as the current component that is being resolved.
+     *
+     * <p>Both parameters are used to determine the appropriate state of the returned
+     * component. The {@link ComponentKey key} describes the component itself, whereas the
+     * {@link ComponentRequestContext request context} describes the use case for the
+     * component.
+     *
+     * <p>Note that singleton components are typically resolved using the default request
+     * context, and ignore the given request context.
+     *
      * @param key The key of the component to return.
-     * @param requestContext The context in which the component is requested.
-     * @param <T> The type of the component to return.
+     * @param requestContext The request context to use for resolving the component.
+     *
      * @return The component for the given key.
+     *
+     * @param <T> The type of the component to return.
      */
     <T> T get(ComponentKey<T> key, ComponentRequestContext requestContext);
 
+    /**
+     * Returns the component for the given key.
+     *
+     * @param key The key of the component to return.
+     * @param <T> The type of the component to return.
+     *
+     * @return The component for the given key.
+     */
     default <T> T get(ComponentKey<T> key) {
-        return get(key, ComponentRequestContext.createForComponent());
+        return this.get(key, ComponentRequestContext.createForComponent());
     }
 
     /**
      * Returns the component for the given type and name metadata. If {@code named} is null, the given
      * {@link Class} is used to identify the component.
+     *
      * @param type The type of the component to return.
      * @param qualifiers The metadata of the component to return.
      * @param <T> The type of the component to return.
+     *
      * @return The component for the given type and name metadata.
+     *
+     * @deprecated Use {@link #get(ComponentKey)} instead.
      */
+    @Deprecated(since = "0.6.0", forRemoval = true)
     default <T> T get(Class<T> type, QualifierKey<?>... qualifiers) {
         ComponentKey<T> key = ComponentKey.builder(type).qualifiers(qualifiers).build();
         return this.get(key);
@@ -69,12 +95,39 @@ public interface ComponentProvider {
 
     /**
      * Returns the component for the given type.
+     *
      * @param type The type of the component to return.
      * @param <T> The type of the component to return.
+     *
      * @return The component for the given type.
      */
     default <T> T get(Class<T> type) {
         ComponentKey<T> key = ComponentKey.of(type);
         return this.get(key);
+    }
+
+    /**
+     * Returns the component for the given type, using the request context to determine the
+     * use case for the component. The request context may be used to provide additional
+     * information to the provider, such as the current component that is being resolved.
+     *
+     * <p>Both parameters are used to determine the appropriate state of the returned
+     * component. The {@link Class type} describes the component itself, whereas the
+     * {@link ComponentRequestContext request context} describes the use case for the
+     * component.
+     *
+     * <p>Note that singleton components are typically resolved using the default request
+     * context, and ignore the given request context.
+     *
+     * @param type The type of the component to return.
+     * @param requestContext The request context to use for resolving the component.
+     *
+     * @return The component for the given type.
+     *
+     * @param <T> The type of the component to return.
+     */
+    default <T> T get(Class<T> type, ComponentRequestContext requestContext) {
+        ComponentKey<T> key = ComponentKey.of(type);
+        return this.get(key, requestContext);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ContextDrivenComponentInstanceFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ContextDrivenComponentInstanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ContextDrivenComponentInstanceFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ContextDrivenComponentInstanceFactory.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.component;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.ContextDrivenProvider;
 import org.dockbox.hartshorn.inject.ObjectContainer;
 import org.dockbox.hartshorn.inject.binding.ComponentInstanceFactory;
@@ -32,7 +33,7 @@ public class ContextDrivenComponentInstanceFactory implements ComponentInstanceF
     }
 
     @Override
-    public <T> Option<ObjectContainer<T>> instantiate(ComponentKey<T> key) throws ApplicationException {
-        return new ContextDrivenProvider<>(key).provide(this.applicationContext);
+    public <T> Option<ObjectContainer<T>> instantiate(ComponentKey<T> key, ComponentRequestContext requestContext) throws ApplicationException {
+        return new ContextDrivenProvider<>(key).provide(this.applicationContext, requestContext);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAwareComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAwareComponentProvider.java
@@ -28,6 +28,7 @@ import org.dockbox.hartshorn.application.DefaultBindingConfigurerContext;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
 import org.dockbox.hartshorn.context.DefaultProvisionContext;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.binding.Binder;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
@@ -144,8 +145,8 @@ public class ScopeAwareComponentProvider extends DefaultProvisionContext impleme
     }
 
     @Override
-    public <T> T get(ComponentKey<T> componentKey) {
-        return this.getOrCreateProvider(componentKey.scope()).get(componentKey);
+    public <T> T get(ComponentKey<T> key, ComponentRequestContext requestContext) {
+        return this.getOrCreateProvider(key.scope()).get(key, requestContext);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAwareComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAwareComponentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/AbstractComponentPopulationStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/AbstractComponentPopulationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/AbstractComponentPopulationStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/AbstractComponentPopulationStrategy.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentRequiredException;
+import org.dockbox.hartshorn.component.ComponentResolutionException;
 import org.dockbox.hartshorn.component.populate.inject.InjectionPoint;
 import org.dockbox.hartshorn.component.populate.inject.RequireInjectionPointRule;
 import org.dockbox.hartshorn.context.ContextCarrier;
@@ -94,7 +95,7 @@ public abstract class AbstractComponentPopulationStrategy implements ComponentPo
             }
             catch(ApplicationException | ApplicationRuntimeException e) {
                 if (this.shouldRequire(point)) {
-                    throw new ComponentRequiredException("Could not resolve value for injection point " + point.injectionPoint().qualifiedName(), e);
+                    throw new ComponentResolutionException("Could not resolve value for injection point " + point.injectionPoint().qualifiedName(), e);
                 }
                 else {
                     this.applicationContext().handle(e);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectPopulationStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectPopulationStrategy.java
@@ -24,6 +24,7 @@ import org.dockbox.hartshorn.component.populate.ComponentInjectionPoint;
 import org.dockbox.hartshorn.component.populate.ComponentPopulationStrategy;
 import org.dockbox.hartshorn.component.populate.PopulateComponentContext;
 import org.dockbox.hartshorn.inject.ComponentKeyResolver;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.util.ContextualInitializer;
 import org.dockbox.hartshorn.util.Customizer;
 import org.dockbox.hartshorn.util.Lazy;
@@ -110,7 +111,8 @@ public class InjectPopulationStrategy extends AbstractComponentPopulationStrateg
         }
 
         ComponentKey<?> componentKey = this.applicationContext().environment().componentKeyResolver().resolve(injectionPoint.injectionPoint());
-        Object component = this.applicationContext().get(componentKey);
+        ComponentRequestContext requestContext = ComponentRequestContext.createForInjectionPoint(injectionPoint);
+        Object component = this.applicationContext().get(componentKey, requestContext);
 
         // Ensure types are compatible, or a default value is provided if it is available. This primarily
         // applies to component collections.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentProcessingContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentProcessingContext.java
@@ -34,8 +34,8 @@ public class ComponentProcessingContext<T> extends DefaultApplicationAwareContex
     private final ComponentRequestContext requestContext;
     private final Map<ComponentKey<?>, Object> data;
     private final boolean permitsProxying;
+    private final ComponentKey<T> key;
 
-    protected ComponentKey<T> key;
     protected T instance;
 
     public ComponentProcessingContext(ApplicationContext applicationContext, ComponentRequestContext requestContext, ComponentKey<T> key, T instance, boolean permitsProxying) {
@@ -45,6 +45,10 @@ public class ComponentProcessingContext<T> extends DefaultApplicationAwareContex
         this.instance = instance;
         this.data = new ConcurrentHashMap<>();
         this.permitsProxying = permitsProxying;
+    }
+
+    public ComponentRequestContext requestContext() {
+        return this.requestContext;
     }
 
     public ComponentKey<T> key() {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentProcessingContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentProcessingContext.java
@@ -26,18 +26,21 @@ import java.util.function.Function;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.context.DefaultApplicationAwareContext;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
 public class ComponentProcessingContext<T> extends DefaultApplicationAwareContext {
 
+    private final ComponentRequestContext requestContext;
     private final Map<ComponentKey<?>, Object> data;
     private final boolean permitsProxying;
 
     protected ComponentKey<T> key;
     protected T instance;
 
-    public ComponentProcessingContext(ApplicationContext applicationContext, ComponentKey<T> key, T instance, boolean permitsProxying) {
+    public ComponentProcessingContext(ApplicationContext applicationContext, ComponentRequestContext requestContext, ComponentKey<T> key, T instance, boolean permitsProxying) {
         super(applicationContext);
+        this.requestContext = requestContext;
         this.key = key;
         this.instance = instance;
         this.data = new ConcurrentHashMap<>();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ModifiableComponentProcessingContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ModifiableComponentProcessingContext.java
@@ -20,6 +20,7 @@ import java.util.function.Consumer;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.util.IllegalModificationException;
 
 public class ModifiableComponentProcessingContext<T> extends ComponentProcessingContext<T> {
@@ -28,8 +29,9 @@ public class ModifiableComponentProcessingContext<T> extends ComponentProcessing
     private boolean requestInstanceLock = false;
 
     public ModifiableComponentProcessingContext(ApplicationContext applicationContext, ComponentKey<T> key,
-                                                T instance, boolean permitsProxying, Consumer<T> onLockRequested) {
-        super(applicationContext, key, instance, permitsProxying);
+            ComponentRequestContext requestContext,
+            T instance, boolean permitsProxying, Consumer<T> onLockRequested) {
+        super(applicationContext, requestContext, key, instance, permitsProxying);
         this.onLockRequested = onLockRequested;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/proxy/ContextMethodPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/proxy/ContextMethodPostProcessor.java
@@ -18,11 +18,15 @@ package org.dockbox.hartshorn.component.processing.proxy;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.component.populate.ComponentMethodInjectionPoint;
+import org.dockbox.hartshorn.component.populate.inject.InjectionPoint;
 import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.component.processing.ProcessingPriority;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.proxy.advice.intercept.MethodInterceptor;
 import org.dockbox.hartshorn.inject.Provided;
 import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
+import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
 public class ContextMethodPostProcessor extends ServiceAnnotatedMethodInterceptorPostProcessor<Provided> {
@@ -33,15 +37,23 @@ public class ContextMethodPostProcessor extends ServiceAnnotatedMethodIntercepto
         Provided annotation = methodContext.annotation(Provided.class);
         String name = annotation.value();
 
+        MethodView<T, ?> method = methodContext.method();
+
         //noinspection unchecked
-        TypeView<R> type = (TypeView<R>) methodContext.method().returnType();
+        TypeView<R> type = (TypeView<R>) method.returnType();
         ComponentKey<?> key = ComponentKey.of(type);
         if (!name.isEmpty()) {
             key = key.mutable().name(name).build();
         }
 
+        InjectionPoint injectionPoint = new InjectionPoint(method);
+        ComponentRequestContext requestContext = ComponentRequestContext.createForInjectionPoint(injectionPoint);
+
         ComponentKey<?> finalKey = key;
-        return interceptorContext -> conversionService.convert(context.get(finalKey), type.type());
+        return interceptorContext -> {
+            Object result = context.get(finalKey, requestContext);
+            return conversionService.convert(result, type.type());
+        };
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ContextKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ContextKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ContextKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ContextKey.java
@@ -19,7 +19,6 @@ package org.dockbox.hartshorn.context;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.Scope;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AutoConfiguringDependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AutoConfiguringDependencyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AutoConfiguringDependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/AutoConfiguringDependencyContext.java
@@ -23,7 +23,6 @@ import org.dockbox.hartshorn.component.processing.Binds.BindingType;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
 import org.dockbox.hartshorn.inject.binding.IllegalScopeException;
 import org.dockbox.hartshorn.util.ApplicationException;
-import org.dockbox.hartshorn.util.function.CheckedSupplier;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.View;
 
@@ -46,12 +45,12 @@ import org.dockbox.hartshorn.util.introspect.view.View;
  */
 public class AutoConfiguringDependencyContext<T> extends AbstractDependencyContext<T> {
 
-    private final CheckedSupplier<T> supplier;
+    private final ContextAwareComponentSupplier<T> supplier;
     private final View view;
 
     public AutoConfiguringDependencyContext(ComponentKey<T> componentKey, DependencyMap dependencies,
                                             ScopeKey scope, int priority, BindingType bindingType,
-                                            View view, CheckedSupplier<T> supplier) {
+                                            View view, ContextAwareComponentSupplier<T> supplier) {
         super(componentKey, dependencies, scope, priority, bindingType);
         this.supplier = supplier;
         this.view = view;
@@ -83,8 +82,8 @@ public class AutoConfiguringDependencyContext<T> extends AbstractDependencyConte
             try {
                 switch(instanceType) {
                 case SUPPLIER -> collector.supplier(this.supplier);
-                case SINGLETON -> collector.singleton(this.supplier.get());
-                case LAZY_SINGLETON -> collector.lazySingleton(this.supplier);
+                case SINGLETON -> collector.singleton(this.supplier.get(ComponentRequestContext.createForComponent()));
+                case LAZY_SINGLETON -> collector.lazySingleton(() -> this.supplier.get(ComponentRequestContext.createForComponent()));
                 }
             }
             catch(ApplicationException e) {
@@ -98,8 +97,8 @@ public class AutoConfiguringDependencyContext<T> extends AbstractDependencyConte
         try {
             switch (instanceType) {
                 case SUPPLIER -> function.to(this.supplier);
-                case SINGLETON -> function.singleton(this.supplier.get());
-                case LAZY_SINGLETON -> function.lazySingleton(this.supplier);
+                case SINGLETON -> function.singleton(this.supplier.get(ComponentRequestContext.createForComponent()));
+                case LAZY_SINGLETON -> function.lazySingleton(() -> this.supplier.get(ComponentRequestContext.createForComponent()));
             }
         }
         catch (ApplicationException e) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentRequestContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentRequestContext.java
@@ -1,8 +1,40 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.inject;
 
+import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.populate.inject.InjectionPoint;
 import org.dockbox.hartshorn.context.DefaultContext;
 
+/**
+ * A context that is used to provide information about the current component request. This gives additional
+ * insights of <i>where</i> a component will be used, contrary to a {@link ComponentKey} which describes the
+ * component itself.
+ *
+ * <p>The target of the request context is typically an injection point, but it may also be used to describe
+ * the use case of a component in other scenarios through custom context implementations.
+ *
+ * @since 0.6.0
+ *
+ * @see InjectionPoint
+ * @see ComponentKey
+ *
+ * @author Guus Lieben
+ */
 public final class ComponentRequestContext extends DefaultContext {
 
     private final InjectionPoint injectionPoint;
@@ -11,18 +43,42 @@ public final class ComponentRequestContext extends DefaultContext {
         this.injectionPoint = injectionPoint;
     }
 
+    /**
+     * Creates a new {@link ComponentRequestContext} for the given injection point.
+     *
+     * @param injectionPoint The injection point for which the request context is created.
+     * @return A new request context for the given injection point.
+     */
     public static ComponentRequestContext createForInjectionPoint(InjectionPoint injectionPoint) {
         return new ComponentRequestContext(injectionPoint);
     }
 
+    /**
+     * Creates a new {@link ComponentRequestContext} for a component that is not used in a specific injection
+     * point, or for a component that is used in an unknown context.
+     *
+     * @return A new request context for a component.
+     */
     public static ComponentRequestContext createForComponent() {
         return new ComponentRequestContext(null);
     }
 
+    /**
+     * Returns the injection point for which the request context was created. If the request context was created
+     * for a component that is not used in a specific injection point, this method will return {@code null}.
+     *
+     * @return The injection point for which the request context was created, or {@code null} if the request context
+     * was created for a component.
+     */
     public InjectionPoint injectionPoint() {
         return this.injectionPoint;
     }
 
+    /**
+     * Returns whether the request context was created for a specific injection point.
+     *
+     * @return {@code true} if the request context was created for a specific injection point, {@code false} otherwise.
+     */
     public boolean isForInjectionPoint() {
         return this.injectionPoint != null;
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentRequestContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComponentRequestContext.java
@@ -1,0 +1,29 @@
+package org.dockbox.hartshorn.inject;
+
+import org.dockbox.hartshorn.component.populate.inject.InjectionPoint;
+import org.dockbox.hartshorn.context.DefaultContext;
+
+public final class ComponentRequestContext extends DefaultContext {
+
+    private final InjectionPoint injectionPoint;
+
+    private ComponentRequestContext(InjectionPoint injectionPoint) {
+        this.injectionPoint = injectionPoint;
+    }
+
+    public static ComponentRequestContext createForInjectionPoint(InjectionPoint injectionPoint) {
+        return new ComponentRequestContext(injectionPoint);
+    }
+
+    public static ComponentRequestContext createForComponent() {
+        return new ComponentRequestContext(null);
+    }
+
+    public InjectionPoint injectionPoint() {
+        return this.injectionPoint;
+    }
+
+    public boolean isForInjectionPoint() {
+        return this.injectionPoint != null;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComposedProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComposedProvider.java
@@ -69,8 +69,8 @@ public final class ComposedProvider<T> implements Provider<T> {
     }
 
     @Override
-    public Option<ObjectContainer<T>> provide(ApplicationContext context) throws ApplicationException {
-        return this.provider.provide(context)
+    public Option<ObjectContainer<T>> provide(ApplicationContext context, ComponentRequestContext requestContext) throws ApplicationException {
+        return this.provider.provide(context, requestContext)
                 .map(this::doMapContainer);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComposedProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ComposedProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextAwareComponentSupplier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextAwareComponentSupplier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.inject;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextAwareComponentSupplier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextAwareComponentSupplier.java
@@ -1,0 +1,16 @@
+package org.dockbox.hartshorn.inject;
+
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.option.Option;
+
+@FunctionalInterface
+public interface ContextAwareComponentSupplier<T> extends NonTypeAwareProvider<T> {
+
+    @Override
+    default Option<ObjectContainer<T>> provide(ApplicationContext context, ComponentRequestContext requestContext) throws ApplicationException {
+        return Option.of(new ComponentObjectContainer<>(this.get(requestContext)));
+    }
+
+    T get(ComponentRequestContext context) throws ApplicationException;
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextDrivenProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextDrivenProvider.java
@@ -18,6 +18,7 @@ package org.dockbox.hartshorn.inject;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.introspect.IntrospectionViewContextAdapter;
 import org.dockbox.hartshorn.introspect.ViewContextAdapter;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
@@ -42,6 +43,7 @@ import org.dockbox.hartshorn.util.option.Option;
 public class ContextDrivenProvider<C> implements TypeAwareProvider<C> {
 
     private final ComponentKey<? extends C> context;
+
     private ConstructorView<? extends C> optimalConstructor;
 
     public ContextDrivenProvider(ComponentKey<? extends C> type) {
@@ -49,15 +51,15 @@ public class ContextDrivenProvider<C> implements TypeAwareProvider<C> {
     }
 
     @Override
-    public Option<ObjectContainer<C>> provide(ApplicationContext context) throws ApplicationException {
+    public Option<ObjectContainer<C>> provide(ApplicationContext context, ComponentRequestContext requestContext) throws ApplicationException {
         Option<? extends ConstructorView<? extends C>> constructor = this.optimalConstructor(context);
         if (constructor.absent()) {
             return Option.empty();
         }
-
-        ViewContextAdapter adapter = context.get(ViewContextAdapter.class);
         try {
-            return adapter.scope(this.context.scope())
+            ViewContextAdapter contextAdapter = new IntrospectionViewContextAdapter(context);
+            contextAdapter.add(requestContext);
+            return contextAdapter.scope(this.context.scope())
                     .create(constructor.get())
                     .cast(this.type())
                     .map(ComponentObjectContainer::new);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextDrivenProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextDrivenProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/LazySingletonProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/LazySingletonProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/LazySingletonProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/LazySingletonProvider.java
@@ -43,7 +43,7 @@ public class LazySingletonProvider<T> implements NonTypeAwareProvider<T> {
     }
 
     @Override
-    public Option<ObjectContainer<T>> provide(ApplicationContext context) throws ApplicationException {
+    public Option<ObjectContainer<T>> provide(ApplicationContext context, ComponentRequestContext requestContext) throws ApplicationException {
         if (this.container == null) {
             this.container = this.supplier.get();
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Provider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Provider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Provider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Provider.java
@@ -39,10 +39,11 @@ public sealed interface Provider<T> permits TypeAwareProvider, NonTypeAwareProvi
      * to retrieve required dependencies for the instance. The context should not be used to enable
      * the instance, or populate fields of the instance.
      *
-     * @param context The {@link ApplicationContext} to use.
+     * @param context        The {@link ApplicationContext} to use.
+     * @param requestContext
      * @return The instance, if it can be created.
      */
-    Option<ObjectContainer<T>> provide(ApplicationContext context) throws ApplicationException;
+    Option<ObjectContainer<T>> provide(ApplicationContext context, ComponentRequestContext requestContext) throws ApplicationException;
 
     /**
      * Maps the result of this provider using the provided {@link Function}. The result of the

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SingletonProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SingletonProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SingletonProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SingletonProvider.java
@@ -39,7 +39,7 @@ public class SingletonProvider<T> implements NonTypeAwareProvider<T> {
     }
 
     @Override
-    public Option<ObjectContainer<T>> provide(ApplicationContext context) {
+    public Option<ObjectContainer<T>> provide(ApplicationContext context, ComponentRequestContext requestContext) {
         return Option.of(this.container);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SupplierProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SupplierProvider.java
@@ -38,7 +38,7 @@ import org.dockbox.hartshorn.util.option.Option;
 public record SupplierProvider<C>(CheckedSupplier<C> supplier) implements NonTypeAwareProvider<C> {
 
     @Override
-    public Option<ObjectContainer<C>> provide(ApplicationContext context) throws ApplicationException {
+    public Option<ObjectContainer<C>> provide(ApplicationContext context, ComponentRequestContext requestContext) throws ApplicationException {
         C instance = this.supplier.get();
         return Option.of(instance).map(ComponentObjectContainer::new);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SupplierProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/SupplierProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ComponentInstanceFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ComponentInstanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ComponentInstanceFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ComponentInstanceFactory.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.inject.binding;
 
 import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.ObjectContainer;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.option.Option;
@@ -35,10 +36,11 @@ public interface ComponentInstanceFactory {
      * may contain a scope. Depending on the implementation, these attributes may be used to determine the
      * instance that is created.
      *
-     * @param key The key of the component to create
+     * @param <T>            The type of the component
+     * @param key            The key of the component to create
+     * @param requestContext
      * @return The created instance
-     * @param <T> The type of the component
      * @throws ApplicationException When the instance cannot be created
      */
-    <T> Option<ObjectContainer<T>> instantiate(ComponentKey<T> key) throws ApplicationException;
+    <T> Option<ObjectContainer<T>> instantiate(ComponentKey<T> key, ComponentRequestContext requestContext) throws ApplicationException;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
@@ -23,6 +23,8 @@ import org.dockbox.hartshorn.component.Scope;
 import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.component.ScopeModuleContext;
 import org.dockbox.hartshorn.inject.ComponentObjectContainer;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
+import org.dockbox.hartshorn.inject.ContextAwareComponentSupplier;
 import org.dockbox.hartshorn.inject.ContextDrivenProvider;
 import org.dockbox.hartshorn.inject.LazySingletonProvider;
 import org.dockbox.hartshorn.inject.ObjectContainer;
@@ -171,7 +173,7 @@ public class HierarchyBindingFunction<T> implements BindingFunction<T> {
     public Binder lazySingleton(Class<T> type) {
         return this.lazyContainerSingleton(() -> {
             ComponentKey<T> key = ComponentKey.builder(type).scope(this.scope).build();
-            Option<ObjectContainer<T>> object = this.instanceFactory().instantiate(key);
+            Option<ObjectContainer<T>> object = this.instanceFactory().instantiate(key, ComponentRequestContext.createForComponent());
             return object.orNull();
         });
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/CollectionProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/CollectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/CollectionProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/CollectionProvider.java
@@ -16,8 +16,15 @@
 
 package org.dockbox.hartshorn.inject.binding.collection;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.inject.CollectionObjectContainer;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.NonTypeAwareProvider;
 import org.dockbox.hartshorn.inject.ObjectContainer;
 import org.dockbox.hartshorn.inject.Provider;
@@ -25,12 +32,6 @@ import org.dockbox.hartshorn.inject.TypeAwareProvider;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * A provider which provides a {@link ComponentCollection} of all the provided instances. This provider
@@ -110,10 +111,10 @@ public class CollectionProvider<T> implements NonTypeAwareProvider<ComponentColl
     }
 
     @Override
-    public Option<ObjectContainer<ComponentCollection<T>>> provide(ApplicationContext context) throws ApplicationException {
+    public Option<ObjectContainer<ComponentCollection<T>>> provide(ApplicationContext context, ComponentRequestContext requestContext) throws ApplicationException {
         Set<ObjectContainer<T>> containers = new HashSet<>();
         for(Provider<T> provider : this.providers) {
-            Option<ObjectContainer<T>> container = provider.provide(context);
+            Option<ObjectContainer<T>> container = provider.provide(context, requestContext);
             if(container.present()) {
                 containers.add(container.get());
             }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/CollectorBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/CollectorBindingFunction.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.inject.binding.collection;
 
+import org.dockbox.hartshorn.inject.ContextAwareComponentSupplier;
 import org.dockbox.hartshorn.inject.Provider;
 import org.dockbox.hartshorn.inject.binding.Binder;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
@@ -50,6 +51,8 @@ public interface CollectorBindingFunction<T> {
      * @return The binder
      */
     Binder supplier(CheckedSupplier<T> supplier);
+
+    Binder supplier(ContextAwareComponentSupplier<T> supplier);
 
     /**
      * Binds to the given instance, this will always return the same instance

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/CollectorBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/CollectorBindingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/ComposedCollectionProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/ComposedCollectionProvider.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.inject.CollectionObjectContainer;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.NonTypeAwareProvider;
 import org.dockbox.hartshorn.inject.ObjectContainer;
 import org.dockbox.hartshorn.inject.Provider;
@@ -47,10 +48,10 @@ public class ComposedCollectionProvider<T> implements NonTypeAwareProvider<Compo
     }
 
     @Override
-    public Option<ObjectContainer<ComponentCollection<T>>> provide(ApplicationContext context) throws ApplicationException {
+    public Option<ObjectContainer<ComponentCollection<T>>> provide(ApplicationContext context, ComponentRequestContext requestContext) throws ApplicationException {
         Set<ObjectContainer<T>> components = new HashSet<>();
         for (CollectionProvider<T> provider : this.providers) {
-            Option<ObjectContainer<ComponentCollection<T>>> containers = provider.provide(context);
+            Option<ObjectContainer<ComponentCollection<T>>> containers = provider.provide(context, requestContext);
             if (containers.present()) {
                 ComponentCollection<T> componentCollection = containers.get().instance();
                 if (componentCollection instanceof ContainerAwareComponentCollection<T> containerAwareCollection) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/ComposedCollectionProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/ComposedCollectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/HierarchyCollectorBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/HierarchyCollectorBindingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/HierarchyCollectorBindingFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/collection/HierarchyCollectorBindingFunction.java
@@ -18,6 +18,7 @@ package org.dockbox.hartshorn.inject.binding.collection;
 
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.inject.ComponentObjectContainer;
+import org.dockbox.hartshorn.inject.ContextAwareComponentSupplier;
 import org.dockbox.hartshorn.inject.ContextDrivenProvider;
 import org.dockbox.hartshorn.inject.LazySingletonProvider;
 import org.dockbox.hartshorn.inject.Provider;
@@ -59,6 +60,11 @@ public class HierarchyCollectorBindingFunction<T> implements CollectorBindingFun
     @Override
     public Binder supplier(CheckedSupplier<T> supplier) {
         return this.provider(new SupplierProvider<>(supplier));
+    }
+
+    @Override
+    public Binder supplier(ContextAwareComponentSupplier<T> supplier) {
+        return this.provider(supplier);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/MethodInstanceBindingStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/MethodInstanceBindingStrategy.java
@@ -30,6 +30,7 @@ import org.dockbox.hartshorn.component.processing.Binds;
 import org.dockbox.hartshorn.component.processing.Binds.BindingType;
 import org.dockbox.hartshorn.inject.AutoConfiguringDependencyContext;
 import org.dockbox.hartshorn.inject.ComponentInitializationException;
+import org.dockbox.hartshorn.inject.ContextAwareComponentSupplier;
 import org.dockbox.hartshorn.inject.DependencyContext;
 import org.dockbox.hartshorn.inject.DependencyMap;
 import org.dockbox.hartshorn.inject.Priority;
@@ -40,7 +41,6 @@ import org.dockbox.hartshorn.util.Customizer;
 import org.dockbox.hartshorn.util.LazyStreamableConfigurer;
 import org.dockbox.hartshorn.util.StreamableConfigurer;
 import org.dockbox.hartshorn.util.TypeUtils;
-import org.dockbox.hartshorn.util.function.CheckedSupplier;
 import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.option.Option;
@@ -91,9 +91,10 @@ public class MethodInstanceBindingStrategy implements BindingStrategy {
 
         DependencyMap dependenciesMap = DependencyMap.create().immediate(dependencies);
 
-        ViewContextAdapter contextAdapter = new IntrospectionViewContextAdapter(applicationContext);
-        CheckedSupplier<T> supplier = () -> {
+        ContextAwareComponentSupplier<T> supplier = requestContext -> {
             try {
+                ViewContextAdapter contextAdapter = new IntrospectionViewContextAdapter(applicationContext);
+                contextAdapter.add(requestContext);
                 return contextAdapter.load(bindsMethod).orNull();
             }
             catch(Throwable throwable) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/ExecutableElementContextParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/ExecutableElementContextParameterLoader.java
@@ -19,6 +19,8 @@ package org.dockbox.hartshorn.introspect;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.ComponentRequiredException;
+import org.dockbox.hartshorn.component.populate.inject.InjectionPoint;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.Required;
 import org.dockbox.hartshorn.util.ApplicationBoundParameterLoaderContext;
 import org.dockbox.hartshorn.util.introspect.util.RuleBasedParameterLoader;
@@ -38,7 +40,9 @@ public class ExecutableElementContextParameterLoader extends RuleBasedParameterL
     @Override
     protected <T> T loadDefault(ParameterView<T> parameter, int index, ApplicationBoundParameterLoaderContext context, Object... args) {
         ComponentKey<?> componentKey = this.applicationContext.environment().componentKeyResolver().resolve(parameter);
-        Object out = context.provider().get(componentKey);
+
+        ComponentRequestContext requestContext = ComponentRequestContext.createForInjectionPoint(new InjectionPoint(parameter));
+        Object out = context.provider().get(componentKey, requestContext);
 
         boolean required = isRequired(parameter);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/InjectionPointParameterLoaderRule.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/InjectionPointParameterLoaderRule.java
@@ -1,0 +1,28 @@
+package org.dockbox.hartshorn.introspect;
+
+import org.dockbox.hartshorn.component.populate.inject.InjectionPoint;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
+import org.dockbox.hartshorn.util.ApplicationBoundParameterLoaderContext;
+import org.dockbox.hartshorn.util.introspect.util.ParameterLoaderRule;
+import org.dockbox.hartshorn.util.introspect.view.ParameterView;
+import org.dockbox.hartshorn.util.option.Option;
+
+public class InjectionPointParameterLoaderRule implements ParameterLoaderRule<ApplicationBoundParameterLoaderContext> {
+
+    private final ComponentRequestContext requestContext;
+
+    public InjectionPointParameterLoaderRule(ComponentRequestContext requestContext) {
+        this.requestContext = requestContext;
+    }
+
+    @Override
+    public boolean accepts(ParameterView<?> parameter, int index, ApplicationBoundParameterLoaderContext context, Object... args) {
+        return requestContext.isForInjectionPoint() && parameter.type().isChildOf(InjectionPoint.class);
+    }
+
+    @Override
+    public <T> Option<T> load(ParameterView<T> parameter, int index, ApplicationBoundParameterLoaderContext context, Object... args) {
+        InjectionPoint injectionPoint = requestContext.injectionPoint();
+        return Option.of(parameter.type().cast(injectionPoint));
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/InjectionPointParameterLoaderRule.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/InjectionPointParameterLoaderRule.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.introspect;
 
 import org.dockbox.hartshorn.component.populate.inject.InjectionPoint;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
@@ -16,6 +16,8 @@
 
 package org.dockbox.hartshorn.util;
 
+import java.util.List;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.ComponentProvider;
@@ -25,11 +27,10 @@ import org.dockbox.hartshorn.context.ContextCarrier;
 import org.dockbox.hartshorn.context.ContextIdentity;
 import org.dockbox.hartshorn.context.DefaultProvisionContext;
 import org.dockbox.hartshorn.context.ProvisionContext;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.util.introspect.util.ParameterLoaderContext;
 import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 import org.dockbox.hartshorn.util.option.Option;
-
-import java.util.List;
 
 public class ApplicationBoundParameterLoaderContext extends ParameterLoaderContext implements ContextCarrier, ProvisionContext {
 
@@ -65,13 +66,13 @@ public class ApplicationBoundParameterLoaderContext extends ParameterLoaderConte
         }
         return new ComponentProvider() {
             @Override
-            public <T> T get(ComponentKey<T> key) {
+            public <T> T get(ComponentKey<T> key, ComponentRequestContext requestContext) {
                 ApplicationBoundParameterLoaderContext self = ApplicationBoundParameterLoaderContext.this;
                 // Explicit scopes get priority, otherwise use our local scope
                 if (key.scope() == Scope.DEFAULT_SCOPE) {
-                    return self.provider.get(key.mutable().scope(self.scope).build());
+                    return self.provider.get(key.mutable().scope(self.scope).build(), requestContext);
                 }
-                return self.provider.get(key);
+                return self.provider.get(key, requestContext);
             }
         };
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
@@ -563,7 +563,7 @@ public class ApplicationContextTests {
     @Test
     @TestComponents(components = SetterInjectedComponentWithAbsentBinding.class)
     void testSetterInjectionWithAbsentRequiredComponent() {
-        Assertions.assertThrows(ComponentRequiredException.class, () -> this.applicationContext.get(SetterInjectedComponentWithAbsentBinding.class));
+        Assertions.assertThrows(ComponentResolutionException.class, () -> this.applicationContext.get(SetterInjectedComponentWithAbsentBinding.class));
     }
 
     @Test

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
@@ -585,9 +585,17 @@ public class ApplicationContextTests {
         Assertions.assertSame(sampleContext, component.context());
     }
 
+    @Inject
+    private Logger loggerField;
+
     @InjectTest
-    void loggerCanBeInjected(Logger logger) {
-        Assertions.assertNotNull(logger);
+    void loggerCanBeInjected(Logger loggerParameter) {
+        Assertions.assertNotNull(loggerParameter);
+        // Name should match the consuming class' name, and not the name of the configuration that uses it
+        Assertions.assertEquals(loggerParameter.getName(), ApplicationContextTests.class.getName());
+
+        Assertions.assertNotNull(this.loggerField);
+        Assertions.assertEquals(this.loggerField.getName(), ApplicationContextTests.class.getName());
     }
 
     @Test

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
@@ -498,7 +498,7 @@ public class ApplicationContextTests {
             }
 
             DependencyContext<?> dependencyContext = new AutoConfiguringDependencyContext<>(componentKey,
-                    dependencyMap, Scope.DEFAULT_SCOPE.installableScopeType(), -1, BindingType.STANDALONE, origin, () -> null);
+                    dependencyMap, Scope.DEFAULT_SCOPE.installableScopeType(), -1, BindingType.STANDALONE, origin, requestContext -> null);
             dependencyContexts.add(dependencyContext);
         }
 

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/inject/ProviderSelectionStrategyTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/inject/ProviderSelectionStrategyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/inject/ProviderSelectionStrategyTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/inject/ProviderSelectionStrategyTests.java
@@ -19,6 +19,7 @@ package test.org.dockbox.hartshorn.inject;
 import java.util.stream.Stream;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.component.ComponentKey;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.ExactPriorityProviderSelectionStrategy;
 import org.dockbox.hartshorn.inject.HighestPriorityProviderSelectionStrategy;
 import org.dockbox.hartshorn.inject.MaximumPriorityProviderSelectionStrategy;
@@ -129,7 +130,7 @@ public class ProviderSelectionStrategyTests {
         else {
             Assertions.assertNotNull(provider);
 
-            Option<? extends ObjectContainer<?>> value = Assertions.assertDoesNotThrow(() -> provider.provide(null));
+            Option<? extends ObjectContainer<?>> value = Assertions.assertDoesNotThrow(() -> provider.provide(null, ComponentRequestContext.createForComponent()));
             Assertions.assertTrue(value.present());
 
             ObjectContainer<?> container = value.get();


### PR DESCRIPTION
### Type of Change
- [x] Enhancement (non-breaking change that affects existing code)
- [x] Feature (non-breaking change that adds functionality)

### Description
Introduces a context type to allow access to target information of injection requests of components: `ComponentRequestContext`. Using this context, providers can obtain access to target information (applicable to non-singleton components), allowing them to configure components for specific usages.

A common example of this is the provision of `Logger` instances, which should be specific to the class in which it will be used.

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] I have added documentation that describes my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1065