### PR TITLE
#1071 Restructure component providers and registries

### DIFF
--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/ArgumentConverterConfiguration.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/ArgumentConverterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.dockbox.hartshorn.commands.annotations.UseCommands;
 import org.dockbox.hartshorn.commands.context.ArgumentConverterRegistryCustomizer;
 import org.dockbox.hartshorn.commands.definition.ArgumentConverter;
 import org.dockbox.hartshorn.component.ComponentContainer;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 import org.dockbox.hartshorn.component.Configuration;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.processing.Binds;
@@ -143,11 +143,11 @@ public class ArgumentConverterConfiguration {
     public ArgumentConverter<ComponentContainer<?>> componentContainerArgumentConverter() {
         return ArgumentConverterImpl.<ComponentContainer<?>>builder(TypeUtils.adjustWildcards(ComponentContainer.class, Class.class), "service")
                 .withConverter((src, in) -> Option.of(src.applicationContext()
-                        .get(ComponentLocator.class).containers().stream()
+                        .get(ComponentRegistry.class).containers().stream()
                         .filter(container -> container.id().equalsIgnoreCase(in))
                         .findFirst()))
                 .withSuggestionProvider((src, in) -> src.applicationContext()
-                        .get(ComponentLocator.class).containers().stream()
+                        .get(ComponentRegistry.class).containers().stream()
                         .map(ComponentContainer::id)
                         .filter(id -> id.toLowerCase(Locale.ROOT).startsWith(in.toLowerCase(Locale.ROOT)))
                         .toList())

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/ParameterTypeArgumentConverterRegistryCustomizer.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/ParameterTypeArgumentConverterRegistryCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class ParameterTypeArgumentConverterRegistryCustomizer implements Argumen
 
     @Override
     public void configure(ArgumentConverterRegistry registry) {
-        Collection<TypeView<?>> parameterDeclarations = this.environment.types(Parameter.class);
+        Collection<TypeView<?>> parameterDeclarations = this.environment.typeResolver().types(Parameter.class);
         for(TypeView<?> parameterDeclaration : parameterDeclarations) {
             Parameter meta = parameterDeclaration.annotations().get(Parameter.class).get();
             CustomParameterPattern pattern = this.environment.applicationContext().get(meta.pattern());

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/CommandDefinitionContextImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/CommandDefinitionContextImpl.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.commands.context;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -294,7 +295,7 @@ public class CommandDefinitionContextImpl extends DefaultProvisionContext implem
 
     private List<CommandElement<?>> requiredElements() {
         return this.elements().stream()
-                .filter(commandElement -> !commandElement.optional())
+                .filter(Predicate.not(CommandElement::optional))
                 .toList();
     }
 

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationURIContextList.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationURIContextList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,13 @@ package org.dockbox.hartshorn.config;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.dockbox.hartshorn.context.ContextIdentity;
 import org.dockbox.hartshorn.context.ContextKey;
 import org.dockbox.hartshorn.context.DefaultProvisionContext;
 
 public class ConfigurationURIContextList extends DefaultProvisionContext {
 
-    public static final ContextKey<ConfigurationURIContextList> CONTEXT_KEY = ContextKey.builder(ConfigurationURIContextList.class)
+    public static final ContextIdentity<ConfigurationURIContextList> CONTEXT_KEY = ContextKey.builder(ConfigurationURIContextList.class)
             .fallback(ConfigurationURIContextList::new)
             .build();
 

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/SerializerMethodPostProcessor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/SerializerMethodPostProcessor.java
@@ -52,10 +52,9 @@ public class SerializerMethodPostProcessor extends AbstractSerializerPostProcess
             return true;
         }
         TypeParameterList typeParameters = method.genericReturnType().typeParameters().allInput();
-        return typeParameters.count() == 1 && Boolean.TRUE.equals(typeParameters.atIndex(0)
+        return typeParameters.count() == 1 && typeParameters.atIndex(0)
                 .flatMap(TypeParameterView::resolvedType)
-                .map(type -> type.is(String.class))
-                .orElse(false));
+                .test(type -> type.is(String.class));
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ContextualEnvironmentBinderConfiguration.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ContextualEnvironmentBinderConfiguration.java
@@ -23,7 +23,7 @@ import org.dockbox.hartshorn.application.environment.ClasspathResourceLocator;
 import org.dockbox.hartshorn.application.environment.FileSystemProvider;
 import org.dockbox.hartshorn.application.lifecycle.LifecycleObservable;
 import org.dockbox.hartshorn.application.lifecycle.ObservableApplicationEnvironment;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 import org.dockbox.hartshorn.component.ComponentProvider;
 import org.dockbox.hartshorn.inject.binding.Binder;
 import org.dockbox.hartshorn.proxy.ProxyOrchestrator;
@@ -43,7 +43,7 @@ import org.dockbox.hartshorn.util.introspect.annotations.AnnotationLookup;
  * <p>Bindings for specific implementations will optionally be registered for the following types:
  * <ul>
  *     <li>{@link LifecycleObservable}, if the {@link ApplicationEnvironment environment} is an instance of {@link ObservableApplicationEnvironment}</li>
- *     <li>{@link ComponentLocator}, if the {@link ApplicationContext application context} is an instance of {@link DelegatingApplicationContext}</li>
+ *     <li>{@link ComponentRegistry}, if the {@link ApplicationContext application context} is an instance of {@link DelegatingApplicationContext}</li>
  * </ul>
  *
  * @see DefaultBindingConfigurer
@@ -65,9 +65,9 @@ public class ContextualEnvironmentBinderConfiguration implements EnvironmentBind
         binder.bind(ApplicationPropertyHolder.class).singleton(environment.applicationContext());
 
         if (environment.applicationContext() instanceof DelegatingApplicationContext delegatingApplicationContext) {
-            binder.bind(ComponentLocator.class)
+            binder.bind(ComponentRegistry.class)
                     .processAfterInitialization(false)
-                    .singleton(delegatingApplicationContext.locator());
+                    .singleton(delegatingApplicationContext.componentRegistry());
         }
 
         // Application environment

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationContextConstructor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationContextConstructor.java
@@ -34,7 +34,7 @@ import org.dockbox.hartshorn.application.environment.ContextualApplicationEnviro
 import org.dockbox.hartshorn.application.lifecycle.LifecycleObserver;
 import org.dockbox.hartshorn.application.lifecycle.ObservableApplicationEnvironment;
 import org.dockbox.hartshorn.component.ComponentContainer;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 import org.dockbox.hartshorn.component.UseProxying;
 import org.dockbox.hartshorn.component.processing.ComponentFinalizingPostProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
@@ -229,7 +229,7 @@ public final class StandardApplicationContextConstructor implements ApplicationC
             }
         }
 
-        for (ComponentContainer<?> container : applicationContext.get(ComponentLocator.class).containers()) {
+        for (ComponentContainer<?> container : applicationContext.get(ComponentRegistry.class).containers()) {
             this.buildContext.logger().debug("Instantiating non-lazy singleton {} in application context", container.id());
             if (container.singleton() && !container.lazy()) {
                 applicationContext.get(container.type().type());

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/SimpleApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/SimpleApplicationContext.java
@@ -121,7 +121,7 @@ public class SimpleApplicationContext extends DelegatingApplicationContext imple
     public synchronized void loadContext() {
         this.checkRunning();
 
-        Collection<ComponentContainer<?>> containers = this.locator().containers();
+        Collection<ComponentContainer<?>> containers = this.componentRegistry().containers();
         LOG.debug("Located %d components".formatted(containers.size()));
 
         try {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ApplicationEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ApplicationEnvironment.java
@@ -75,9 +75,18 @@ public interface ApplicationEnvironment extends ContextCarrier, ExceptionHandler
      * Gets the primary {@link Introspector} for this {@link ApplicationEnvironment}. The introspector is responsible
      * for all introspection operations within the environment. This may or may not be the same as the binding for
      * {@link Introspector}, but is typically the same.
+     *
      * @return The primary {@link Introspector}
      */
     Introspector introspector();
+
+    /**
+     * Gets the {@link EnvironmentTypeResolver} for the current environment. The resolver is responsible for resolving
+     * types within the environment, and is typically used for scanning for types and annotations.
+     *
+     * @return The environment type resolver
+     */
+    EnvironmentTypeResolver typeResolver();
 
     /**
      * Indicates whether the current environment exists within a Continuous Integration environment. If this returns
@@ -104,67 +113,6 @@ public interface ApplicationEnvironment extends ContextCarrier, ExceptionHandler
      * @return {@code true} if strict mode is enabled, {@code false} otherwise.
      */
     boolean isStrictMode();
-
-    /**
-     * Gets types decorated with a given annotation, both classes and annotations.
-     *
-     * @param <A> The annotation constraint
-     * @param annotation The annotation expected to be present on one or more types
-     * @return The annotated types
-     */
-    <A extends Annotation> Collection<TypeView<?>> types(Class<A> annotation);
-
-    /**
-     * Gets all sub-types of a given type. The prefix is typically a package. If no sub-types exist for the given type,
-     * and empty list is returned.
-     *
-     * @param parent The parent type to scan for subclasses
-     * @param <T> The type of the parent
-     * @return The list of sub-types, or an empty list
-     */
-    <T> Collection<TypeView<? extends T>> children(Class<T> parent);
-
-    /**
-     * Gets annotations of the given type, which are decorated with the given annotation. For example, given the
-     * annotation and class below, the result of requesting annotations with {@link Documented} for {@code MyClass}
-     * would be a list containing {@code MyAnnotation}, but not {@code AnotherAnnotation}.
-     *
-     * <pre>{@code
-     * @Documented
-     * public @interface MyAnnotation { }
-     *
-     * public @interface AnotherAnnotation { }
-     *
-     * @MyAnnotation
-     * public class MyClass { }
-     * }</pre>
-     *
-     * @param type The type to scan for annotations
-     * @param annotation The annotation expected to be present on zero or more annotations
-     * @return The annotated annotations
-     */
-    List<Annotation> annotationsWith(TypeView<?> type, Class<? extends Annotation> annotation);
-
-    /**
-     * Gets annotations of the given type, which are decorated with the given annotation. For example, given the
-     * annotation and class below, the result of requesting annotations with {@link Documented} for {@code MyClass}
-     * would be a list containing {@code MyAnnotation}, but not {@code AnotherAnnotation}.
-     *
-     * <pre>{@code
-     * @Documented
-     * public @interface MyAnnotation { }
-     *
-     * public @interface AnotherAnnotation { }
-     *
-     * @MyAnnotation
-     * public class MyClass { }
-     * }</pre>
-     *
-     * @param type The type to scan for annotations
-     * @param annotation The annotation expected to be present on zero or more annotations
-     * @return The annotated annotations
-     */
-    List<Annotation> annotationsWith(Class<?> type, Class<? extends Annotation> annotation);
 
     /**
      * Indicates whether the given type should be treated as a singleton. How this is determined is up to the

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ClassPathEnvironmentTypeResolver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ClassPathEnvironmentTypeResolver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.application.environment;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.dockbox.hartshorn.util.introspect.Introspector;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+
+public class ClassPathEnvironmentTypeResolver implements EnvironmentTypeResolver {
+
+    private final EnvironmentTypeCollector typeCollector;
+    private final Introspector introspector;
+
+    public ClassPathEnvironmentTypeResolver(EnvironmentTypeCollector typeCollector, Introspector introspector) {
+        this.typeCollector = typeCollector;
+        this.introspector = introspector;
+    }
+
+    @Override
+    public <A extends Annotation> Collection<TypeView<?>> types(Class<A> annotation) {
+        return this.typeCollector.types(type -> type.annotations().has(annotation));
+    }
+
+    @Override
+    public <T> Collection<TypeView<? extends T>> children(Class<T> parent) {
+        return this.typeCollector.types(type -> type.isChildOf(parent) && !type.is(parent));
+    }
+
+    @Override
+    public List<Annotation> annotationsWith(TypeView<?> type, Class<? extends Annotation> annotation) {
+        Collection<Annotation> annotations = new ArrayList<>();
+        for (Annotation typeAnnotation : type.annotations().all()) {
+            if (this.introspector.introspect(typeAnnotation.annotationType()).annotations().has(annotation)) {
+                annotations.add(typeAnnotation);
+            }
+        }
+        return List.copyOf(annotations);
+    }
+
+    @Override
+    public List<Annotation> annotationsWith(Class<?> type, Class<? extends Annotation> annotation) {
+        return this.annotationsWith(this.introspector.introspect(type), annotation);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ContextualApplicationEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ContextualApplicationEnvironment.java
@@ -253,10 +253,9 @@ public final class ContextualApplicationEnvironment implements ObservableApplica
 
     @Override
     public boolean singleton(TypeView<?> type) {
-        ComponentLocator componentLocator = this.applicationContext().get(ComponentLocator.class);
-        return Boolean.TRUE.equals(componentLocator.container(type.type())
-                .map(ComponentContainer::singleton)
-                .orElseGet(() -> type.annotations().has(Singleton.class)));
+        ComponentRegistry componentRegistry = this.applicationContext().get(ComponentRegistry.class);
+        return componentRegistry.container(type.type())
+            .test(container -> container.singleton() || container.type().annotations().has(Singleton.class));
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/EnvironmentTypeResolver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/EnvironmentTypeResolver.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.application.environment;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.util.Collection;
+import java.util.List;
+import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
+import org.dockbox.hartshorn.util.introspect.annotations.AnnotationLookup;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+
+public interface EnvironmentTypeResolver {
+
+    /**
+     * Gets types decorated with a given annotation, both classes and annotations.
+     *
+     * @param <A> The annotation constraint
+     * @param annotation The annotation expected to be present on one or more types
+     * @return The annotated types
+     */
+    <A extends Annotation> Collection<TypeView<?>> types(Class<A> annotation);
+
+    /**
+     * Gets all sub-types of a given type. The prefix is typically a package. If no sub-types exist for the given type,
+     * and empty list is returned.
+     *
+     * @param parent The parent type to scan for subclasses
+     * @param <T> The type of the parent
+     * @return The list of sub-types, or an empty list
+     *
+     * @deprecated Should not be used as it is not a common use-case. Instead, you should use a {@link ComponentPostProcessor}
+     * to process managed components to find if they are a sub-type of a given type.
+     */
+    @Deprecated(since = "0.6.0", forRemoval = true)
+    <T> Collection<TypeView<? extends T>> children(Class<T> parent);
+
+    /**
+     * Gets annotations of the given type, which are decorated with the given annotation. For example, given the
+     * annotation and class below, the result of requesting annotations with {@link Documented} for {@code MyClass}
+     * would be a list containing {@code MyAnnotation}, but not {@code AnotherAnnotation}.
+     *
+     * <pre>{@code
+     * @Documented
+     * public @interface MyAnnotation { }
+     *
+     * public @interface AnotherAnnotation { }
+     *
+     * @MyAnnotation
+     * public class MyClass { }
+     * }</pre>
+     *
+     * @param type The type to scan for annotations
+     * @param annotation The annotation expected to be present on zero or more annotations
+     * @return The annotated annotations
+     *
+     * @deprecated Should not be used, refer to {@link #types(Class)} if you need to find types with a specific annotation, or
+     * {@link AnnotationLookup annotation lookups} if you need to find annotations on a specific type.
+     */
+    @Deprecated(since = "0.6.0", forRemoval = true)
+    List<Annotation> annotationsWith(TypeView<?> type, Class<? extends Annotation> annotation);
+
+    /**
+     * Gets annotations of the given type, which are decorated with the given annotation. For example, given the
+     * annotation and class below, the result of requesting annotations with {@link Documented} for {@code MyClass}
+     * would be a list containing {@code MyAnnotation}, but not {@code AnotherAnnotation}.
+     *
+     * <pre>{@code
+     * @Documented
+     * public @interface MyAnnotation { }
+     *
+     * public @interface AnotherAnnotation { }
+     *
+     * @MyAnnotation
+     * public class MyClass { }
+     * }</pre>
+     *
+     * @param type The type to scan for annotations
+     * @param annotation The annotation expected to be present on zero or more annotations
+     * @return The annotated annotations
+     *
+     * @deprecated Should not be used, refer to {@link #types(Class)} if you need to find types with a specific annotation, or
+     * {@link AnnotationLookup annotation lookups} if you need to find annotations on a specific type.
+     */
+    @Deprecated(since = "0.6.0", forRemoval = true)
+    List<Annotation> annotationsWith(Class<?> type, Class<? extends Annotation> annotation);
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ApplicationConfiguration.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ApplicationConfiguration.java
@@ -48,15 +48,15 @@ import jakarta.inject.Singleton;
 public class ApplicationConfiguration {
 
     @Binds
-    public Logger logger(InjectionPoint injectionPoint, ComponentLocator locator) {
+    public Logger logger(InjectionPoint injectionPoint, ComponentRegistry componentRegistry) {
         Class<?> declaringType = switch(injectionPoint.injectionPoint()) {
             case ExecutableElementView<?> executableElementView -> executableElementView.declaredBy().type();
             case FieldView<?, ?> fieldView -> fieldView.declaredBy().type();
             case ParameterView<?> parameterView -> parameterView.declaredBy().declaredBy().type();
             default -> throw new IllegalStateException("Unexpected value: " + injectionPoint.injectionPoint());
         };
-        
-        return locator.container(declaringType)
+
+        return componentRegistry.container(declaringType)
             .map(ComponentContainer::name)
             .map(LoggerFactory::getLogger)
             .orElseGet(() -> LoggerFactory.getLogger(declaringType));

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/Component.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/Component.java
@@ -52,7 +52,7 @@ import org.dockbox.hartshorn.component.processing.ComponentProcessor;
  * }</pre>
  *
  * @see Service
- * @see ComponentLocator
+ * @see ComponentRegistry
  * @see ComponentContainer
  * @see ComponentProcessor
  *

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentContainerImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentContainerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,20 +25,19 @@ import java.util.Objects;
 public class ComponentContainerImpl<T> implements ComponentContainer<T> {
 
     private final Component annotation;
-    private final Class<?> component;
-    private final TypeView<T> introspectedComponent;
-    private final ApplicationContext context;
+    private final TypeView<T> component;
 
-    public ComponentContainerImpl(ApplicationContext context, Class<T> component) {
-        this.introspectedComponent = context.environment().introspector().introspect(component);
-        Option<Component> annotated = this.introspectedComponent.annotations().get(Component.class);
+    public ComponentContainerImpl(TypeView<T> component) {
+        Option<Component> annotated = component.annotations().get(Component.class);
         if (annotated.absent()) {
-            throw new InvalidComponentException("Provided component candidate (" + component.getCanonicalName() + ") is not annotated with @" + Component.class.getSimpleName());
+            throw new InvalidComponentException("Provided component candidate (" + component.qualifiedName() + ") is not annotated with @" + Component.class.getSimpleName());
+        }
+        if (component.isAnnotation()) {
+            throw new InvalidComponentException("Provided component candidate (" + component.qualifiedName() + ") is an annotation and cannot be used as a component, is it a component stereotype?");
         }
 
         this.component = component;
         this.annotation = annotated.get();
-        this.context = context;
     }
 
     public Component annotation() {
@@ -46,18 +45,14 @@ public class ComponentContainerImpl<T> implements ComponentContainer<T> {
     }
 
     public Class<?> component() {
-        return this.component;
-    }
-
-    public ApplicationContext context() {
-        return this.context;
+        return this.component.type();
     }
 
     @Override
     public String id() {
         String id = this.annotation().id();
         if (id != null && id.isEmpty()) {
-            return ComponentUtilities.id(this.context, this.component, true);
+            return ComponentUtilities.id(this, true);
         }
         return id;
     }
@@ -66,14 +61,14 @@ public class ComponentContainerImpl<T> implements ComponentContainer<T> {
     public String name() {
         String name = this.annotation().name();
         if (name != null && name.isEmpty()) {
-            return ComponentUtilities.name(this.context, this.component, true);
+            return ComponentUtilities.name(this, true);
         }
         return name;
     }
 
     @Override
     public TypeView<T> type() {
-        return this.introspectedComponent;
+        return this.component;
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentProviderPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentProviderPostProcessor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.component;
+
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
+import org.dockbox.hartshorn.inject.ObjectContainer;
+import org.dockbox.hartshorn.util.ApplicationException;
+
+public interface ComponentProviderPostProcessor {
+
+    <T> T processInstance(
+            ComponentKey<T> componentKey,
+            ObjectContainer<T> objectContainer,
+            T instance,
+            ComponentRequestContext requestContext
+    ) throws ApplicationException;
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentRegistry.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentRegistry.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 import org.dockbox.hartshorn.context.ContextCarrier;
 import org.dockbox.hartshorn.util.option.Option;
 
-public interface ComponentLocator extends ContextCarrier {
+public interface ComponentRegistry extends ContextCarrier {
 
     Collection<ComponentContainer<?>> containers();
 
@@ -29,6 +29,4 @@ public interface ComponentLocator extends ContextCarrier {
     Collection<ComponentContainer<?>> containers(ComponentType functional);
 
     Option<ComponentContainer<?>> container(Class<?> type);
-
-    <T> void validate(ComponentKey<T> key);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentStoreCallback.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentStoreCallback.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.component;
+
+public interface ComponentStoreCallback {
+
+    <T> void store(ComponentKey<T> key, T instance);
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentUtilities.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.dockbox.hartshorn.component;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.util.StringUtilities;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 
 import java.util.Locale;
@@ -47,6 +48,10 @@ public final class ComponentUtilities {
         return id(context, type, false);
     }
 
+    public static String id(ComponentContainer<?> container) {
+        return id(container, false);
+    }
+
     /**
      * Generates an ID for the given type. If the type is a {@link ComponentContainer}, the ID of the container is
      * returned. Otherwise, the ID is generated based on the type's simple name. If {@code ignoreContainerName} is
@@ -54,24 +59,15 @@ public final class ComponentUtilities {
      *
      * @param context the application context
      * @param type the type to generate an ID for
-     * @param ignoreContainerName whether or not to ignore the container name
+     * @param ignoreContainerName whether to ignore the container name
      * @return the ID
      */
     public static String id(ApplicationContext context, Class<?> type, boolean ignoreContainerName) {
         return format(context, type, ignoreContainerName, '-', ComponentContainer::id).toLowerCase(Locale.ROOT);
     }
 
-    /**
-     * Generates a name for the given type. If the type is a {@link ComponentContainer}, the name of the container is
-     * returned. Otherwise, the name is generated based on the type's simple name.
-     *
-     * @param context the application context
-     * @param type the type to generate a name for
-     * @param ignoreContainerName whether or not to ignore the container name
-     * @return the name
-     */
-    public static String name(ApplicationContext context, Class<?> type, boolean ignoreContainerName) {
-        return format(context, type, ignoreContainerName, ' ', ComponentContainer::name);
+    public static String id(ComponentContainer<?> container, boolean ignoreContainerName) {
+        return format(container, ignoreContainerName, '-', ComponentContainer::id).toLowerCase(Locale.ROOT);
     }
 
     /**
@@ -80,21 +76,46 @@ public final class ComponentUtilities {
      *
      * @param context the application context
      * @param type the type to generate a name for
-     * @param ignoreContainerName whether or not to ignore the container name
+     * @param ignoreContainerName whether to ignore the container name
+     * @return the name
+     */
+    public static String name(ApplicationContext context, Class<?> type, boolean ignoreContainerName) {
+        return format(context, type, ignoreContainerName, ' ', ComponentContainer::name);
+    }
+
+    public static String name(ComponentContainer<?> container, boolean ignoreContainerName) {
+        return format(container, ignoreContainerName, ' ', ComponentContainer::name);
+    }
+
+    /**
+     * Generates a name for the given type. If the type is a {@link ComponentContainer}, the name of the container is
+     * returned. Otherwise, the name is generated based on the type's simple name.
+     *
+     * @param context the application context
+     * @param type the type to generate a name for
+     * @param ignoreContainerName whether to ignore the container name
      * @param delimiter the delimiter to use when generating the name
      * @param attribute the attribute to use when generating the name
      * @return the name
      */
     public static String format(ApplicationContext context, Class<?> type, boolean ignoreContainerName, char delimiter, Function<ComponentContainer<?>, String> attribute) {
-        Option<ComponentContainer<?>> container = context.get(ComponentLocator.class).container(type);
-        if (!ignoreContainerName && container.present()) {
-            String name = attribute.apply(container.get());
+        Option<ComponentContainer<?>> container = context.get(ComponentRegistry.class).container(type);
+        if (container.present()) {
+            return format(container.get(), ignoreContainerName, delimiter, attribute);
+        }
+        TypeView<?> typeView = context.environment().introspector().introspect(type);
+        return format(new ComponentContainerImpl<>(typeView), ignoreContainerName, delimiter, attribute);
+    }
+
+    public static <T> String format(ComponentContainer<T> container, boolean ignoreContainerName, char delimiter, Function<ComponentContainer<?>, String> attribute) {
+        if (!ignoreContainerName) {
+            String name = attribute.apply(container);
             if (StringUtilities.notEmpty(name)) {
                 return name;
             }
         }
 
-        String raw = type.getSimpleName();
+        String raw = container.type().name();
         if (raw.endsWith("Service")) {
             raw = raw.substring(0, raw.length() - 7);
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchyAwareComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchyAwareComponentProvider.java
@@ -16,22 +16,10 @@
 
 package org.dockbox.hartshorn.component;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
 import org.dockbox.hartshorn.component.processing.CompositeComponentPostProcessor;
-import org.dockbox.hartshorn.component.processing.ModifiableComponentProcessingContext;
 import org.dockbox.hartshorn.context.ContextCarrier;
+import org.dockbox.hartshorn.context.ContextIdentity;
 import org.dockbox.hartshorn.context.ContextKey;
 import org.dockbox.hartshorn.context.DefaultProvisionContext;
 import org.dockbox.hartshorn.inject.ComponentInitializationException;
@@ -40,33 +28,19 @@ import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.ContextDrivenProvider;
 import org.dockbox.hartshorn.inject.ObjectContainer;
 import org.dockbox.hartshorn.inject.Provider;
-import org.dockbox.hartshorn.inject.binding.AbstractBindingHierarchy;
 import org.dockbox.hartshorn.inject.binding.Binder;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
 import org.dockbox.hartshorn.inject.binding.ConcurrentHashSingletonCache;
 import org.dockbox.hartshorn.inject.binding.ContextWrappedHierarchy;
 import org.dockbox.hartshorn.inject.binding.HierarchyBindingFunction;
-import org.dockbox.hartshorn.inject.binding.NativePrunableBindingHierarchy;
 import org.dockbox.hartshorn.inject.binding.SingletonCache;
 import org.dockbox.hartshorn.inject.binding.collection.CollectionBindingHierarchy;
-import org.dockbox.hartshorn.inject.binding.collection.ComponentCollection;
-import org.dockbox.hartshorn.inject.binding.collection.ContainerAwareComponentCollection;
-import org.dockbox.hartshorn.inject.binding.collection.ImmutableCompositeBindingHierarchy;
-import org.dockbox.hartshorn.inject.binding.collection.SimpleComponentCollection;
-import org.dockbox.hartshorn.proxy.ProxyFactory;
-import org.dockbox.hartshorn.proxy.lookup.StateAwareProxyFactory;
 import org.dockbox.hartshorn.util.ApplicationException;
-import org.dockbox.hartshorn.util.ApplicationRuntimeException;
-import org.dockbox.hartshorn.util.CollectionUtilities;
 import org.dockbox.hartshorn.util.IllegalModificationException;
-import org.dockbox.hartshorn.util.Tristate;
 import org.dockbox.hartshorn.util.TypeUtils;
-import org.dockbox.hartshorn.util.collections.ConcurrentSetTreeMultiMap;
 import org.dockbox.hartshorn.util.collections.HashSetMultiMap;
 import org.dockbox.hartshorn.util.collections.MultiMap;
-import org.dockbox.hartshorn.util.collections.NavigableMultiMap;
-import org.dockbox.hartshorn.util.introspect.ParameterizableType;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 
@@ -88,17 +62,19 @@ import org.dockbox.hartshorn.util.option.Option;
  */
 public class HierarchyAwareComponentProvider extends DefaultProvisionContext implements HierarchicalComponentProvider, ContextCarrier {
 
-    private final transient ScopedProviderOwner owner;
-    private final transient Scope scope;
+    private final ScopedProviderOwner owner;
+    private final Scope scope;
 
-    private final transient SingletonCache singletonCache = new ConcurrentHashSingletonCache();
-    private final transient Map<ComponentKeyView<?>, BindingHierarchy<?>> hierarchies = new ConcurrentHashMap<>();
-    private final transient ComponentPostProcessor processor;
+    private final SingletonCache singletonCache = new ConcurrentHashSingletonCache();
+    private final ComponentProviderPostProcessor processor;
+    private final HierarchyCache hierarchyCache;
 
     public HierarchyAwareComponentProvider(ScopedProviderOwner owner, Scope scope) {
         this.owner = owner;
         this.scope = scope;
-        this.processor = new CompositeComponentPostProcessor(owner::postProcessors);
+        CompositeComponentPostProcessor postProcessor = new CompositeComponentPostProcessor(owner::postProcessors);
+        this.processor = new SimpleComponentProviderPostProcessor(owner, postProcessor, owner.applicationContext(), this::storeSingletons);
+        this.hierarchyCache = new HierarchyCache(owner.applicationContext(), owner.applicationProvider(), this);
     }
 
     private <T> Option<ObjectContainer<T>> create(ComponentKey<T> key, ComponentRequestContext requestContext) {
@@ -121,7 +97,7 @@ public class HierarchyAwareComponentProvider extends DefaultProvisionContext imp
         }
         BindingHierarchy<C> hierarchy = this.hierarchy(key);
 
-        ContextKey<ScopeModuleContext> scopeModuleContextKey = ContextKey.builder(ScopeModuleContext.class)
+        ContextIdentity<ScopeModuleContext> scopeModuleContextKey = ContextKey.builder(ScopeModuleContext.class)
                 .fallback(ScopeModuleContext::new)
                 .build();
         Option<ScopeModuleContext> scopeModuleContext = this.applicationContext().first(scopeModuleContextKey);
@@ -135,11 +111,11 @@ public class HierarchyAwareComponentProvider extends DefaultProvisionContext imp
 
     @Override
     public <C> Binder bind(BindingHierarchy<C> hierarchy) {
-        this.hierarchies.put(hierarchy.key().view(), hierarchy);
+        this.hierarchyCache.put(hierarchy);
         return this;
     }
 
-    public <T> Option<ObjectContainer<T>> provide(ComponentKey<T> key, ComponentRequestContext requestContext) throws ApplicationException {
+    protected <T> Option<ObjectContainer<T>> provide(ComponentKey<T> key, ComponentRequestContext requestContext) throws ApplicationException {
         Option<BindingHierarchy<T>> hierarchy = Option.of(this.hierarchy(key, true));
         if (hierarchy.present()) {
             Provider<T> provider = key.strategy().selectProvider(hierarchy.get());
@@ -148,57 +124,6 @@ public class HierarchyAwareComponentProvider extends DefaultProvisionContext imp
             }
         }
         return Option.empty();
-    }
-
-    protected <T> T process(ComponentKey<T> key, ObjectContainer<T> objectContainer, @Nullable ComponentContainer<?> container, ComponentRequestContext requestContext) throws ApplicationException {
-        if (container != null && !container.permitsProcessing()) {
-            return objectContainer.instance();
-        }
-
-        ModifiableComponentProcessingContext<T> processingContext = this.prepareProcessingContext(key, objectContainer.instance(), container, requestContext);
-        objectContainer.processed(true);
-
-        processingContext = this.process(processingContext);
-        return processingContext.instance();
-    }
-
-    protected <E, T extends ContainerAwareComponentCollection<E>> T processCollection(ComponentKey<T> key, T collection, ComponentRequestContext requestContext) throws ApplicationException {
-        ComponentKey<E> build = TypeUtils.adjustWildcards(key.mutable()
-                .type(key.parameterizedType().parameters().get(0))
-                .build(), ComponentKey.class);
-
-        for(ObjectContainer<E> container : collection.containers()) {
-            this.process(build, container, null, requestContext);
-        }
-        return collection;
-    }
-
-    protected <T> ModifiableComponentProcessingContext<T> prepareProcessingContext(ComponentKey<T> key, T instance, @Nullable ComponentContainer<?> container, ComponentRequestContext requestContext) {
-        ModifiableComponentProcessingContext<T> processingContext = new ModifiableComponentProcessingContext<>(
-                this.applicationContext(), key, requestContext, instance,
-                container == null || container.permitsProxying(),
-                latest -> this.storeSingletons(key, latest));
-
-        if (container != null) {
-            processingContext.put(ComponentKey.of(ComponentContainer.class), container);
-            if (container.permitsProxying()) {
-                StateAwareProxyFactory<T> factory = this.applicationContext().environment().proxyOrchestrator().factory(key.type());
-
-                if (instance != null) {
-                    factory.trackState(false);
-                    factory.advisors().type().delegateAbstractOnly(instance);
-                    factory.trackState(true);
-                }
-                processingContext.put(ComponentKey.of(ProxyFactory.class), factory);
-            }
-        }
-        return processingContext;
-    }
-
-    protected <T> ModifiableComponentProcessingContext<T> process(ModifiableComponentProcessingContext<T> processingContext) throws ApplicationException {
-        this.processor.process(processingContext);
-        this.storeSingletons(processingContext.key(), processingContext.instance());
-        return processingContext;
     }
 
     protected <T> void storeSingletons(ComponentKey<T> key, T instance) {
@@ -221,7 +146,7 @@ public class HierarchyAwareComponentProvider extends DefaultProvisionContext imp
         }
     }
 
-    public <T> Option<ObjectContainer<T>> createContextualInstanceContainer(ComponentKey<T> key, ComponentRequestContext requestContext) throws ApplicationException {
+    protected <T> Option<ObjectContainer<T>> createContextualInstanceContainer(ComponentKey<T> key, ComponentRequestContext requestContext) throws ApplicationException {
         return new ContextDrivenProvider<>(key).provide(this.applicationContext(), requestContext);
     }
 
@@ -253,94 +178,10 @@ public class HierarchyAwareComponentProvider extends DefaultProvisionContext imp
         }
 
         try {
-            return this.processInstance(componentKey, objectContainer, instance, requestContext);
+            return this.processor.processInstance(componentKey, objectContainer, instance, requestContext);
         }
         catch(ApplicationException e) {
             throw new ComponentResolutionException("Failed to process component with key " + componentKey, e);
-        }
-    }
-
-    private <T> T processInstance(ComponentKey<T> componentKey, ObjectContainer<T> objectContainer, T instance, ComponentRequestContext requestContext)
-            throws ApplicationException {
-        Class<? extends T> type = componentKey.type();
-        if (instance != null) {
-            type = TypeUtils.adjustWildcards(instance.getClass(), Class.class);
-        }
-
-        Option<ComponentContainer<?>> container = this.owner.componentLocator().container(type);
-        instance = container.present()
-                ? this.getManagedComponent(componentKey, objectContainer, container, requestContext)
-                : this.getUnmanagedComponent(componentKey, objectContainer, type,requestContext);
-
-        if (instance == null) {
-            throw new ComponentResolutionException("No component found for key " + componentKey);
-        }
-
-        return this.finishComponentRequest(componentKey, instance);
-    }
-
-    private <T> T finishComponentRequest(ComponentKey<T> componentKey, T instance) {
-        this.storeSingletons(componentKey, instance);
-
-        // Inject properties if applicable
-        if (componentKey.enable()) {
-            try {
-                instance = this.owner.postConstructor().doPostConstruct(instance);
-            } catch (ApplicationException e) {
-                throw new ComponentInitializationException("Failed to perform post-construction on component with key " + componentKey, e);
-            }
-        }
-
-        return instance;
-    }
-
-    private <T> T getManagedComponent(ComponentKey<T> componentKey, ObjectContainer<T> objectContainer,
-                                      Option<ComponentContainer<?>> container, ComponentRequestContext requestContext) throws ApplicationException {
-        // Will only mark the object container as processed if the component container permits
-        // processing.
-        return this.process(componentKey, objectContainer, container.get(), requestContext);
-    }
-
-    private <T> T getUnmanagedComponent(ComponentKey<T> componentKey, ObjectContainer<T> objectContainer, Class<? extends T> type, ComponentRequestContext requestContext)
-            throws ApplicationException {
-        TypeView<? extends T> typeView = this.applicationContext().environment().introspector().introspect(type);
-        if (typeView.annotations().has(Component.class)) {
-            throw new ApplicationRuntimeException("Component " + typeView.name() + " is not registered");
-        }
-        if (ComponentCollection.class.isAssignableFrom(componentKey.type())) {
-            if (ComponentCollection.class != componentKey.type()) {
-                throw new IllegalArgumentException("Component collection key must be of type ComponentCollection, specific implementations are not supported");
-            }
-            ComponentCollection<Object> collection = this.processComponentCollection(
-                    TypeUtils.adjustWildcards(componentKey, ComponentKey.class),
-                    TypeUtils.adjustWildcards(objectContainer, ObjectContainer.class),
-                requestContext
-            );
-            return componentKey.type().cast(collection);
-        }
-        return this.process(componentKey, objectContainer, null, requestContext);
-    }
-
-    private <E, T extends ComponentCollection<E>> ComponentCollection<E> processComponentCollection(ComponentKey<T> componentKey, ObjectContainer<T> objectContainer, ComponentRequestContext requestContext)
-            throws ApplicationException {
-        if (objectContainer.instance() == null) {
-            return new SimpleComponentCollection<>(Set.of());
-        }
-        else if (objectContainer.instance() instanceof ContainerAwareComponentCollection<?> containerAwareComponentCollection) {
-
-            ContainerAwareComponentCollection<E> collection = TypeUtils.adjustWildcards(
-                    containerAwareComponentCollection,
-                    ContainerAwareComponentCollection.class);
-
-            ComponentKey<ContainerAwareComponentCollection<E>> key = TypeUtils.adjustWildcards(
-                    componentKey,
-                    ComponentKey.class);
-
-            ContainerAwareComponentCollection<E> processed = this.processCollection(key, collection, requestContext);
-            return new SimpleComponentCollection<>(Set.copyOf(processed));
-        }
-        else {
-            throw new IllegalArgumentException("Component collection from provider must be of type ContainerAwareComponentCollection");
         }
     }
 
@@ -357,7 +198,7 @@ public class HierarchyAwareComponentProvider extends DefaultProvisionContext imp
     @Override
     public MultiMap<Scope, BindingHierarchy<?>> hierarchies() {
         MultiMap<Scope, BindingHierarchy<?>> map = new HashSetMultiMap<>();
-        map.putAll(this.scope, this.hierarchies.values());
+        map.putAll(this.scope, this.hierarchyCache.hierarchies());
         return map;
     }
 
@@ -369,176 +210,14 @@ public class HierarchyAwareComponentProvider extends DefaultProvisionContext imp
             throw new IllegalArgumentException("Cannot create a binding hierarchy for a component key with a different scope");
         }
 
-        BindingHierarchy<?> hierarchy = this.getOrComputeHierarchy(key, permitFallbackResolution);
+        BindingHierarchy<?> hierarchy = this.hierarchyCache.getOrComputeHierarchy(key, permitFallbackResolution);
         BindingHierarchy<T> adjustedHierarchy = TypeUtils.adjustWildcards(hierarchy, BindingHierarchy.class);
         // onUpdate callback is purely so updates will still be saved even if the reference is lost
         if (adjustedHierarchy instanceof ContextWrappedHierarchy || adjustedHierarchy instanceof CollectionBindingHierarchy<?>) {
             return adjustedHierarchy;
         }
         else {
-            return new ContextWrappedHierarchy<>(adjustedHierarchy, this.applicationContext(), updated -> this.hierarchies.put(key.view(), updated));
+            return new ContextWrappedHierarchy<>(adjustedHierarchy, this.applicationContext(), updated -> this.hierarchyCache.put(key.view(), updated));
         }
-    }
-
-    private <T> BindingHierarchy<?> getOrComputeHierarchy(ComponentKey<T> key, boolean permitFallbackResolution) {
-        ComponentKeyView<T> view = key.view();
-        if (this.hierarchies.containsKey(view)) {
-            return this.hierarchies.get(view);
-        }
-        else {
-            return this.computeHierarchy(key, permitFallbackResolution);
-        }
-    }
-
-    @NonNull
-    private <T> BindingHierarchy<?> computeHierarchy(ComponentKey<T> key, boolean permitFallbackResolution) {
-        BindingHierarchy<?> hierarchy = this.tryCreateHierarchy(key, permitFallbackResolution);
-
-        return Objects.requireNonNullElseGet(hierarchy, () -> {
-            // If we don't have an explicit hierarchy on the key, we can try to use the hierarchy of
-            // the application context. This is useful for components that are not explicitly scoped,
-            // but are still accessed through a scope.
-            if(permitFallbackResolution && this.owner.applicationProvider() != this) {
-                return this.owner.applicationProvider().hierarchy(key);
-            }
-            return new NativePrunableBindingHierarchy<>(key, this.applicationContext());
-        });
-    }
-
-    @Nullable
-    private <T> BindingHierarchy<?> tryCreateHierarchy(ComponentKey<T> key, boolean permitFallbackResolution) {
-        BindingHierarchy<?> hierarchy;
-        if(this.isStrict(key)) {
-            hierarchy = this.createHierarchy(key);
-            if (hierarchy != null) {
-                this.hierarchies.put(key.view(), hierarchy);
-            }
-        }
-        else if (permitFallbackResolution) {
-            // Don't bind this hierarchy, as it's a loose match. If the configuration changes, the loose
-            // match may not be valid anymore, so we don't want to cache it.
-            hierarchy = this.looseLookupHierarchy(key);
-        }
-        else if (this.isCollectionComponentKey(key)) {
-            hierarchy = new CollectionBindingHierarchy<>(TypeUtils.adjustWildcards(key, ComponentKey.class), this.applicationContext());
-        }
-        else {
-            hierarchy = null;
-        }
-        return hierarchy;
-    }
-
-    protected boolean isStrict(ComponentKey<?> key) {
-        if (key.strict() == Tristate.UNDEFINED) {
-            return this.applicationContext().environment().isStrictMode();
-        }
-        else {
-            return key.strict().booleanValue();
-        }
-    }
-
-    @Nullable
-    private <T> AbstractBindingHierarchy<?> createHierarchy(ComponentKey<T> key) {
-        if (this.isCollectionComponentKey(key)) {
-            return new CollectionBindingHierarchy<>(
-                TypeUtils.adjustWildcards(key, ComponentKey.class),
-                this.applicationContext()
-            );
-        }
-        else {
-            return null;
-        }
-    }
-
-    @Nullable
-    private <T> BindingHierarchy<?> looseLookupHierarchy(ComponentKey<T> key) {
-        Set<ComponentKeyView<?>> hierarchyKeys = this.hierarchies.keySet();
-        Set<ComponentKeyView<?>> compatibleKeys = hierarchyKeys.stream()
-            .filter(hierarchyKey -> this.isCompatible(key, hierarchyKey))
-            .collect(Collectors.toSet());
-
-        if (this.isCollectionComponentKey(key)) {
-            return this.composeCollectionHierarchy(TypeUtils.adjustWildcards(key, ComponentKey.class), compatibleKeys);
-        }
-        else {
-            if (compatibleKeys.size() == 1) {
-                ComponentKeyView<?> compatibleKey = CollectionUtilities.first(compatibleKeys);
-                return this.hierarchies.get(compatibleKey);
-            }
-            else {
-                // Acceptable, as long as there is a single highest priority binding. If multiple match, it's an error.
-                return this.lookupHighestPriorityHierarchy(key, compatibleKeys);
-            }
-        }
-    }
-
-    private boolean isCollectionComponentKey(ComponentKey<?> key) {
-        return ComponentCollection.class.isAssignableFrom(key.type());
-    }
-
-    @Nullable
-    private BindingHierarchy<?> lookupHighestPriorityHierarchy(ComponentKey<?> key, Set<ComponentKeyView<?>> compatibleKeys) {
-        Set<BindingHierarchy<?>> compatibleHierarchies = compatibleKeys.stream()
-            .map(this.hierarchies::get)
-            .collect(Collectors.toSet());
-
-        // Track entire hierarchy, so potential duplicate top-priority hierarchies can be reported
-        NavigableMultiMap<Integer, BindingHierarchy<?>> providers = new ConcurrentSetTreeMultiMap<>();
-        for (BindingHierarchy<?> compatibleHierarchy : compatibleHierarchies) {
-            int highestPriority = compatibleHierarchy.highestPriority();
-            compatibleHierarchy.get(highestPriority).peek(provider -> {
-                providers.put(highestPriority, compatibleHierarchy);
-            });
-        }
-        Collection<BindingHierarchy<?>> highestPriority = providers.lastEntry();
-        if (highestPriority.size() > 1) {
-            Set<ComponentKey<?>> foundKeys = highestPriority.stream()
-                .map(BindingHierarchy::key)
-                .collect(Collectors.toSet());
-            throw new AmbiguousComponentException(key, foundKeys);
-        }
-        return CollectionUtilities.first(highestPriority);
-    }
-
-    private boolean isCompatible(ComponentKey<?> key, ComponentKeyView<?> other) {
-        ParameterizableType originType = key.parameterizedType();
-        ParameterizableType targetType = other.type();
-        return this.isCompatible(originType, targetType);
-    }
-
-    private boolean isCompatible(ParameterizableType originType, ParameterizableType targetType) {
-        if (!originType.type().isAssignableFrom(targetType.type())) {
-            return false;
-        }
-        List<ParameterizableType> originalParameters = originType.parameters();
-        List<ParameterizableType> targetParameters = targetType.parameters();
-        if (originalParameters.size() != targetParameters.size()) {
-            return false;
-        }
-        for (int i = 0; i < originalParameters.size(); i++) {
-            ParameterizableType originalParameter = originalParameters.get(i);
-            ParameterizableType targetParameter = targetParameters.get(i);
-            if (!this.isCompatible(originalParameter, targetParameter)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private <T> BindingHierarchy<?> composeCollectionHierarchy(ComponentKey<ComponentCollection<T>> key, Set<ComponentKeyView<?>> compatibleKeys) {
-        Set<CollectionBindingHierarchy<?>> hierarchies = new HashSet<>();
-        for (ComponentKeyView<?> compatibleKey : compatibleKeys) {
-            BindingHierarchy<?> hierarchy = this.hierarchies.get(compatibleKey);
-            if (hierarchy instanceof CollectionBindingHierarchy<?> collectionBindingHierarchy) {
-                hierarchies.add(collectionBindingHierarchy);
-            }
-            else {
-                throw new IllegalStateException("Found incompatible hierarchy for key " + compatibleKey +". Expected CollectionBindingHierarchy, but found " + hierarchy.getClass().getSimpleName());
-            }
-        }
-        return new ImmutableCompositeBindingHierarchy<>(
-            key, this.applicationContext(),
-            TypeUtils.adjustWildcards(hierarchies, Collection.class)
-        );
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchyCache.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchyCache.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.component;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.inject.binding.AbstractBindingHierarchy;
+import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
+import org.dockbox.hartshorn.inject.binding.NativePrunableBindingHierarchy;
+import org.dockbox.hartshorn.inject.binding.collection.CollectionBindingHierarchy;
+import org.dockbox.hartshorn.inject.binding.collection.ComponentCollection;
+import org.dockbox.hartshorn.inject.binding.collection.ImmutableCompositeBindingHierarchy;
+import org.dockbox.hartshorn.util.CollectionUtilities;
+import org.dockbox.hartshorn.util.Tristate;
+import org.dockbox.hartshorn.util.TypeUtils;
+import org.dockbox.hartshorn.util.collections.ConcurrentSetTreeMultiMap;
+import org.dockbox.hartshorn.util.collections.NavigableMultiMap;
+import org.dockbox.hartshorn.util.introspect.ParameterizableType;
+
+public class HierarchyCache {
+
+    private final transient Map<ComponentKeyView<?>, BindingHierarchy<?>> hierarchies = new ConcurrentHashMap<>();
+
+    private final ApplicationContext applicationContext;
+    private final HierarchicalComponentProvider globalProvider;
+    private final HierarchicalComponentProvider owner;
+
+    public HierarchyCache(
+            ApplicationContext applicationContext,
+            HierarchicalComponentProvider globalProvider,
+            HierarchicalComponentProvider owner) {
+        this.applicationContext = applicationContext;
+        this.globalProvider = globalProvider;
+        this.owner = owner;
+    }
+
+    public void put(BindingHierarchy<?> hierarchy) {
+        this.hierarchies.put(hierarchy.key().view(), hierarchy);
+    }
+
+    public <T> void put(ComponentKeyView<T> view, BindingHierarchy<T> updated) {
+        this.hierarchies.put(view, updated);
+    }
+
+    public Set<BindingHierarchy<?>> hierarchies() {
+        return Set.copyOf(this.hierarchies.values());
+    }
+
+    public <T> BindingHierarchy<?> getOrComputeHierarchy(ComponentKey<T> key, boolean permitFallbackResolution) {
+        ComponentKeyView<T> view = key.view();
+        if (this.hierarchies.containsKey(view)) {
+            return this.hierarchies.get(view);
+        }
+        else {
+            return this.computeHierarchy(key, permitFallbackResolution);
+        }
+    }
+
+    @NonNull
+    private <T> BindingHierarchy<?> computeHierarchy(ComponentKey<T> key, boolean permitFallbackResolution) {
+        BindingHierarchy<?> hierarchy = this.tryCreateHierarchy(key, permitFallbackResolution);
+
+        return Objects.requireNonNullElseGet(hierarchy, () -> {
+            // If we don't have an explicit hierarchy on the key, we can try to use the hierarchy of
+            // the application context. This is useful for components that are not explicitly scoped,
+            // but are still accessed through a scope.
+            if(permitFallbackResolution && this.globalProvider != this.owner) {
+                return this.globalProvider.hierarchy(key);
+            }
+            return new NativePrunableBindingHierarchy<>(key, this.applicationContext);
+        });
+    }
+
+    @Nullable
+    private <T> BindingHierarchy<?> tryCreateHierarchy(ComponentKey<T> key, boolean permitFallbackResolution) {
+        BindingHierarchy<?> hierarchy;
+        if(this.isStrict(key)) {
+            hierarchy = this.createHierarchy(key);
+            if (hierarchy != null) {
+                this.hierarchies.put(key.view(), hierarchy);
+            }
+        }
+        else if (permitFallbackResolution) {
+            // Don't bind this hierarchy, as it's a loose match. If the configuration changes, the loose
+            // match may not be valid anymore, so we don't want to cache it.
+            hierarchy = this.looseLookupHierarchy(key);
+        }
+        else if (this.isCollectionComponentKey(key)) {
+            hierarchy = new CollectionBindingHierarchy<>(TypeUtils.adjustWildcards(key, ComponentKey.class), this.applicationContext);
+        }
+        else {
+            hierarchy = null;
+        }
+        return hierarchy;
+    }
+
+    protected boolean isStrict(ComponentKey<?> key) {
+        if (key.strict() == Tristate.UNDEFINED) {
+            return this.applicationContext.environment().isStrictMode();
+        }
+        else {
+            return key.strict().booleanValue();
+        }
+    }
+
+    @Nullable
+    private <T> AbstractBindingHierarchy<?> createHierarchy(ComponentKey<T> key) {
+        if (this.isCollectionComponentKey(key)) {
+            return new CollectionBindingHierarchy<>(
+                    TypeUtils.adjustWildcards(key, ComponentKey.class),
+                    this.applicationContext
+            );
+        }
+        else {
+            return null;
+        }
+    }
+
+    @Nullable
+    private <T> BindingHierarchy<?> looseLookupHierarchy(ComponentKey<T> key) {
+        Set<ComponentKeyView<?>> hierarchyKeys = this.hierarchies.keySet();
+        Set<ComponentKeyView<?>> compatibleKeys = hierarchyKeys.stream()
+                .filter(hierarchyKey -> this.isCompatible(key, hierarchyKey))
+                .collect(Collectors.toSet());
+
+        if (this.isCollectionComponentKey(key)) {
+            return this.composeCollectionHierarchy(TypeUtils.adjustWildcards(key, ComponentKey.class), compatibleKeys);
+        }
+        else {
+            if (compatibleKeys.size() == 1) {
+                ComponentKeyView<?> compatibleKey = CollectionUtilities.first(compatibleKeys);
+                return this.hierarchies.get(compatibleKey);
+            }
+            else {
+                // Acceptable, as long as there is a single highest priority binding. If multiple match, it's an error.
+                return this.lookupHighestPriorityHierarchy(key, compatibleKeys);
+            }
+        }
+    }
+
+    private boolean isCollectionComponentKey(ComponentKey<?> key) {
+        return ComponentCollection.class.isAssignableFrom(key.type());
+    }
+
+    @Nullable
+    private BindingHierarchy<?> lookupHighestPriorityHierarchy(ComponentKey<?> key, Set<ComponentKeyView<?>> compatibleKeys) {
+        Set<BindingHierarchy<?>> compatibleHierarchies = compatibleKeys.stream()
+                .map(this.hierarchies::get)
+                .collect(Collectors.toSet());
+
+        // Track entire hierarchy, so potential duplicate top-priority hierarchies can be reported
+        NavigableMultiMap<Integer, BindingHierarchy<?>> providers = new ConcurrentSetTreeMultiMap<>();
+        for (BindingHierarchy<?> compatibleHierarchy : compatibleHierarchies) {
+            int highestPriority = compatibleHierarchy.highestPriority();
+            compatibleHierarchy.get(highestPriority).peek(provider -> {
+                providers.put(highestPriority, compatibleHierarchy);
+            });
+        }
+        Collection<BindingHierarchy<?>> highestPriority = providers.lastEntry();
+        if (highestPriority.size() > 1) {
+            Set<ComponentKey<?>> foundKeys = highestPriority.stream()
+                    .map(BindingHierarchy::key)
+                    .collect(Collectors.toSet());
+            throw new AmbiguousComponentException(key, foundKeys);
+        }
+        return CollectionUtilities.first(highestPriority);
+    }
+
+    private boolean isCompatible(ComponentKey<?> key, ComponentKeyView<?> other) {
+        ParameterizableType originType = key.parameterizedType();
+        ParameterizableType targetType = other.type();
+        return this.isCompatible(originType, targetType);
+    }
+
+    private boolean isCompatible(ParameterizableType originType, ParameterizableType targetType) {
+        if (!originType.type().isAssignableFrom(targetType.type())) {
+            return false;
+        }
+        List<ParameterizableType> originalParameters = originType.parameters();
+        List<ParameterizableType> targetParameters = targetType.parameters();
+        if (originalParameters.size() != targetParameters.size()) {
+            return false;
+        }
+        for (int i = 0; i < originalParameters.size(); i++) {
+            ParameterizableType originalParameter = originalParameters.get(i);
+            ParameterizableType targetParameter = targetParameters.get(i);
+            if (!this.isCompatible(originalParameter, targetParameter)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private <T> BindingHierarchy<?> composeCollectionHierarchy(ComponentKey<ComponentCollection<T>> key, Set<ComponentKeyView<?>> compatibleKeys) {
+        Set<CollectionBindingHierarchy<?>> hierarchies = new HashSet<>();
+        for (ComponentKeyView<?> compatibleKey : compatibleKeys) {
+            BindingHierarchy<?> hierarchy = this.hierarchies.get(compatibleKey);
+            if (hierarchy instanceof CollectionBindingHierarchy<?> collectionBindingHierarchy) {
+                hierarchies.add(collectionBindingHierarchy);
+            }
+            else {
+                throw new IllegalStateException("Found incompatible hierarchy for key " + compatibleKey +". Expected CollectionBindingHierarchy, but found " + hierarchy.getClass().getSimpleName());
+            }
+        }
+        return new ImmutableCompositeBindingHierarchy<>(
+                key, this.applicationContext,
+                TypeUtils.adjustWildcards(hierarchies, Collection.class)
+        );
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAwareComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAwareComponentProvider.java
@@ -44,7 +44,7 @@ import org.dockbox.hartshorn.util.collections.MultiMap;
 public class ScopeAwareComponentProvider extends DefaultProvisionContext implements HierarchicalComponentProvider, ScopedProviderOwner {
 
     private final transient ApplicationContext applicationContext;
-    private final transient ComponentLocator locator;
+    private final transient ComponentRegistry registry;
 
     private final transient MultiMap<Integer, ComponentPostProcessor> postProcessors = new ConcurrentSetTreeMultiMap<>();
     private final transient ComponentInstanceFactory factory;
@@ -53,9 +53,9 @@ public class ScopeAwareComponentProvider extends DefaultProvisionContext impleme
     private final HierarchyAwareComponentProvider applicationComponentProvider;
     private final Set<Class<? extends ComponentPostProcessor>> uninitializedPostProcessors = ConcurrentHashMap.newKeySet();
 
-    protected ScopeAwareComponentProvider(SingleElementContext<? extends ComponentLocator> initializerContext, Configurer configurer) {
-        this.locator = initializerContext.input();
-        this.applicationContext = this.locator.applicationContext();
+    protected ScopeAwareComponentProvider(SingleElementContext<? extends ComponentRegistry> initializerContext, Configurer configurer) {
+        this.registry = initializerContext.input();
+        this.applicationContext = this.registry.applicationContext();
 
         SingleElementContext<ApplicationContext> applicationInitializerContext = initializerContext.transform(this.applicationContext);
         this.postConstructor = configurer.componentPostConstructor.initialize(applicationInitializerContext);
@@ -96,8 +96,8 @@ public class ScopeAwareComponentProvider extends DefaultProvisionContext impleme
     }
 
     @Override
-    public ComponentLocator componentLocator() {
-        return this.locator;
+    public ComponentRegistry componentRegistry() {
+        return this.registry;
     }
 
     @Override
@@ -180,7 +180,7 @@ public class ScopeAwareComponentProvider extends DefaultProvisionContext impleme
         return this.applicationComponentProvider;
     }
 
-    public static ContextualInitializer<ComponentLocator, ComponentProvider> create(Customizer<Configurer> customizer) {
+    public static ContextualInitializer<ComponentRegistry, ComponentProvider> create(Customizer<Configurer> customizer) {
         return context -> {
             Configurer configurer = new Configurer();
             customizer.configure(configurer);
@@ -188,7 +188,7 @@ public class ScopeAwareComponentProvider extends DefaultProvisionContext impleme
             ScopeAwareComponentProvider componentProvider = new ScopeAwareComponentProvider(context, configurer);
             DefaultBindingConfigurerContext.compose(context, binder -> {
                 binder.bind(ComponentInstanceFactory.class).singleton(componentProvider.factory);
-                binder.bind(ComponentLocator.class).singleton(componentProvider.locator);
+                binder.bind(ComponentRegistry.class).singleton(componentProvider.registry);
             });
             return componentProvider;
         };

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopedProviderOwner.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopedProviderOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.inject.binding.ComponentInstanceFactory;
 
 public interface ScopedProviderOwner extends PostProcessingComponentProvider {
 
-    ComponentLocator componentLocator();
+    ComponentRegistry componentRegistry();
 
     ComponentInstanceFactory instanceFactory();
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/SimpleComponentProviderPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/SimpleComponentProviderPostProcessor.java
@@ -63,7 +63,7 @@ public class SimpleComponentProviderPostProcessor implements ComponentProviderPo
             type = TypeUtils.adjustWildcards(instance.getClass(), Class.class);
         }
 
-        Option<ComponentContainer<?>> container = this.owner.componentLocator().container(type);
+        Option<ComponentContainer<?>> container = this.owner.componentRegistry().container(type);
         instance = container.present()
                 ? this.processManagedComponent(componentKey, objectContainer, container, requestContext)
                 : this.processUnmanagedComponent(componentKey, objectContainer, type,requestContext);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/SimpleComponentProviderPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/SimpleComponentProviderPostProcessor.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.component;
+
+import java.util.Set;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
+import org.dockbox.hartshorn.component.processing.ModifiableComponentProcessingContext;
+import org.dockbox.hartshorn.inject.ComponentInitializationException;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
+import org.dockbox.hartshorn.inject.ObjectContainer;
+import org.dockbox.hartshorn.inject.binding.collection.ComponentCollection;
+import org.dockbox.hartshorn.inject.binding.collection.ContainerAwareComponentCollection;
+import org.dockbox.hartshorn.inject.binding.collection.SimpleComponentCollection;
+import org.dockbox.hartshorn.proxy.ProxyFactory;
+import org.dockbox.hartshorn.proxy.lookup.StateAwareProxyFactory;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.ApplicationRuntimeException;
+import org.dockbox.hartshorn.util.TypeUtils;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.option.Option;
+
+public class SimpleComponentProviderPostProcessor implements ComponentProviderPostProcessor {
+
+    private final ScopedProviderOwner owner;
+    private final ComponentPostProcessor processor;
+    private final ApplicationContext applicationContext;
+    private final ComponentStoreCallback storeSingleton;
+
+    public SimpleComponentProviderPostProcessor(
+            ScopedProviderOwner owner,
+            ComponentPostProcessor processor,
+            ApplicationContext applicationContext,
+            ComponentStoreCallback storeSingleton
+    ) {
+        this.owner = owner;
+        this.processor = processor;
+        this.applicationContext = applicationContext;
+        this.storeSingleton = storeSingleton;
+    }
+
+    @Override
+    public <T> T processInstance(ComponentKey<T> componentKey, ObjectContainer<T> objectContainer, T instance,
+            ComponentRequestContext requestContext) throws ApplicationException {
+        Class<? extends T> type = componentKey.type();
+        if (instance != null) {
+            type = TypeUtils.adjustWildcards(instance.getClass(), Class.class);
+        }
+
+        Option<ComponentContainer<?>> container = this.owner.componentLocator().container(type);
+        instance = container.present()
+                ? this.processManagedComponent(componentKey, objectContainer, container, requestContext)
+                : this.processUnmanagedComponent(componentKey, objectContainer, type,requestContext);
+
+        if (instance == null) {
+            throw new ComponentResolutionException("No component found for key " + componentKey);
+        }
+
+        return this.finishComponentRequest(componentKey, instance);
+    }
+
+
+    private <T> T finishComponentRequest(ComponentKey<T> componentKey, T instance) {
+        this.storeSingleton.store(componentKey, instance);
+
+        // Inject properties if applicable
+        if (componentKey.enable()) {
+            try {
+                instance = this.owner.postConstructor().doPostConstruct(instance);
+            } catch (ApplicationException e) {
+                throw new ComponentInitializationException("Failed to perform post-construction on component with key " + componentKey, e);
+            }
+        }
+
+        return instance;
+    }
+
+    private <T> T processManagedComponent(ComponentKey<T> componentKey, ObjectContainer<T> objectContainer,
+            Option<ComponentContainer<?>> container, ComponentRequestContext requestContext) throws ApplicationException {
+        // Will only mark the object container as processed if the component container permits
+        // processing.
+        return this.process(componentKey, objectContainer, container.get(), requestContext);
+    }
+
+    private <T> T processUnmanagedComponent(ComponentKey<T> componentKey, ObjectContainer<T> objectContainer, Class<? extends T> type, ComponentRequestContext requestContext)
+            throws ApplicationException {
+        TypeView<? extends T> typeView = this.applicationContext.environment().introspector().introspect(type);
+        if (typeView.annotations().has(Component.class)) {
+            throw new ApplicationRuntimeException("Component " + typeView.name() + " is not registered");
+        }
+        if (ComponentCollection.class.isAssignableFrom(componentKey.type())) {
+            if (ComponentCollection.class != componentKey.type()) {
+                throw new IllegalArgumentException("Component collection key must be of type ComponentCollection, specific implementations are not supported");
+            }
+            ComponentCollection<Object> collection = this.processComponentCollection(
+                    TypeUtils.adjustWildcards(componentKey, ComponentKey.class),
+                    TypeUtils.adjustWildcards(objectContainer, ObjectContainer.class),
+                    requestContext
+            );
+            return componentKey.type().cast(collection);
+        }
+        return this.process(componentKey, objectContainer, null, requestContext);
+    }
+
+    private <E, T extends ComponentCollection<E>> ComponentCollection<E> processComponentCollection(ComponentKey<T> componentKey, ObjectContainer<T> objectContainer, ComponentRequestContext requestContext)
+            throws ApplicationException {
+        if (objectContainer.instance() == null) {
+            return new SimpleComponentCollection<>(Set.of());
+        }
+        else if (objectContainer.instance() instanceof ContainerAwareComponentCollection<?> containerAwareComponentCollection) {
+
+            ContainerAwareComponentCollection<E> collection = TypeUtils.adjustWildcards(
+                    containerAwareComponentCollection,
+                    ContainerAwareComponentCollection.class);
+
+            ComponentKey<ContainerAwareComponentCollection<E>> key = TypeUtils.adjustWildcards(
+                    componentKey,
+                    ComponentKey.class);
+
+            ContainerAwareComponentCollection<E> processed = this.processCollection(key, collection, requestContext);
+            return new SimpleComponentCollection<>(Set.copyOf(processed));
+        }
+        else {
+            throw new IllegalArgumentException("Component collection from provider must be of type ContainerAwareComponentCollection");
+        }
+    }
+
+    protected <T> ModifiableComponentProcessingContext<T> process(ModifiableComponentProcessingContext<T> processingContext) throws ApplicationException {
+        this.processor.process(processingContext);
+        this.storeSingleton.store(processingContext.key(), processingContext.instance());
+        return processingContext;
+    }
+
+    protected <T> T process(ComponentKey<T> key, ObjectContainer<T> objectContainer, @Nullable ComponentContainer<?> container, ComponentRequestContext requestContext) throws ApplicationException {
+        if (container != null && !container.permitsProcessing()) {
+            return objectContainer.instance();
+        }
+
+        ModifiableComponentProcessingContext<T> processingContext = this.prepareProcessingContext(key, objectContainer.instance(), container, requestContext);
+        objectContainer.processed(true);
+
+        processingContext = this.process(processingContext);
+        return processingContext.instance();
+    }
+
+    protected <E, T extends ContainerAwareComponentCollection<E>> T processCollection(ComponentKey<T> key, T collection, ComponentRequestContext requestContext) throws ApplicationException {
+        ComponentKey<E> build = TypeUtils.adjustWildcards(key.mutable()
+                .type(key.parameterizedType().parameters().getFirst())
+                .build(), ComponentKey.class);
+
+        for(ObjectContainer<E> container : collection.containers()) {
+            this.process(build, container, null, requestContext);
+        }
+        return collection;
+    }
+
+    protected <T> ModifiableComponentProcessingContext<T> prepareProcessingContext(ComponentKey<T> key, T instance, @Nullable ComponentContainer<?> container, ComponentRequestContext requestContext) {
+        ModifiableComponentProcessingContext<T> processingContext = new ModifiableComponentProcessingContext<>(
+                this.applicationContext, key, requestContext, instance,
+                container == null || container.permitsProxying(),
+                latest -> this.storeSingleton.store(key, latest));
+
+        if (container != null) {
+            processingContext.put(ComponentKey.of(ComponentContainer.class), container);
+            if (container.permitsProxying()) {
+                StateAwareProxyFactory<T> factory = this.applicationContext.environment().proxyOrchestrator().factory(key.type());
+
+                if (instance != null) {
+                    factory.trackState(false);
+                    factory.advisors().type().delegateAbstractOnly(instance);
+                    factory.trackState(true);
+                }
+                processingContext.put(ComponentKey.of(ProxyFactory.class), factory);
+            }
+        }
+        return processingContext;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectContextParameterResolver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectContextParameterResolver.java
@@ -75,7 +75,7 @@ public class InjectContextParameterResolver implements InjectParameterResolver {
                 .orNull();
 
         TypeView<? extends Context> type = TypeUtils.adjustWildcards(injectionPoint.type(), TypeView.class);
-        ContextIdentity<? extends Context> key = ContextKey.of(type.type());
+        ContextKey<? extends Context> key = ContextKey.of(type.type());
         if (StringUtilities.notEmpty(name)) {
             key = key.mutable().name(name).build();
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectContextParameterResolver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectContextParameterResolver.java
@@ -18,6 +18,7 @@ package org.dockbox.hartshorn.component.populate.inject;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.populate.PopulateComponentContext;
+import org.dockbox.hartshorn.context.ContextIdentity;
 import org.dockbox.hartshorn.inject.Named;
 import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.context.ContextKey;
@@ -52,7 +53,7 @@ public class InjectContextParameterResolver implements InjectParameterResolver {
             return false;
         }
 
-        ContextKey<? extends Context> contextKey = getContextKey(injectionPoint);
+        ContextIdentity<? extends Context> contextKey = getContextKey(injectionPoint);
         // If absent, we still prefer bindings from the application context in case
         // manual bindings exist. A common example of this is the ApplicationContext
         // itself, which is a self-containing context.
@@ -61,7 +62,7 @@ public class InjectContextParameterResolver implements InjectParameterResolver {
 
     @Override
     public Object resolve(InjectionPoint injectionPoint, PopulateComponentContext<?> context) {
-        ContextKey<? extends Context> key = getContextKey(injectionPoint);
+        ContextIdentity<? extends Context> key = getContextKey(injectionPoint);
         return this.applicationContext.first(key).orNull();
     }
 
@@ -74,7 +75,7 @@ public class InjectContextParameterResolver implements InjectParameterResolver {
                 .orNull();
 
         TypeView<? extends Context> type = TypeUtils.adjustWildcards(injectionPoint.type(), TypeView.class);
-        ContextKey<? extends Context> key = ContextKey.of(type.type());
+        ContextIdentity<? extends Context> key = ContextKey.of(type.type());
         if (StringUtilities.notEmpty(name)) {
             key = key.mutable().name(name).build();
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.component.processing;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentContainer;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 import org.dockbox.hartshorn.component.IllegalComponentModificationException;
 import org.dockbox.hartshorn.proxy.Proxy;
 import org.dockbox.hartshorn.util.ApplicationException;
@@ -30,7 +30,7 @@ import org.dockbox.hartshorn.util.TypeUtils;
  * can be used to add additional functionality to a component, or to modify the component in some way.
  *
  * <p>The component post processor will only process a component if it is known to the application, which
- * is validated through the active {@link ComponentLocator}. If no {@link ComponentContainer} exists for
+ * is validated through the active {@link ComponentRegistry}. If no {@link ComponentContainer} exists for
  * the component, the component post processor will not be called.
  *
  * <p>To specify when a component post processor should be active, and when the application should ignore

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentPreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentPreProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.component.processing;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentContainer;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 
 /**
  * A component pre-processor is responsible for pre-processing a component. This can be used to
@@ -26,7 +26,7 @@ import org.dockbox.hartshorn.component.ComponentLocator;
  * information to the component before it is created.
  *
  * <p>The component post processor will only process a component if it is known to the application, which
- * is validated through the active {@link ComponentLocator}. If no {@link ComponentContainer} exists for
+ * is validated through the active {@link ComponentRegistry}. If no {@link ComponentContainer} exists for
  * the component, the component post processor will not be called.
  *
  * <p>To specify when a component post processor should be active, and when the application should ignore

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/BindsMethodDependencyResolver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/BindsMethodDependencyResolver.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.application.DefaultBindingConfigurerContext;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 import org.dockbox.hartshorn.component.Configuration;
 import org.dockbox.hartshorn.component.condition.ConditionMatcher;
 import org.dockbox.hartshorn.component.processing.Binds;
@@ -45,7 +45,7 @@ public class BindsMethodDependencyResolver extends AbstractContainerDependencyRe
 
     private final ConditionMatcher conditionMatcher;
     private final BindingStrategyRegistry registry;
-    private final ComponentLocator componentLocator;
+    private final ComponentRegistry componentRegistry;
 
     public BindsMethodDependencyResolver(ConditionMatcher conditionMatcher) {
         this(conditionMatcher, new SimpleBindingStrategyRegistry());
@@ -55,7 +55,7 @@ public class BindsMethodDependencyResolver extends AbstractContainerDependencyRe
         super(conditionMatcher.applicationContext());
         this.conditionMatcher = conditionMatcher;
         this.registry = registry;
-        this.componentLocator = conditionMatcher.applicationContext().get(ComponentLocator.class);
+        this.componentRegistry = conditionMatcher.applicationContext().get(ComponentRegistry.class);
     }
 
     public BindingStrategyRegistry registry() {
@@ -79,7 +79,7 @@ public class BindsMethodDependencyResolver extends AbstractContainerDependencyRe
         ApplicationContext applicationContext, TypeView<T> componentType, List<? extends MethodView<T, ?>> bindsMethods) {
         // Binds methods are only processed on managed components. If the component container is not present, there is nothing to do but check that there
         // is no incorrect usage of the @Binds annotation.
-        if (this.componentLocator.container(componentType.type()).absent()) {
+        if (this.componentRegistry.container(componentType.type()).absent()) {
             throw new IllegalStateException(
                 "Component " + componentType.type().getName() + " is not a managed component, but contains binding declarations.");
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ManagedComponentDependencyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ManagedComponentDependencyContext.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.inject;
 import java.util.Set;
 
 import org.dockbox.hartshorn.component.ComponentKey;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 import org.dockbox.hartshorn.component.Scope;
 import org.dockbox.hartshorn.component.ScopeKey;
 import org.dockbox.hartshorn.component.processing.Binds.BindingType;
@@ -29,12 +29,12 @@ import org.dockbox.hartshorn.util.introspect.view.View;
 
 /**
  * A {@link DependencyContext} implementation that is used for managed components. Managed components are components that
- * are managed by the container. Typically, these are obtained through the active {@link ComponentLocator}.
+ * are managed by the container. Typically, these are obtained through the active {@link ComponentRegistry}.
  *
  * @param <T> the type of the component that is managed
  *
  * @see DependencyContext
- * @see ComponentLocator
+ * @see ComponentRegistry
  *
  * @since 0.5.0
  *

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/ExecutableElementContextParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/ExecutableElementContextParameterLoader.java
@@ -53,8 +53,7 @@ public class ExecutableElementContextParameterLoader extends RuleBasedParameterL
     }
 
     private static boolean isRequired(AnnotatedElementView parameter) {
-        return Boolean.TRUE.equals(parameter.annotations().get(Required.class)
-                .map(Required::value)
-                .orElse(false));
+        return parameter.annotations().get(Required.class)
+                .test(Required::value);
     }
 }

--- a/hartshorn-core/src/test/groovy/test/org/dockbox/hartshorn/core/groovy/GroovyComponentTests.groovy
+++ b/hartshorn-core/src/test/groovy/test/org/dockbox/hartshorn/core/groovy/GroovyComponentTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package test.org.dockbox.hartshorn.core.groovy
 
 import jakarta.inject.Inject
 import org.dockbox.hartshorn.application.context.ApplicationContext
-import org.dockbox.hartshorn.component.ComponentLocator
+import org.dockbox.hartshorn.component.ComponentRegistry
 import org.dockbox.hartshorn.testsuite.HartshornTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
@@ -42,7 +41,7 @@ class GroovyComponentTests {
     private ApplicationContext applicationContext
 
     @Inject
-    private ComponentLocator componentLocator
+    private ComponentRegistry componentRegistry
 
     @ParameterizedTest
     @MethodSource("components")
@@ -50,7 +49,7 @@ class GroovyComponentTests {
         def component = this.applicationContext.get(componentType)
         Assertions.assertNotNull(component)
 
-        def container = this.componentLocator.container(componentType)
+        def container = this.componentRegistry.container(componentType)
         Assertions.assertNotNull(container)
         Assertions.assertTrue(container.present())
 

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ContextAwareTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ContextAwareTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package test.org.dockbox.hartshorn;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.dockbox.hartshorn.testsuite.TestComponents;
 import org.junit.jupiter.api.Assertions;
@@ -46,8 +46,8 @@ public class ContextAwareTests {
     }
 
     @Test
-    void testServiceLocatorIsBound() {
-        ComponentLocator componentLocator = this.applicationContext.get(ComponentLocator.class);
-        Assertions.assertNotNull(componentLocator);
+    void testComponentRegistryIsBound() {
+        ComponentRegistry componentRegistry = this.applicationContext.get(ComponentRegistry.class);
+        Assertions.assertNotNull(componentRegistry);
     }
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ContextKeyTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ContextKeyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package test.org.dockbox.hartshorn;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.context.ContextIdentity;
 import org.dockbox.hartshorn.context.ContextKey;
 import org.dockbox.hartshorn.testsuite.HartshornTestApplication;
 import org.junit.jupiter.api.Assertions;
@@ -27,26 +28,26 @@ public class ContextKeyTests {
 
     @Test
     void testContextKeyNameIsNullIfUndefined() {
-        ContextKey<Context> undefinedNameKey = ContextKey.builder(Context.class).build();
+        ContextIdentity<Context> undefinedNameKey = ContextKey.builder(Context.class).build();
         Assertions.assertNull(undefinedNameKey.name());
     }
 
     @Test
     void testContextKeyNameIsNullIfEmpty() {
-        ContextKey<Context> emptyNameKey = ContextKey.builder(Context.class).name("").build();
+        ContextIdentity<Context> emptyNameKey = ContextKey.builder(Context.class).name("").build();
         Assertions.assertNull(emptyNameKey.name());
     }
 
     @Test
     void testContextKeyNameIsNullIfNull() {
         // Ensure no NPE is thrown
-        ContextKey<Context> nullNameKey = Assertions.assertDoesNotThrow(() -> ContextKey.builder(Context.class).name(null).build());
+        ContextIdentity<Context> nullNameKey = Assertions.assertDoesNotThrow(() -> ContextKey.builder(Context.class).name(null).build());
         Assertions.assertNull(nullNameKey.name());
     }
 
     @Test
     void testRequiresApplicationContextIsTrueIfFunction() {
-        ContextKey<Context> key = ContextKey.builder(Context.class)
+        ContextIdentity<Context> key = ContextKey.builder(Context.class)
                 .fallback(applicationContext -> null)
                 .build();
         Assertions.assertTrue(key.requiresApplicationContext());
@@ -54,7 +55,7 @@ public class ContextKeyTests {
 
     @Test
     void testRequiresApplicationContextIsFalseIfSupplier() {
-        ContextKey<Context> key = ContextKey.builder(Context.class)
+        ContextIdentity<Context> key = ContextKey.builder(Context.class)
                 .fallback(() -> null)
                 .build();
         Assertions.assertFalse(key.requiresApplicationContext());
@@ -89,7 +90,7 @@ public class ContextKeyTests {
     @Test
     void testMutableKeyCreatesClone() {
         ContextKey<Context> key = ContextKey.builder(Context.class).build();
-        ContextKey<Context> mutableKey = key.mutable().name("mutable").build();
+        ContextIdentity<Context> mutableKey = key.mutable().name("mutable").build();
         Assertions.assertNotSame(key, mutableKey);
         Assertions.assertNull(key.name());
         Assertions.assertEquals("mutable", mutableKey.name());

--- a/hartshorn-core/src/test/kotlin/test/org/dockbox/hartshorn/core/application/BootstrapConfigurationContractTests.kt
+++ b/hartshorn-core/src/test/kotlin/test/org/dockbox/hartshorn/core/application/BootstrapConfigurationContractTests.kt
@@ -128,8 +128,8 @@ class BootstrapConfigurationContractTests {
     fun testDelegatingApplicationContextContract() {
         val instance = DelegatingApplicationContext.Configurer()
 
-        assertDeferred(instance) { configurer, deferred: ComponentLocator? -> configurer.componentLocator(deferred) }
-        assertContextInitializer(instance) { configurer, initializer -> configurer.componentLocator(initializer) }
+        assertDeferred(instance) { configurer, deferred: ComponentRegistry? -> configurer.componentRegistry(deferred) }
+        assertContextInitializer(instance) { configurer, initializer -> configurer.componentRegistry(initializer) }
 
         assertDeferred(instance) { configurer, deferred: ComponentProvider? -> configurer.componentProvider(deferred) }
         assertContextInitializer(instance) { configurer, initializer -> configurer.componentProvider(initializer) }

--- a/hartshorn-core/src/test/kotlin/test/org/dockbox/hartshorn/core/kotlin/KotlinComponentTests.kt
+++ b/hartshorn-core/src/test/kotlin/test/org/dockbox/hartshorn/core/kotlin/KotlinComponentTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package test.org.dockbox.hartshorn.core.kotlin
 
 import jakarta.inject.Inject
 import org.dockbox.hartshorn.application.context.ApplicationContext
 import org.dockbox.hartshorn.application.environment.ApplicationEnvironment
-import org.dockbox.hartshorn.component.ComponentLocator
+import org.dockbox.hartshorn.component.ComponentRegistry
 import org.dockbox.hartshorn.testsuite.HartshornTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
@@ -43,7 +42,7 @@ class KotlinComponentTests {
     private lateinit var applicationContext: ApplicationContext
 
     @Inject
-    private lateinit var componentLocator: ComponentLocator
+    private lateinit var componentRegistry: ComponentRegistry
 
     @ParameterizedTest
     @MethodSource("components")
@@ -51,7 +50,7 @@ class KotlinComponentTests {
         val component: T = this.applicationContext.get(componentType)
         Assertions.assertNotNull(component)
 
-        val container = this.componentLocator.container(componentType)
+        val container = this.componentRegistry.container(componentType)
         Assertions.assertNotNull(container)
         Assertions.assertTrue(container.present())
 

--- a/hartshorn-core/src/test/scala/test/org/dockbox/hartshorn/core/scala/ScalaComponentTests.scala
+++ b/hartshorn-core/src/test/scala/test/org/dockbox/hartshorn/core/scala/ScalaComponentTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package test.org.dockbox.hartshorn.core.scala
 
 import jakarta.inject.Inject
 import org.dockbox.hartshorn.application.context.ApplicationContext
 import org.dockbox.hartshorn.application.environment.ApplicationEnvironment
-import org.dockbox.hartshorn.component.ComponentLocator
+import org.dockbox.hartshorn.component.ComponentRegistry
 import org.dockbox.hartshorn.testsuite.HartshornTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
@@ -43,7 +42,7 @@ class ScalaComponentTests {
   private var applicationContext: ApplicationContext = _
 
   @Inject
-  private var componentLocator: ComponentLocator = _
+  private var componentRegistry: ComponentRegistry = _
 
   @ParameterizedTest
   @MethodSource(Array("components"))
@@ -51,7 +50,7 @@ class ScalaComponentTests {
     val component = this.applicationContext.get(componentType)
     Assertions.assertNotNull(component)
 
-    val container = this.componentLocator.container(componentType)
+    val container = this.componentRegistry.container(componentType)
     Assertions.assertNotNull(container)
     Assertions.assertTrue(container.present())
 

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/runtime/ValidateExpressionRuntime.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/runtime/ValidateExpressionRuntime.java
@@ -65,7 +65,7 @@ public class ValidateExpressionRuntime extends StandardRuntime {
      */
     public static boolean valid(ResultCollector collector) {
         Option<Boolean> result = collector.result(ExpressionCustomizer.VALIDATION_ID, Boolean.class);
-        return Boolean.TRUE.equals(result.orElse(false));
+        return result.test(Boolean::booleanValue);
     }
 
     /**

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationConfiguration.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationConfiguration.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.i18n;
 
 import org.dockbox.hartshorn.application.ExceptionHandler;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 import org.dockbox.hartshorn.component.Configuration;
 import org.dockbox.hartshorn.component.condition.RequiresActivator;
 import org.dockbox.hartshorn.component.processing.Binds;
@@ -83,12 +83,12 @@ public class TranslationConfiguration {
      * Configures the default translation key generator to allow generating translation keys for methods
      * which rely on implicit translation keys.
      *
-     * @param componentLocator the component locator to account for component IDs
+     * @param componentRegistry the component registry to account for component IDs
      * @return the translation key generator
      */
     @Binds
     @Singleton
-    public TranslationKeyGenerator translationKeyGenerator(ComponentLocator componentLocator) {
-        return new SimpleTranslationKeyGenerator(componentLocator);
+    public TranslationKeyGenerator translationKeyGenerator(ComponentRegistry componentRegistry) {
+        return new SimpleTranslationKeyGenerator(componentRegistry);
     }
 }

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/SimpleTranslationKeyGenerator.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/SimpleTranslationKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.dockbox.hartshorn.i18n.services;
 
 import org.dockbox.hartshorn.component.ComponentContainer;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 import org.dockbox.hartshorn.i18n.annotations.InjectTranslation;
 import org.dockbox.hartshorn.util.StringUtilities;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
@@ -37,11 +37,11 @@ import jakarta.inject.Inject;
  */
 public class SimpleTranslationKeyGenerator implements TranslationKeyGenerator {
 
-    private final ComponentLocator componentLocator;
+    private final ComponentRegistry componentRegistry;
 
     @Inject
-    public SimpleTranslationKeyGenerator(ComponentLocator componentLocator) {
-        this.componentLocator = componentLocator;
+    public SimpleTranslationKeyGenerator(ComponentRegistry componentRegistry) {
+        this.componentRegistry = componentRegistry;
     }
 
     @Override
@@ -63,7 +63,7 @@ public class SimpleTranslationKeyGenerator implements TranslationKeyGenerator {
         String methodKey = String.join(".", StringUtilities.splitCapitals(methodName)).toLowerCase();
 
         TypeView<?> declaringType = method.declaredBy();
-        Option<ComponentContainer<?>> container = this.componentLocator.container(declaringType.type());
+        Option<ComponentContainer<?>> container = this.componentRegistry.container(declaringType.type());
         if (container.present()) {
             String containerKey = container.get().id();
             if (containerKey != null) {

--- a/hartshorn-i18n/src/test/java/test/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
+++ b/hartshorn-i18n/src/test/java/test/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
 
 package test.org.dockbox.hartshorn.i18n;
 
+import java.util.Objects;
+import java.util.function.Predicate;
 import org.dockbox.hartshorn.application.HartshornApplication;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentContainer;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 import org.dockbox.hartshorn.i18n.annotations.InjectTranslation;
 import org.dockbox.hartshorn.i18n.services.TranslationKeyGenerator;
 import org.dockbox.hartshorn.util.CollectionUtilities;
@@ -173,8 +175,8 @@ public final class TranslationBatchGenerator {
     private static List<File> existingFiles() {
         File batch = TranslationBatchGenerator.existingBatch();
         if (batch.exists() && batch.isDirectory()) {
-            return Stream.of(batch.listFiles())
-                    .filter(file -> !file.isDirectory())
+            return Stream.of(Objects.requireNonNull(batch.listFiles()))
+                    .filter(Predicate.not(File::isDirectory))
                     .toList();
         }
         else {
@@ -185,7 +187,7 @@ public final class TranslationBatchGenerator {
     public static Map<String, String> collect(ApplicationContext context) {
         Map<String, String> batch = new HashMap<>();
         TranslationKeyGenerator keyGenerator = context.get(TranslationKeyGenerator.class);
-        for (ComponentContainer<?> container : context.get(ComponentLocator.class).containers()) {
+        for (ComponentContainer<?> container : context.get(ComponentRegistry.class).containers()) {
             TypeView<?> type = container.type();
             List<? extends MethodView<?, ?>> methods = type.methods().annotatedWith(InjectTranslation.class);
             for (MethodView<?, ?> method : methods) {

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ParameterizableType.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ParameterizableType.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.util.introspect;
 
+import java.util.function.Predicate;
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
 import org.dockbox.hartshorn.reporting.Reportable;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
@@ -100,7 +101,7 @@ public final class ParameterizableType implements Reportable {
             .asList()
             .stream()
             .flatMap(parameter -> parameter.resolvedType()
-                .filter(typeView -> !typeView.isWildcard())
+                .filter(Predicate.not(TypeView::isWildcard))
                 .orComputeFlat(() -> {
                     Set<TypeView<?>> bounds = parameter.upperBounds();
                     if (bounds.size() == 1) {

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyObject.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyObject.java
@@ -78,14 +78,19 @@ public interface ProxyObject<T> {
         if (obj == null) {
             return false;
         }
-        return this.manager().delegate().test(delegate -> {
-            if (this.manager().orchestrator().isProxy(obj)) {
-                return this.manager().orchestrator().manager(obj)
+        else if (this.manager().proxy() == obj) {
+            return true;
+        }
+        else {
+            return this.manager().delegate().test(delegate -> {
+                if (this.manager().orchestrator().isProxy(obj)) {
+                    return this.manager().orchestrator().manager(obj)
                         .flatMap(ProxyManager::delegate)
                         .test(delegate::equals);
-            }
-            return delegate.equals(obj) || this.manager().proxy() == obj;
-        });
+                }
+                return delegate.equals(obj);
+            });
+        }
     }
 
     /**

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyObject.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,15 +78,14 @@ public interface ProxyObject<T> {
         if (obj == null) {
             return false;
         }
-        return Boolean.TRUE.equals(this.manager().delegate().map(delegate -> {
+        return this.manager().delegate().test(delegate -> {
             if (this.manager().orchestrator().isProxy(obj)) {
                 return this.manager().orchestrator().manager(obj)
                         .flatMap(ProxyManager::delegate)
-                        .map(delegate::equals)
-                        .orElse(false);
+                        .test(delegate::equals);
             }
-            return delegate.equals(obj);
-        }).orElseGet(() -> this.manager().proxy() == obj));
+            return delegate.equals(obj) || this.manager().proxy() == obj;
+        });
     }
 
     /**

--- a/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/component/ComponentDiagnosticsReporter.java
+++ b/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/component/ComponentDiagnosticsReporter.java
@@ -25,7 +25,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.component.ComponentContainer;
-import org.dockbox.hartshorn.component.ComponentLocator;
+import org.dockbox.hartshorn.component.ComponentRegistry;
 import org.dockbox.hartshorn.reporting.CategorizedDiagnosticsReporter;
 import org.dockbox.hartshorn.reporting.ConfigurableDiagnosticsReporter;
 import org.dockbox.hartshorn.reporting.DiagnosticsPropertyCollector;
@@ -55,14 +55,14 @@ public class ComponentDiagnosticsReporter implements ConfigurableDiagnosticsRepo
 
     @Override
     public void report(DiagnosticsPropertyCollector collector) {
-        ComponentLocator componentLocator = this.applicationContext.get(ComponentLocator.class);
+        ComponentRegistry componentRegistry = this.applicationContext.get(ComponentRegistry.class);
 
         if (this.configuration.groupBy() == ComponentAttribute.NONE) {
-            Reportable[] reporters = this.diagnosticsReporters(componentLocator.containers());
+            Reportable[] reporters = this.diagnosticsReporters(componentRegistry.containers());
             collector.property("all").write(reporters);
         }
         else {
-            Map<String, List<ComponentContainer<?>>> groupedContainers = componentLocator.containers().stream()
+            Map<String, List<ComponentContainer<?>>> groupedContainers = componentRegistry.containers().stream()
                     .collect(Collectors.groupingBy(container -> switch (this.configuration.groupBy()) {
                         case STEREOTYPE -> stereotype(container).getCanonicalName();
                         case PACKAGE -> container.type().packageInfo().name();

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/CollectionUtilities.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/CollectionUtilities.java
@@ -29,6 +29,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import java.util.function.Predicate;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -110,7 +111,7 @@ public final class CollectionUtilities {
      */
     public static <T> Set<T> difference(Collection<T> collectionOne, Collection<T> collectionTwo) {
         BiFunction<Collection<T>, Collection<T>, List<T>> filter = (c1, c2) -> c1.stream()
-                .filter(element -> !c2.contains(element))
+                .filter(Predicate.not(c2::contains))
                 .toList();
 
         List<T> differenceInOne = filter.apply(collectionOne, collectionTwo);

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/option/Option.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/option/Option.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -400,6 +400,20 @@ public interface Option<T> extends Context, Iterable<T> {
      */
     default <K extends T, A extends K> Option<A> adjust(@NonNull Class<K> type) {
         return this.ofType(type).map(value -> TypeUtils.adjustWildcards(value, type));
+    }
+
+    /**
+     * Tests the value wrapped by the current {@link Option} instance using the given {@link Predicate}. If a value is
+     * present, the result of the {@link Predicate} is returned. If no value is present, {@code false} is returned.
+     *
+     * <p>This is particularly useful as a convenience method when returning primitive {@code boolean} values directly
+     * from a {@link Option}, as it does not require explicit unboxing on the caller's end.
+     *
+     * @param predicate the {@link Predicate} to test the value with.
+     * @return the result of the {@link Predicate} if a value is present, otherwise {@code false}.
+     */
+    default boolean test(@NonNull Predicate<T> predicate) {
+        return Boolean.TRUE.equals(this.map(predicate::test).orElse(false));
     }
 
     /**


### PR DESCRIPTION
### Type of Change
- [x] Enhancement (non-breaking change that affects existing code)

### Description
The current `HierarchyAwareComponentProvider` is a mix of various concerns and responsibilities. While this is fine from a technical perspective, maintaining this type is more complex than it should be, especially considering its core responsibility within the framework.

The `HierarchyAwareComponentProvider` was responsible for various concerns, which have been separated to new components:
- Creating components, primary concern of ``HierarchyAwareComponentProvider`, retained
- Post-processing components, concern after the component is already provided, moved to `ComponentProviderPostProcessor`. Implemented by `SimpleComponentProviderPostProcessor` which delegates to a `ComponentPostProcessor` (commonly a composite of all registered post-processors)
- Tracking and validating component hierarchies, moved to `HierarchyCache`

### Checklist
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] I have added documentation that describes my changes (through #1060)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1071

### Additional Notes
Minor changes have been made to the component locator (now called component registry), and a utility `Option#test` was added for convenience.