### PR TITLE
#1075 Read-only views of context types

### DIFF
--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
@@ -163,7 +163,7 @@ public class CommandGatewayImpl implements CommandGateway {
 
     @Override
     public void register(CommandExecutorContext context) {
-        Option<CommandDefinitionContext> container = context.first(CommandDefinitionContext.class);
+        Option<CommandDefinitionContext> container = context.firstContext(CommandDefinitionContext.class);
         if (container.absent()) {
             throw new InvalidExecutorException("Executor contexts should contain at least one container context");
         }
@@ -184,7 +184,7 @@ public class CommandGatewayImpl implements CommandGateway {
         for (String alias : aliases) {
             this.contexts().put(alias, context);
         }
-        this.context.add(context);
+        this.context.addContext(context);
     }
 
     @Override

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
@@ -64,7 +64,7 @@ public class CommandParserImpl implements CommandParser {
     @Override
     public Option<CommandContext> parse(String command, CommandSource source, CommandExecutorContext context) throws ParsingException {
         ApplicationContext applicationContext = context.applicationContext();
-        Option<CommandDefinitionContext> container = context.first(CommandDefinitionContext.class);
+        Option<CommandDefinitionContext> container = context.firstContext(CommandDefinitionContext.class);
         if (container.absent()) {
             return Option.empty();
         }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
@@ -87,7 +87,7 @@ public class MethodCommandExecutorContext<T> extends DefaultApplicationAwareCont
             this.isChild = false;
         }
 
-        this.add(new CommandDefinitionContextImpl(this.applicationContext(), converterRegistry, this.command(), this.method()));
+        this.addContext(new CommandDefinitionContextImpl(this.applicationContext(), converterRegistry, this.command(), this.method()));
 
         this.parentAliases = new CopyOnWriteArrayList<>();
         if (parent != null) {
@@ -219,7 +219,7 @@ public class MethodCommandExecutorContext<T> extends DefaultApplicationAwareCont
     }
 
     private CommandDefinitionContext definition() {
-        Option<CommandDefinitionContext> definition = this.first(CommandDefinitionContext.class);
+        Option<CommandDefinitionContext> definition = this.firstContext(CommandDefinitionContext.class);
         if (definition.absent()) {
             throw new DefinitionContextLostException();
         }

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServicePreProcessor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServicePreProcessor.java
@@ -83,7 +83,7 @@ public class ConfigurationServicePreProcessor extends ComponentPreProcessor {
             LOG.warn("Found multiple configuration files for " + key.type().getSimpleName() + ": " + config);
         }
 
-        ConfigurationURIContextList uriContextList = context.first(ConfigurationURIContextList.CONTEXT_KEY).get();
+        ConfigurationURIContextList uriContextList = context.firstContext(ConfigurationURIContextList.CONTEXT_KEY).get();
         for (URI uri : config) {
             ConfigurationURIContext uriContext = new ConfigurationURIContext(uri, key, source);
             uriContextList.add(uriContext);

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/properties/PropertyAwareComponentPostProcessor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/properties/PropertyAwareComponentPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ public abstract class PropertyAwareComponentPostProcessor extends ComponentPostP
 
     protected void verifyPropertiesAvailable(ApplicationContext context, PropertyHolder propertyHolder) throws ObjectMappingException {
         if (propertyHolder.properties().isEmpty()) {
-            ConfigurationURIContextList uriContextList = context.first(ConfigurationURIContextList.CONTEXT_KEY).get();
+            ConfigurationURIContextList uriContextList = context.firstContext(ConfigurationURIContextList.CONTEXT_KEY).get();
             URIConfigProcessor configProcessor = context.get(URIConfigProcessor.class);
             configProcessor.process(context, uriContextList.uris());
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationInitializerContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/ApplicationInitializerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class ApplicationInitializerContext<I> extends AbstractSingleElementConte
      * @return The current context.
      */
     public ApplicationInitializerContext<I> initializeInitial() {
-        this.add(new DefaultBindingConfigurerContext());
+        this.addContext(new DefaultBindingConfigurerContext());
         return this;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/DefaultBindingConfigurerContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/DefaultBindingConfigurerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.application;
 
-import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.context.DefaultContext;
 
 /**
@@ -62,8 +62,8 @@ public class DefaultBindingConfigurerContext extends DefaultContext {
      * @param context The context to access the {@link DefaultBindingConfigurerContext} from.
      * @param configurer The configurer to compose with the configurer that is currently configured in the context.
      */
-    public static void compose(Context context, DefaultBindingConfigurer configurer) {
         context.first(DefaultBindingConfigurerContext.class)
+    public static void compose(ContextView context, DefaultBindingConfigurer configurer) {
                 .peek(bindingConfigurerContext -> bindingConfigurerContext.compose(configurer));
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/DefaultBindingConfigurerContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/DefaultBindingConfigurerContext.java
@@ -62,8 +62,8 @@ public class DefaultBindingConfigurerContext extends DefaultContext {
      * @param context The context to access the {@link DefaultBindingConfigurerContext} from.
      * @param configurer The configurer to compose with the configurer that is currently configured in the context.
      */
-        context.first(DefaultBindingConfigurerContext.class)
     public static void compose(ContextView context, DefaultBindingConfigurer configurer) {
+        context.firstContext(DefaultBindingConfigurerContext.class)
                 .peek(bindingConfigurerContext -> bindingConfigurerContext.compose(configurer));
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationBuilder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationBuilder.java
@@ -56,6 +56,10 @@ public final class StandardApplicationBuilder implements ApplicationBuilder<Appl
     /**
      * The state of the factory. This is used to prevent multiple threads from creating a new application context at the
      * same time, even though {@link #create()} is synchronized.
+     *
+     * @since 0.4.8
+     *
+     * @author Guus Lieben
      */
     private enum FactoryState {
         /**

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationContextConstructor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/StandardApplicationContextConstructor.java
@@ -104,7 +104,7 @@ public final class StandardApplicationContextConstructor implements ApplicationC
         this.enhanceTypeReferenceCollectorContext(initializerContext, environment, collectorContext, activators);
 
         ServiceActivatorContext serviceActivatorContext = new ServiceActivatorContext(applicationContext, activators);
-        applicationContext.add(serviceActivatorContext);
+        applicationContext.addContext(serviceActivatorContext);
 
         Set<ServiceActivator> serviceActivatorAnnotations = activators.stream()
                 .map(environment.introspector()::introspect)
@@ -113,7 +113,7 @@ public final class StandardApplicationContextConstructor implements ApplicationC
 
 
         this.buildContext.logger().debug("Registering {} type reference collectors to application context", collectorContext.collectors().size());
-        applicationContext.add(collectorContext);
+        applicationContext.addContext(collectorContext);
 
         Set<Class<? extends ComponentProcessor>> processorTypes = serviceActivatorAnnotations.stream()
                 .flatMap(serviceActivator -> Arrays.stream(serviceActivator.processors()))

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ContextClosedException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ContextClosedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.application.context;
 
-import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.util.ApplicationRuntimeException;
 
 /**
@@ -30,7 +30,7 @@ import org.dockbox.hartshorn.util.ApplicationRuntimeException;
  */
 public class ContextClosedException extends ApplicationRuntimeException {
 
-    public ContextClosedException(Class<? extends Context> type) {
+    public ContextClosedException(Class<? extends ContextView> type) {
         super("Context (" + type.getSimpleName() + ") is already closed.");
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/DelegatingApplicationContext.java
@@ -114,7 +114,7 @@ public abstract class DelegatingApplicationContext extends DefaultApplicationAwa
         EnvironmentBinderConfiguration configuration = new ContextualEnvironmentBinderConfiguration();
 
         DefaultBindingConfigurer bindingConfigurer = configurer.defaultBindings.initialize(applicationInitializerContext);
-        for (DefaultBindingConfigurerContext configurerContext : initializerContext.all(DefaultBindingConfigurerContext.class)) {
+        for (DefaultBindingConfigurerContext configurerContext : initializerContext.contexts(DefaultBindingConfigurerContext.class)) {
             bindingConfigurer = bindingConfigurer.compose(configurerContext.configurer());
         }
         configuration.configureBindings(this.environment, bindingConfigurer, this);
@@ -150,20 +150,20 @@ public abstract class DelegatingApplicationContext extends DefaultApplicationAwa
 
     @Override
     public Set<Annotation> activators() {
-        return this.first(ServiceActivatorContext.class)
+        return this.firstContext(ServiceActivatorContext.class)
                 .map(ServiceActivatorContext::activators)
                 .orElseGet(Set::of);
     }
 
     @Override
     public <A> Option<A> activator(Class<A> activator) {
-        return this.first(ServiceActivatorContext.class)
+        return this.firstContext(ServiceActivatorContext.class)
                 .map(context -> context.activator(activator));
     }
 
     @Override
     public boolean hasActivator(Class<? extends Annotation> activator) {
-        return this.first(ServiceActivatorContext.class)
+        return this.firstContext(ServiceActivatorContext.class)
                 .map(context -> context.hasActivator(activator))
                 .orElseGet(() -> false);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ApplicationEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/ApplicationEnvironment.java
@@ -16,10 +16,6 @@
 
 package org.dockbox.hartshorn.application.environment;
 
-import java.lang.annotation.Annotation;
-import java.lang.annotation.Documented;
-import java.util.Collection;
-import java.util.List;
 import java.util.Properties;
 
 import org.dockbox.hartshorn.application.ExceptionHandler;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/DefaultProxyOrchestratorLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/DefaultProxyOrchestratorLoader.java
@@ -31,6 +31,13 @@ public final class DefaultProxyOrchestratorLoader {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Creates a new {@link ContextualInitializer initializer} that will load the default {@link ProxyOrchestrator}
+     * implementation from the {@link DiscoveryService}.
+     *
+     * @param customizer The customizer to apply to the {@link Configurer} before loading the {@link ProxyOrchestrator}
+     * @return The initializer
+     */
     public static ContextualInitializer<Introspector, ProxyOrchestrator> create(Customizer<Configurer> customizer) {
         return context -> {
             // Call, but ignore the result of the customizer for now

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/EnvironmentTypeCollector.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/environment/EnvironmentTypeCollector.java
@@ -71,7 +71,7 @@ public class EnvironmentTypeCollector {
      * @param <T> the type of the elements in the collection
      */
     public <T> Collection<TypeView<? extends T>> types(Predicate<TypeView<?>> predicate) {
-        Option<TypeReferenceCollectorContext> collectorContext = this.environment.applicationContext().first(TypeReferenceCollectorContext.class);
+        Option<TypeReferenceCollectorContext> collectorContext = this.environment.applicationContext().firstContext(TypeReferenceCollectorContext.class);
         if (collectorContext.absent()) {
             LOG.warn("TypeReferenceCollectorContext not available, falling back to no-op type lookup");
             return Collections.emptyList();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentType.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentType.java
@@ -17,9 +17,9 @@
 package org.dockbox.hartshorn.component;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
 import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
+import org.dockbox.hartshorn.context.ContextView;
 
 /**
  * Represents the type of a component, typically represented through {@link Component#type()} or
@@ -30,7 +30,7 @@ import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 @Deprecated(since = "0.6.0", forRemoval = true)
 public enum ComponentType {
     /**
-     * Components range from POJO's to {@link Context} types. The common property of
+     * Components range from POJO's to {@link ContextView context} types. The common property of
      * all components is that they lack functionality, and only provide context. In domain objects the provided context
      * is the entity definition, in persistent entities the context is the data represented by the entity, and in the
      * case of the {@link ApplicationContext} it is information about all application

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchyAwareComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchyAwareComponentProvider.java
@@ -107,7 +107,7 @@ public class HierarchyAwareComponentProvider extends DefaultProvisionContext imp
         ContextIdentity<ScopeModuleContext> scopeModuleContextKey = ContextKey.builder(ScopeModuleContext.class)
                 .fallback(ScopeModuleContext::new)
                 .build();
-        Option<ScopeModuleContext> scopeModuleContext = this.applicationContext().first(scopeModuleContextKey);
+        Option<ScopeModuleContext> scopeModuleContext = this.applicationContext().firstContext(scopeModuleContextKey);
 
         if (scopeModuleContext.absent() && !(this.scope instanceof ApplicationContext)) {
             throw new IllegalModificationException("Cannot add binding to non-application hierarchy without a module context");

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAwareComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ScopeAwareComponentProvider.java
@@ -77,7 +77,7 @@ public class ScopeAwareComponentProvider extends DefaultProvisionContext impleme
     private HierarchyAwareComponentProvider createComponentProvider(Scope scope) {
         HierarchyAwareComponentProvider provider = new HierarchyAwareComponentProvider(this, scope);
         if (scope != this.applicationContext && scope != Scope.DEFAULT_SCOPE) {
-            ScopeModuleContext scopeModuleContext = this.applicationContext.first(ScopeModuleContext.class).get();
+            ScopeModuleContext scopeModuleContext = this.applicationContext.firstContext(ScopeModuleContext.class).get();
             Collection<BindingHierarchy<?>> hierarchies = scopeModuleContext.hierarchies(scope.installableScopeType());
             for (BindingHierarchy<?> hierarchy : hierarchies) {
                 provider.bind(hierarchy);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionMatcher.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionMatcher.java
@@ -25,8 +25,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.context.ContextCarrier;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 import org.dockbox.hartshorn.util.introspect.view.EnclosableView;
 import org.dockbox.hartshorn.util.option.Option;
@@ -69,7 +69,7 @@ public final class ConditionMatcher implements ContextCarrier {
 
     /**
      * Matches the {@link RequiresCondition} annotations of the given {@link AnnotatedElementView}, providing
-     * any additional {@link Context} instances to the {@link ConditionContext} that is used to match the
+     * any additional {@link ContextView} instances to the {@link ConditionContext} that is used to match the
      * {@link Condition condition implementations}. If any of the conditions does not match, this method will
      * return {@code false}. If all conditions match, this method will return {@code true}.
      *
@@ -81,7 +81,7 @@ public final class ConditionMatcher implements ContextCarrier {
      * @param contexts                the additional contexts to provide to the condition context
      * @return {@code true} if all conditions match, {@code false} otherwise
      */
-    public boolean match(AnnotatedElementView annotatedElementContext, Context... contexts) {
+    public boolean match(AnnotatedElementView annotatedElementContext, ContextView... contexts) {
         SequencedCollection<AnnotatedElementView> views = this.includeEnclosingConditions()
                 ? this.collectEnclosedViews(annotatedElementContext)
                 : List.of(annotatedElementContext);
@@ -106,7 +106,7 @@ public final class ConditionMatcher implements ContextCarrier {
 
     /**
      * Matches the given {@link ConditionDeclaration condition declarations} against the given
-     * {@link AnnotatedElementView}, providing any additional {@link Context} instances to the
+     * {@link AnnotatedElementView}, providing any additional {@link ContextView} instances to the
      * {@link ConditionContext} that is used to match the {@link Condition condition implementations}.
      * If any of the conditions does not match, this method will return {@code false}. If all
      * conditions match, this method will return {@code true}.
@@ -116,7 +116,7 @@ public final class ConditionMatcher implements ContextCarrier {
      * @param contexts                the additional contexts to provide to the condition context
      * @return {@code true} if all conditions match, {@code false} otherwise
      */
-    public boolean match(AnnotatedElementView annotatedElementContext, Set<ConditionDeclaration> declarationContexts, Context... contexts) {
+    public boolean match(AnnotatedElementView annotatedElementContext, Set<ConditionDeclaration> declarationContexts, ContextView... contexts) {
         for(ConditionDeclaration declarationContext : declarationContexts) {
             if(!this.match(annotatedElementContext, declarationContext, contexts)) {
                 return false;
@@ -127,7 +127,7 @@ public final class ConditionMatcher implements ContextCarrier {
 
     /**
      * Matches the given {@link ConditionDeclaration} against the given {@link AnnotatedElementView}, providing any
-     * additional {@link Context} instances to the {@link ConditionContext} that is used to match the {@link Condition
+     * additional {@link ContextView} instances to the {@link ConditionContext} that is used to match the {@link Condition
      * condition implementations}. If the condition does not match, this method will return {@code false}. If the
      * condition matches, this method will return {@code true}.
      *
@@ -136,11 +136,11 @@ public final class ConditionMatcher implements ContextCarrier {
      * @param contexts           the additional contexts to provide to the condition context
      * @return {@code true} if the condition matches, {@code false} otherwise
      */
-    public boolean match(AnnotatedElementView element, ConditionDeclaration declarationContext, Context... contexts) {
+    public boolean match(AnnotatedElementView element, ConditionDeclaration declarationContext, ContextView... contexts) {
         Condition condition = declarationContext.condition(this.applicationContext());
         ConditionContext context = new ConditionContext(this.applicationContext, element, declarationContext);
-        for(Context child : contexts) {
             context.add(child);
+        for(ContextView child : contexts) {
         }
         ConditionResult result = condition.matches(context);
         if(!result.matches() && declarationContext.failOnNoMatch()) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionMatcher.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/condition/ConditionMatcher.java
@@ -139,8 +139,8 @@ public final class ConditionMatcher implements ContextCarrier {
     public boolean match(AnnotatedElementView element, ConditionDeclaration declarationContext, ContextView... contexts) {
         Condition condition = declarationContext.condition(this.applicationContext());
         ConditionContext context = new ConditionContext(this.applicationContext, element, declarationContext);
-            context.add(child);
         for(ContextView child : contexts) {
+            context.addContext(child);
         }
         ConditionResult result = condition.matches(context);
         if(!result.matches() && declarationContext.failOnNoMatch()) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectContextParameterResolver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectContextParameterResolver.java
@@ -57,13 +57,13 @@ public class InjectContextParameterResolver implements InjectParameterResolver {
         // If absent, we still prefer bindings from the application context in case
         // manual bindings exist. A common example of this is the ApplicationContext
         // itself, which is a self-containing context.
-        return this.applicationContext.first(contextKey).present();
+        return this.applicationContext.firstContext(contextKey).present();
     }
 
     @Override
     public Object resolve(InjectionPoint injectionPoint, PopulateComponentContext<?> context) {
-        return this.applicationContext.first(key).orNull();
         ContextIdentity<? extends ContextView> key = getContextKey(injectionPoint);
+        return this.applicationContext.firstContext(key).orNull();
     }
 
     private static ContextKey<? extends ContextView> getContextKey(InjectionPoint injectionPoint) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectContextParameterResolver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectContextParameterResolver.java
@@ -20,18 +20,18 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.populate.PopulateComponentContext;
 import org.dockbox.hartshorn.context.ContextIdentity;
 import org.dockbox.hartshorn.inject.Named;
-import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.context.ContextKey;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.util.StringUtilities;
 import org.dockbox.hartshorn.util.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
 /**
- * A {@link InjectParameterResolver} implementation that resolves {@link Context} instances. This resolver
- * will only accept injection points that implement {@link Context}. If multiple contexts are available,
+ * A {@link InjectParameterResolver} implementation that resolves {@link ContextView} instances. This resolver
+ * will only accept injection points that implement {@link ContextView}. If multiple contexts are available,
  * the first one is returned.
  *
- * @see Context
+ * @see ContextView
  *
  * @since 0.6.0
  *
@@ -48,12 +48,12 @@ public class InjectContextParameterResolver implements InjectParameterResolver {
     @Override
     public boolean accepts(InjectionPoint injectionPoint) {
         TypeView<?> type = injectionPoint.type();
-        boolean childOf = type.isChildOf(Context.class);
+        boolean childOf = type.isChildOf(ContextView.class);
         if (!childOf) {
             return false;
         }
 
-        ContextIdentity<? extends Context> contextKey = getContextKey(injectionPoint);
+        ContextIdentity<? extends ContextView> contextKey = getContextKey(injectionPoint);
         // If absent, we still prefer bindings from the application context in case
         // manual bindings exist. A common example of this is the ApplicationContext
         // itself, which is a self-containing context.
@@ -62,11 +62,11 @@ public class InjectContextParameterResolver implements InjectParameterResolver {
 
     @Override
     public Object resolve(InjectionPoint injectionPoint, PopulateComponentContext<?> context) {
-        ContextIdentity<? extends Context> key = getContextKey(injectionPoint);
         return this.applicationContext.first(key).orNull();
+        ContextIdentity<? extends ContextView> key = getContextKey(injectionPoint);
     }
 
-    private static ContextKey<? extends Context> getContextKey(InjectionPoint injectionPoint) {
+    private static ContextKey<? extends ContextView> getContextKey(InjectionPoint injectionPoint) {
         String name = injectionPoint.injectionPoint().annotations()
                 // Unlike components, contexts only support named qualifiers, so we don't
                 // need to include MetaQualifier annotated annotations here.
@@ -74,8 +74,8 @@ public class InjectContextParameterResolver implements InjectParameterResolver {
                 .map(Named::value)
                 .orNull();
 
-        TypeView<? extends Context> type = TypeUtils.adjustWildcards(injectionPoint.type(), TypeView.class);
-        ContextKey<? extends Context> key = ContextKey.of(type.type());
+        TypeView<? extends ContextView> type = TypeUtils.adjustWildcards(injectionPoint.type(), TypeView.class);
+        ContextKey<? extends ContextView> key = ContextKey.of(type.type());
         if (StringUtilities.notEmpty(name)) {
             key = key.mutable().name(name).build();
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectPopulationStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/populate/inject/InjectPopulationStrategy.java
@@ -16,6 +16,8 @@
 
 package org.dockbox.hartshorn.component.populate.inject;
 
+import java.util.Set;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.ComponentResolutionException;
@@ -32,8 +34,6 @@ import org.dockbox.hartshorn.util.LazyStreamableConfigurer;
 import org.dockbox.hartshorn.util.StreamableConfigurer;
 import org.dockbox.hartshorn.util.introspect.convert.ConversionService;
 
-import java.util.Set;
-
 import jakarta.inject.Inject;
 
 /**
@@ -46,7 +46,7 @@ import jakarta.inject.Inject;
  * <p>By default, all components are resolved through the {@link ApplicationContext}. Additional {@link InjectParameterResolver}
  * implementations can be registered to provide custom resolution logic for specific injection points. This is primarily useful
  * for injecting components which are not registered in the {@link ApplicationContext}, or cannot be resolved through the
- * {@link ApplicationContext} alone. Built-in support for {@link org.dockbox.hartshorn.context.Context} types is provided by the
+ * {@link ApplicationContext} alone. Built-in support for {@link org.dockbox.hartshorn.context.ContextView} types is provided by the
  * {@link InjectContextParameterResolver}.
  *
  * <p>Example:

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ContextConfiguringComponentProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ContextConfiguringComponentProcessor.java
@@ -21,10 +21,11 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.context.ContextKey;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.proxy.ProxyFactory;
 import org.dockbox.hartshorn.util.TypeUtils;
 
-public abstract class ContextConfiguringComponentProcessor<C extends Context> extends ComponentPostProcessor {
+public abstract class ContextConfiguringComponentProcessor<C extends ContextView> extends ComponentPostProcessor {
 
     private final Class<C> contextType;
 
@@ -35,7 +36,7 @@ public abstract class ContextConfiguringComponentProcessor<C extends Context> ex
     @Override
     public <T> void preConfigureComponent(ApplicationContext context, @Nullable T instance, ComponentProcessingContext<T> processingContext) {
         if (this.supports(processingContext)) {
-            C componentContext = processingContext.first(ContextKey.of(this.contextType))
+            C componentContext = processingContext.firstContext(ContextKey.of(this.contextType))
                     .orCompute(() -> this.createContext(context, processingContext)).orNull();
 
             if (componentContext != null) {
@@ -43,13 +44,13 @@ public abstract class ContextConfiguringComponentProcessor<C extends Context> ex
             }
 
             if (instance instanceof Context contextInstance) {
-                contextInstance.add(componentContext);
+                contextInstance.addContext(componentContext);
             }
             else {
                 ComponentKey<ProxyFactory<T>> factoryKey = TypeUtils.adjustWildcards(ComponentKey.of(ProxyFactory.class), ComponentKey.class);
                 if (processingContext.containsKey(factoryKey)) {
                     ProxyFactory<T> proxyFactory = processingContext.get(factoryKey);
-                    proxyFactory.contextContainer().add(componentContext);
+                    proxyFactory.contextContainer().addContext(componentContext);
                 }
             }
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ContextKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ContextKey.java
@@ -26,8 +26,8 @@ import org.dockbox.hartshorn.util.StringUtilities;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
 /**
- * A {@link ContextKey} is a key which can be used to retrieve a context value from a {@link Context}
- * instance. The key is used to identify the value, and can be used to create a new value if none
+ * A {@link ContextKey} is a key which can be used to retrieve a context value from a {@link ContextView
+ * context} instance. The key is used to identify the value, and can be used to create a new value if none
  * exists.
  *
  * <p>Context keys do not have to be unique, but it is recommended to re-use the same unique key to
@@ -39,7 +39,7 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
  * @author Guus Lieben
  * @since 0.5.0
  */
-public final class ContextKey<T extends Context> implements ContextIdentity<T> {
+public final class ContextKey<T extends ContextView> implements ContextIdentity<T> {
 
     private final Class<T> type;
     private final String name;
@@ -156,7 +156,7 @@ public final class ContextKey<T extends Context> implements ContextIdentity<T> {
      * @return A new {@link ContextKey key} which is bound to the given type.
      * @param <T> The type of the context represented by the key.
      */
-    public static <T extends Context> ContextKey<T> of(Class<T> type) {
+    public static <T extends ContextView> ContextKey<T> of(Class<T> type) {
         return builder(type).build();
     }
 
@@ -167,7 +167,7 @@ public final class ContextKey<T extends Context> implements ContextIdentity<T> {
      * @return A new {@link ContextKey key} which is bound to the given type.
      * @param <T> The type of the context represented by the key.
      */
-    public static <T extends Context> ContextKey<T> of(TypeView<T> type) {
+    public static <T extends ContextView> ContextKey<T> of(TypeView<T> type) {
         return builder(type).build();
     }
 
@@ -178,7 +178,7 @@ public final class ContextKey<T extends Context> implements ContextIdentity<T> {
      * @return A new {@link Builder key builder} which is bound to the given type and name.
      * @param <T> The type of the context represented by the key.
      */
-    public static <T extends Context> Builder<T> builder(Class<T> type) {
+    public static <T extends ContextView> Builder<T> builder(Class<T> type) {
         return new Builder<>(type);
     }
 
@@ -189,7 +189,7 @@ public final class ContextKey<T extends Context> implements ContextIdentity<T> {
      * @return A new {@link Builder key builder} which is bound to the given type and name.
      * @param <T> The type of the context represented by the key.
      */
-    public static <T extends Context> Builder<T> builder(TypeView<T> type) {
+    public static <T extends ContextView> Builder<T> builder(TypeView<T> type) {
         return new Builder<>(type.type());
     }
 
@@ -230,7 +230,7 @@ public final class ContextKey<T extends Context> implements ContextIdentity<T> {
      * @author Guus Lieben
      * @since 0.5.0
      */
-    public static class Builder<T extends Context> {
+    public static class Builder<T extends ContextView> {
 
         private final Class<T> type;
         private String name;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/DefaultApplicationAwareContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/DefaultApplicationAwareContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,11 +65,11 @@ public abstract class DefaultApplicationAwareContext extends DefaultProvisionCon
     }
 
     @Override
-    public <C extends Context> Option<C> first(ContextIdentity<C> key) {
-        return super.first(key).orCompute(() -> {
+    public <C extends ContextView> Option<C> firstContext(ContextIdentity<C> key) {
+        return super.firstContext(key).orCompute(() -> {
             if (key instanceof ContextKey<C> contextKey) {
                 C context = contextKey.create(this.applicationContext);
-                this.add(context);
+                this.addContext(context);
                 return context;
             }
             return null;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/DefaultProvisionContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/DefaultProvisionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,12 +34,12 @@ import org.dockbox.hartshorn.util.option.Option;
 public abstract class DefaultProvisionContext extends DefaultContext implements ProvisionContext {
 
     @Override
-    public <C extends Context> Option<C> first(Class<C> context) {
-        return ProvisionContext.super.first(context);
+    public <C extends ContextView> Option<C> firstContext(Class<C> context) {
+        return ProvisionContext.super.firstContext(context);
     }
 
     @Override
-    public <C extends Context> List<C> all(Class<C> context) {
-        return ProvisionContext.super.all(context);
+    public <C extends ContextView> List<C> contexts(Class<C> context) {
+        return ProvisionContext.super.contexts(context);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/InstallIfAbsent.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/InstallIfAbsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates whether a {@link Context} type should be automatically created when
- * it is absent while it is looked up through {@link Context#first(ContextIdentity)}.
+ * Indicates whether a {@link ContextView} type should be automatically created when
+ * it is absent while it is looked up through {@link ContextView#firstContext(ContextIdentity)}.
  *
  * <p>Implementations of {@link ApplicationAwareContext} will use this annotation to
  * determine whether a context should be created when a child context is looked up.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ProvisionContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ProvisionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,12 +32,12 @@ import org.dockbox.hartshorn.util.option.Option;
 public interface ProvisionContext extends Context {
 
     @Override
-    default <C extends Context> Option<C> first(Class<C> context) {
-        return this.first(ContextKey.of(context));
+    default <C extends ContextView> Option<C> firstContext(Class<C> context) {
+        return this.firstContext(ContextKey.of(context));
     }
 
     @Override
-    default <C extends Context> List<C> all(Class<C> context) {
-        return this.all(ContextKey.of(context));
+    default <C extends ContextView> List<C> contexts(Class<C> context) {
+        return this.contexts(ContextKey.of(context));
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Context.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,9 @@ import java.lang.annotation.Target;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 
 /**
- * Annotation for injecting a {@link org.dockbox.hartshorn.context.Context} into a class. The context is
- * obtained through the responsible {@link ApplicationContext}. If the
- * context does not exist in the active application context, the injected value will be {@code null}.
+ * Annotation for injecting a {@link org.dockbox.hartshorn.context.ContextView context} into a class. The
+ * context is obtained through the responsible {@link ApplicationContext}. If the context does not exist
+ * in the active application context, the injected value will be {@code null}.
  *
  * @author Guus Lieben
  * @since 0.4.7

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextDrivenProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/ContextDrivenProvider.java
@@ -58,7 +58,7 @@ public class ContextDrivenProvider<C> implements TypeAwareProvider<C> {
         }
         try {
             ViewContextAdapter contextAdapter = new IntrospectionViewContextAdapter(context);
-            contextAdapter.add(requestContext);
+            contextAdapter.addContext(requestContext);
             return contextAdapter.scope(this.context.scope())
                     .create(constructor.get())
                     .cast(this.type())

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/IntrospectionDependencyResolver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/IntrospectionDependencyResolver.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import org.dockbox.hartshorn.application.environment.ApplicationEnvironment;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.populate.ComponentInjectionPoint;
-import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.util.introspect.view.ExecutableElementView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 
@@ -44,7 +44,7 @@ public final class IntrospectionDependencyResolver {
 
     public Set<ComponentKey<?>> resolveDependencies(ExecutableElementView<?> executable) {
         return executable.parameters().all().stream()
-                .filter(parameter -> !parameter.type().isChildOf(Context.class))
+                .filter(parameter -> !parameter.type().isChildOf(ContextView.class))
                 .map(this.environment.componentKeyResolver()::resolve)
                 .collect(Collectors.toSet());
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/MethodInstanceBindingStrategy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/strategy/MethodInstanceBindingStrategy.java
@@ -94,7 +94,7 @@ public class MethodInstanceBindingStrategy implements BindingStrategy {
         ContextAwareComponentSupplier<T> supplier = requestContext -> {
             try {
                 ViewContextAdapter contextAdapter = new IntrospectionViewContextAdapter(applicationContext);
-                contextAdapter.add(requestContext);
+                contextAdapter.addContext(requestContext);
                 return contextAdapter.load(bindsMethod).orNull();
             }
             catch(Throwable throwable) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/IntrospectionViewContextAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/IntrospectionViewContextAdapter.java
@@ -81,7 +81,7 @@ public class IntrospectionViewContextAdapter extends DefaultContext implements V
         parameterLoader.add(rule);
 
         ApplicationBoundParameterLoaderContext loaderContext = new ApplicationBoundParameterLoaderContext(element, null, this.applicationContext(), this.scope);
-        this.copyContextTo(loaderContext);
+        this.copyToContext(loaderContext);
         return parameterLoader.loadArguments(loaderContext).toArray();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/IntrospectionViewContextAdapter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/introspect/IntrospectionViewContextAdapter.java
@@ -51,7 +51,7 @@ public class IntrospectionViewContextAdapter extends DefaultContext implements V
     }
 
     private ComponentRequestContext componentRequestContext() {
-        return this.first(ComponentRequestContext.class)
+        return this.firstContext(ComponentRequestContext.class)
                 .orElseGet(ComponentRequestContext::createForComponent);
     }
 
@@ -81,7 +81,7 @@ public class IntrospectionViewContextAdapter extends DefaultContext implements V
         parameterLoader.add(rule);
 
         ApplicationBoundParameterLoaderContext loaderContext = new ApplicationBoundParameterLoaderContext(element, null, this.applicationContext(), this.scope);
-        this.copyTo(loaderContext);
+        this.copyContextTo(loaderContext);
         return parameterLoader.loadArguments(loaderContext).toArray();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
@@ -109,7 +109,7 @@ public class ApplicationBoundParameterLoaderContext extends ParameterLoaderConte
     }
 
     @Override
-    public void copyContextTo(Context context) {
-        this.context.copyContextTo(context);
+    public void copyToContext(Context context) {
+        this.context.copyToContext(context);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/ApplicationBoundParameterLoaderContext.java
@@ -25,6 +25,7 @@ import org.dockbox.hartshorn.component.Scope;
 import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.context.ContextCarrier;
 import org.dockbox.hartshorn.context.ContextIdentity;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.context.DefaultProvisionContext;
 import org.dockbox.hartshorn.context.ProvisionContext;
 import org.dockbox.hartshorn.inject.ComponentRequestContext;
@@ -78,32 +79,37 @@ public class ApplicationBoundParameterLoaderContext extends ParameterLoaderConte
     }
 
     @Override
-    public <C extends Context> void add(C context) {
-        this.context.add(context);
+    public <C extends ContextView> void addContext(C context) {
+        this.context.addContext(context);
     }
 
     @Override
-    public <C extends Context> void add(String name, C context) {
-        this.context.add(name, context);
+    public <C extends ContextView> void addContext(String name, C context) {
+        this.context.addContext(name, context);
     }
 
     @Override
-    public List<Context> all() {
-        return this.context.all();
+    public ContextView contextView() {
+        return this.context.contextView();
     }
 
     @Override
-    public <C extends Context> Option<C> first(ContextIdentity<C> key) {
-        return this.context.first(key);
+    public List<ContextView> contexts() {
+        return this.context.contexts();
     }
 
     @Override
-    public <C extends Context> List<C> all(ContextIdentity<C> key) {
-        return this.context.all(key);
+    public <C extends ContextView> Option<C> firstContext(ContextIdentity<C> key) {
+        return this.context.firstContext(key);
     }
 
     @Override
-    public void copyTo(Context context) {
-        this.context.copyTo(context);
+    public <C extends ContextView> List<C> contexts(ContextIdentity<C> key) {
+        return this.context.contexts(key);
+    }
+
+    @Override
+    public void copyContextTo(Context context) {
+        this.context.copyContextTo(context);
     }
 }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ApplicationContextTests.java
@@ -30,7 +30,6 @@ import org.dockbox.hartshorn.application.context.DependencyGraph;
 import org.dockbox.hartshorn.application.context.validate.CyclicDependencyGraphValidator;
 import org.dockbox.hartshorn.component.ComponentKey;
 import org.dockbox.hartshorn.component.ComponentPopulator;
-import org.dockbox.hartshorn.component.ComponentRequiredException;
 import org.dockbox.hartshorn.component.ComponentResolutionException;
 import org.dockbox.hartshorn.component.Scope;
 import org.dockbox.hartshorn.component.populate.StrategyComponentPopulator;
@@ -315,7 +314,7 @@ public class ApplicationContextTests {
     @MethodSource("componentPopulators")
     void testContextFieldsAreInjected(Function<ApplicationContext, ComponentPopulator> populatorFactory) {
         String contextName = "InjectedContext";
-        this.applicationContext.add(new SampleContext(contextName));
+        this.applicationContext.addContext(new SampleContext(contextName));
 
         ComponentPopulator populator = populatorFactory.apply(this.applicationContext);
         ContextInjectedType instance = populator.populate(new ContextInjectedType());
@@ -328,7 +327,7 @@ public class ApplicationContextTests {
     @MethodSource("componentPopulators")
     void testNamedContextFieldsAreInjected(Function<ApplicationContext, ComponentPopulator> populatorFactory) {
         String contextName = "InjectedContext";
-        this.applicationContext.add("another", new SampleContext(contextName));
+        this.applicationContext.addContext("another", new SampleContext(contextName));
 
         ComponentPopulator populator = populatorFactory.apply(this.applicationContext);
         ContextInjectedType instance = populator.populate(new ContextInjectedType());
@@ -578,7 +577,7 @@ public class ApplicationContextTests {
     @TestComponents(components = {SetterInjectedComponent.class, ComponentType.class})
     void testSetterInjectionWithContext() {
         SampleContext sampleContext = new SampleContext("setter");
-        this.applicationContext.add("setter", sampleContext);
+        this.applicationContext.addContext("setter", sampleContext);
         SetterInjectedComponent component = this.applicationContext.get(SetterInjectedComponent.class);
         Assertions.assertNotNull(component);
         Assertions.assertNotNull(component.context());

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ContextKeyTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/ContextKeyTests.java
@@ -17,9 +17,9 @@
 package test.org.dockbox.hartshorn;
 
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.context.ContextIdentity;
 import org.dockbox.hartshorn.context.ContextKey;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.testsuite.HartshornTestApplication;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -28,26 +28,26 @@ public class ContextKeyTests {
 
     @Test
     void testContextKeyNameIsNullIfUndefined() {
-        ContextIdentity<Context> undefinedNameKey = ContextKey.builder(Context.class).build();
+        ContextIdentity<ContextView> undefinedNameKey = ContextKey.builder(ContextView.class).build();
         Assertions.assertNull(undefinedNameKey.name());
     }
 
     @Test
     void testContextKeyNameIsNullIfEmpty() {
-        ContextIdentity<Context> emptyNameKey = ContextKey.builder(Context.class).name("").build();
+        ContextIdentity<ContextView> emptyNameKey = ContextKey.builder(ContextView.class).name("").build();
         Assertions.assertNull(emptyNameKey.name());
     }
 
     @Test
     void testContextKeyNameIsNullIfNull() {
+        ContextIdentity<ContextView> nullNameKey = Assertions.assertDoesNotThrow(() -> ContextKey.builder(ContextView.class).name(null).build());
         // Ensure no NPE is thrown
-        ContextIdentity<Context> nullNameKey = Assertions.assertDoesNotThrow(() -> ContextKey.builder(Context.class).name(null).build());
         Assertions.assertNull(nullNameKey.name());
     }
 
     @Test
     void testRequiresApplicationContextIsTrueIfFunction() {
-        ContextIdentity<Context> key = ContextKey.builder(Context.class)
+        ContextIdentity<ContextView> key = ContextKey.builder(ContextView.class)
                 .fallback(applicationContext -> null)
                 .build();
         Assertions.assertTrue(key.requiresApplicationContext());
@@ -55,7 +55,7 @@ public class ContextKeyTests {
 
     @Test
     void testRequiresApplicationContextIsFalseIfSupplier() {
-        ContextIdentity<Context> key = ContextKey.builder(Context.class)
+        ContextIdentity<ContextView> key = ContextKey.builder(ContextView.class)
                 .fallback(() -> null)
                 .build();
         Assertions.assertFalse(key.requiresApplicationContext());
@@ -63,7 +63,7 @@ public class ContextKeyTests {
 
     @Test
     void testContextDoesNotYieldErrorIfFunctionFallbackProvidesNull() {
-        ContextKey<Context> key = ContextKey.builder(Context.class)
+        ContextKey<ContextView> key = ContextKey.builder(ContextView.class)
                 .fallback(applicationContext -> null)
                 .build();
 
@@ -73,7 +73,7 @@ public class ContextKeyTests {
 
     @Test
     void testContextDoesNotYieldErrorIfSupplierFallbackProvidesNull() {
-        ContextKey<Context> key = ContextKey.builder(Context.class)
+        ContextKey<ContextView> key = ContextKey.builder(ContextView.class)
                 .fallback(() -> null)
                 .build();
 
@@ -83,14 +83,14 @@ public class ContextKeyTests {
 
     @Test
     void testCreateYieldsExceptionIfNoFallbackAndApplication() {
-        ContextKey<Context> key = ContextKey.builder(Context.class).build();
+        ContextKey<ContextView> key = ContextKey.builder(ContextView.class).build();
         Assertions.assertThrows(IllegalStateException.class, () -> key.create(null));
     }
 
     @Test
     void testMutableKeyCreatesClone() {
-        ContextKey<Context> key = ContextKey.builder(Context.class).build();
-        ContextIdentity<Context> mutableKey = key.mutable().name("mutable").build();
+        ContextKey<ContextView> key = ContextKey.builder(ContextView.class).build();
+        ContextIdentity<ContextView> mutableKey = key.mutable().name("mutable").build();
         Assertions.assertNotSame(key, mutableKey);
         Assertions.assertNull(key.name());
         Assertions.assertEquals("mutable", mutableKey.name());

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/populate/ComponentPopulationTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/populate/ComponentPopulationTests.java
@@ -47,7 +47,7 @@ public class ComponentPopulationTests {
     @Test
     void testContextFieldPopulation() {
         SampleContext sampleContext = new SampleContext();
-        this.applicationContext.add(sampleContext);
+        this.applicationContext.addContext(sampleContext);
 
         ComponentPopulationStrategy strategy = InjectPopulationStrategy.create(Customizer.useDefaults())
                 .initialize(SimpleSingleElementContext.create(this.applicationContext));
@@ -80,7 +80,7 @@ public class ComponentPopulationTests {
     @Test
     void testInjectMixedMethodPopulation() {
         SampleContext sampleContext = new SampleContext();
-        this.applicationContext.add(sampleContext);
+        this.applicationContext.addContext(sampleContext);
 
         ComponentPopulationStrategy strategy = InjectPopulationStrategy.create(Customizer.useDefaults())
                 .initialize(SimpleSingleElementContext.create(this.applicationContext));

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/ContextConfiguringComponentProcessorTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/processing/ContextConfiguringComponentProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class ContextConfiguringComponentProcessorTests {
         Assertions.assertTrue(applicationContext.environment().proxyOrchestrator().isProxy(emptyComponent));
 
         Proxy<EmptyComponent> component = (Proxy<EmptyComponent>) emptyComponent;
-        Option<SimpleContext> context = component.manager().first(ContextKey.of(SimpleContext.class));
+        Option<SimpleContext> context = component.manager().firstContext(ContextKey.of(SimpleContext.class));
         Assertions.assertTrue(context.present());
         Assertions.assertEquals("Foo", context.get().value());
     }
@@ -61,7 +61,7 @@ public class ContextConfiguringComponentProcessorTests {
         Assertions.assertNotNull(contextComponent);
         Assertions.assertFalse(applicationContext.environment().proxyOrchestrator().isProxy(contextComponent));
 
-        Option<SimpleContext> context = contextComponent.first(ContextKey.of(SimpleContext.class));
+        Option<SimpleContext> context = contextComponent.firstContext(ContextKey.of(SimpleContext.class));
         Assertions.assertTrue(context.present());
         Assertions.assertEquals("Foo", context.get().value());
     }

--- a/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scan/ActivatorScanningTests.java
+++ b/hartshorn-core/src/test/java/test/org/dockbox/hartshorn/scan/ActivatorScanningTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public class ActivatorScanningTests {
 
     @InjectTest
     void testPrefixFromActivatorIsRegistered(ApplicationContext applicationContext) {
-        Option<TypeReferenceCollectorContext> contextCandidate = applicationContext.first(TypeReferenceCollectorContext.class);
+        Option<TypeReferenceCollectorContext> contextCandidate = applicationContext.firstContext(TypeReferenceCollectorContext.class);
         Assertions.assertTrue(contextCandidate.present());
 
         TypeReferenceCollectorContext context = contextCandidate.get();

--- a/hartshorn-core/src/testFixtures/java/org/dockbox/hartshorn/testsuite/InjectTest.java
+++ b/hartshorn-core/src/testFixtures/java/org/dockbox/hartshorn/testsuite/InjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.util.introspect.annotations.Extends;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +29,7 @@ import jakarta.inject.Inject;
 
 /**
  * Acts as a composite between {@link Inject} and {@link Test}. This allows test method parameters to be injected
- * into the test method. Note that this will inject on provision-basis and will not inject {@link Context} types.
+ * into the test method. Note that this will inject on provision-basis and will not inject {@link ContextView} types.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ExpressionCondition.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ExpressionCondition.java
@@ -116,11 +116,11 @@ public class ExpressionCondition implements Condition {
      */
     protected ValidateExpressionRuntime enhance(ValidateExpressionRuntime runtime, ConditionContext context) {
         // Load parameters first, so they can be overwritten by the customizers and imports.
-        context.first(ProvidedParameterContext.class).peek(parameterContext -> {
+        context.firstContext(ProvidedParameterContext.class).peek(parameterContext -> {
             parameterContext.arguments().forEach((parameter, value) -> runtime.global(parameter.name(), value));
         });
 
-        context.first(ExpressionConditionContext.class).peek(expressionContext -> {
+        context.firstContext(ExpressionConditionContext.class).peek(expressionContext -> {
 
             runtime.customizers(expressionContext.customizers());
             runtime.imports(expressionContext.imports());

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/expression/ComplexExpressionParser.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/expression/ComplexExpressionParser.java
@@ -408,7 +408,7 @@ public class ComplexExpressionParser {
     }
 
     private boolean containedInFunctionContext(Function<FunctionParserContext, Boolean> rule) {
-        Option<FunctionParserContext> context = this.parser.first(FunctionParserContext.class);
+        Option<FunctionParserContext> context = this.parser.firstContext(FunctionParserContext.class);
         if (context.absent()) {
             return false;
         }

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/FunctionStatementParser.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/FunctionStatementParser.java
@@ -66,11 +66,11 @@ public class FunctionStatementParser extends AbstractBodyStatementParser<Functio
     }
 
     private FunctionParserContext functionParserContext(TokenParser parser) {
-        Option<FunctionParserContext> context = parser.first(FunctionParserContext.class);
+        Option<FunctionParserContext> context = parser.firstContext(FunctionParserContext.class);
         // Compute locally, to avoid auto-creation of this context
         return context.orCompute(() -> {
             FunctionParserContext newContext = new FunctionParserContext();
-            parser.add(newContext);
+            parser.addContext(newContext);
             return newContext;
         }).get();
     }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ConditionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ConditionTests.java
@@ -82,8 +82,8 @@ public class ConditionTests {
         ExpressionCondition condition = this.applicationContext.get(ExpressionCondition.class);
         AnnotatedElementView element = this.createAnnotatedElement(expression);
         ConditionContext context = new ConditionContext(this.applicationContext, element, null);
-        for (Context child : contexts) {
-            context.add(child);
+        for (ContextView child : contexts) {
+            context.addContext(child);
         }
         return condition.matches(context);
     }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ConditionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ConditionTests.java
@@ -16,10 +16,12 @@
 
 package test.org.dockbox.hartshorn.hsl;
 
+import java.util.stream.Stream;
+
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.condition.ConditionContext;
 import org.dockbox.hartshorn.component.condition.ConditionResult;
-import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.hsl.UseExpressionValidation;
 import org.dockbox.hartshorn.hsl.condition.ExpressionCondition;
 import org.dockbox.hartshorn.hsl.condition.ExpressionConditionContext;
@@ -34,8 +36,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
-
-import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 
@@ -78,7 +78,7 @@ public class ConditionTests {
         Assertions.assertTrue(result.matches());
     }
 
-    ConditionResult match(String expression, Context... contexts) {
+    ConditionResult match(String expression, ContextView... contexts) {
         ExpressionCondition condition = this.applicationContext.get(ExpressionCondition.class);
         AnnotatedElementView element = this.createAnnotatedElement(expression);
         ConditionContext context = new ConditionContext(this.applicationContext, element, null);

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/JDKInterfaceProxyFactory.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/JDKInterfaceProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,8 +77,8 @@ public abstract class JDKInterfaceProxyFactory<T> extends DefaultProxyFactory<T>
     protected Option<T> createProxy(CheckedFunction<ProxyMethodInterceptor<T>, Option<T>> instantiate) throws ApplicationException {
         LazyProxyManager<T> manager = new LazyProxyManager<>(this);
 
-        this.contextContainer().contexts().forEach(manager::add);
-        this.contextContainer().namedContexts().forEach(manager::add);
+        this.contextContainer().contexts().forEach(manager::addContext);
+        this.contextContainer().namedContexts().forEach(manager::addContext);
 
         ProxyMethodInterceptor<T> interceptor = new ProxyAdvisorMethodInterceptor<>(manager, this.orchestrator());
 

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyContextContainer.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyContextContainer.java
@@ -39,12 +39,9 @@ public class ProxyContextContainer extends DefaultContext {
         this.onModify = onModify;
     }
 
-    /**
-     * Returns all contexts that are stored in this container.
-     *
-     * @return all contexts
-     */
-    public Set<Context> contexts() {
+    @Override
+    public Set<ContextView> unnamedContexts() {
+        // Change access level to public
         return super.unnamedContexts();
     }
 
@@ -55,13 +52,14 @@ public class ProxyContextContainer extends DefaultContext {
     }
 
     @Override
-    public <C extends Context> void add(C context) {
-        super.add(context);
+    public <C extends ContextView> void addContext(C context) {
+        super.addContext(context);
         this.onModify.run();
     }
 
     @Override
-    public <C extends Context> void add(String name, C context) {
+    public <C extends ContextView> void addContext(String name, C context) {
+        super.addContext(name, context);
         this.onModify.run();
     }
 }

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyContextContainer.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/ProxyContextContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 package org.dockbox.hartshorn.proxy;
 
+import java.util.Set;
+
 import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.context.DefaultContext;
 import org.dockbox.hartshorn.util.collections.MultiMap;
-
-import java.util.Set;
 
 /**
  * A proxy context container is a {@link Context} implementation that acts as a temporary container for
@@ -48,7 +49,7 @@ public class ProxyContextContainer extends DefaultContext {
     }
 
     @Override
-    public MultiMap<String, Context> namedContexts() {
+    public MultiMap<String, ContextView> namedContexts() {
         // Change access level to public
         return super.namedContexts();
     }
@@ -61,7 +62,6 @@ public class ProxyContextContainer extends DefaultContext {
 
     @Override
     public <C extends Context> void add(String name, C context) {
-        super.add(name, context);
         this.onModify.run();
     }
 }

--- a/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/application/ApplicationDiagnosticsReporter.java
+++ b/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/application/ApplicationDiagnosticsReporter.java
@@ -169,7 +169,7 @@ public class ApplicationDiagnosticsReporter implements ConfigurableDiagnosticsRe
             if (context instanceof NamedContext namedContext) {
                 contextsCollector.property("name").write(namedContext.name());
             }
-            if (!context.all().isEmpty()) {
+            if (!context.contexts().isEmpty()) {
                 Reportable[] childReporters = childReporters(reporterReference, context);
                 contextsCollector.property("children").write(childReporters);
             }
@@ -181,8 +181,8 @@ public class ApplicationDiagnosticsReporter implements ConfigurableDiagnosticsRe
     }
 
     @NonNull
-    private static Reportable[] childReporters(AtomicReference<BiConsumer<DiagnosticsPropertyCollector, Context>> reporterReference, Context context) {
-        return context.all().stream()
+    private static Reportable[] childReporters(AtomicReference<BiConsumer<DiagnosticsPropertyCollector, ContextView>> reporterReference, ContextView context) {
+        return context.contexts().stream()
                 .map(childContext -> (Reportable) (contextsController -> reporterReference.get().accept(contextsController, childContext)))
                 .toArray(Reportable[]::new);
     }

--- a/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/application/ApplicationDiagnosticsReporter.java
+++ b/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/application/ApplicationDiagnosticsReporter.java
@@ -30,7 +30,7 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.application.environment.ApplicationEnvironment;
 import org.dockbox.hartshorn.application.lifecycle.ObservableApplicationEnvironment;
 import org.dockbox.hartshorn.application.lifecycle.Observer;
-import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.context.NamedContext;
 import org.dockbox.hartshorn.reporting.CategorizedDiagnosticsReporter;
 import org.dockbox.hartshorn.reporting.ConfigurableDiagnosticsReporter;
@@ -159,9 +159,9 @@ public class ApplicationDiagnosticsReporter implements ConfigurableDiagnosticsRe
      * @param collector the collector to write to
      */
     protected void reportContexts(DiagnosticsPropertyCollector collector) {
-        AtomicReference<BiConsumer<DiagnosticsPropertyCollector, Context>> reporterReference = new AtomicReference<>();
+        AtomicReference<BiConsumer<DiagnosticsPropertyCollector, ContextView>> reporterReference = new AtomicReference<>();
 
-        BiConsumer<DiagnosticsPropertyCollector, Context> reporter = (contextsCollector, context) -> {
+        BiConsumer<DiagnosticsPropertyCollector, ContextView> reporter = (contextsCollector, context) -> {
             contextsCollector.property("type").write(context.getClass().getCanonicalName());
             if (context instanceof Reportable reportable) {
                 contextsCollector.property("data").write(reportable);

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/Context.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,6 @@
 
 package org.dockbox.hartshorn.context;
 
-import java.util.List;
-
-import org.dockbox.hartshorn.util.option.Option;
-
 /**
  * A context is a collection of objects that can be used to share data between different parts of the application. This
  * is the interface for any context which is capable of storing other contexts.
@@ -27,7 +23,7 @@ import org.dockbox.hartshorn.util.option.Option;
  * @author Guus Lieben
  * @since 0.4.1
  */
-public interface Context {
+public interface Context extends ContextView {
 
     /**
      * Adds the given context to the current context.
@@ -35,7 +31,7 @@ public interface Context {
      * @param context The context to add.
      * @param <C> The type of the context.
      */
-    <C extends Context> void add(C context);
+    <C extends ContextView> void addContext(C context);
 
     /**
      * Adds the given context as a named context using the given name.
@@ -44,57 +40,13 @@ public interface Context {
      * @param context The context to add.
      * @param <C> The type of the context.
      */
-    <C extends Context> void add(String name, C context);
+    <C extends ContextView> void addContext(String name, C context);
 
     /**
-     * Returns all contexts stored in the current context.
-     * @return All contexts stored in the current context.
-     */
-    List<Context> all();
-
-    /**
-     * Returns the first context of the given type.
+     * Returns a view of the current context. This view is read-only and does not allow
+     * for modification of the context.
      *
-     * @param context The type of the context.
-     * @param <C> The type of the context.
-     * @return The first context of the given type.
+     * @return A view of the current context.
      */
-    <C extends Context> Option<C> first(Class<C> context);
-
-    /**
-     * Returns all contexts of the given type. If no contexts of the given type are found, an empty list is returned.
-     *
-     * @param context The type of the context.
-     * @return All contexts of the given type.
-     * @param <C> The type of the context.
-     */
-    <C extends Context> List<C> all(Class<C> context);
-
-    /**
-     * Returns the first context matching the given identity. If no context is found, an attempt may be made to create
-     * a new context using the fallback function of the identity. If no fallback function is present, or it is not
-     * compatible with the current context, an empty option is returned.
-     *
-     * @param key The identity of the context.
-     * @return The first context matching the given identity.
-     * @param <C> The type of the context.
-     */
-    <C extends Context> Option<C> first(ContextIdentity<C> key);
-
-    /**
-     * Returns all contexts matching the given identity. If no contexts are found, an empty list is returned.
-     *
-     * @param key The identity of the context.
-     * @return All contexts matching the given identity.
-     * @param <C> The type of the context.
-     */
-    <C extends Context> List<C> all(ContextIdentity<C> key);
-
-    /**
-     * Copies all child contexts from the current context to the given context. This will not copy the current context
-     * itself.
-     *
-     * @param context The context to copy to.
-     */
-    void copyTo(Context context);
+    ContextView contextView();
 }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/ContextIdentity.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/ContextIdentity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.context;
 
 /**
  * A context identity is a key that can be used to identify a context. It can be used to
- * look up a context in a {@link Context} instance, or to create a new context instance.
+ * look up a context in a {@link ContextView} instance, or to create a new context instance.
  *
  * <p>Note that a context identity is not a context itself. It is only a key that can be
  * used to reach a usable context.
@@ -28,7 +28,7 @@ package org.dockbox.hartshorn.context;
  * @author Guus Lieben
  * @since 0.5.0
  */
-public interface ContextIdentity<T extends Context> {
+public interface ContextIdentity<T extends ContextView> {
 
     /**
      * Gets the type of the context represented by this identity.

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/ContextView.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/ContextView.java
@@ -79,5 +79,5 @@ public interface ContextView {
      *
      * @param context The context to copy to.
      */
-    void copyContextTo(Context context);
+    void copyToContext(Context context);
 }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/ContextView.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/ContextView.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.context;
+
+import java.util.List;
+
+import org.dockbox.hartshorn.util.option.Option;
+
+/**
+ * Immutable view of a {@link Context}, providing read-only access to the contexts stored within.
+ *
+ * @since 0.6.0
+ *
+ * @author Guus Lieben
+ */
+public interface ContextView {
+
+    /**
+     * Returns all contexts stored in the current context.
+     * @return All contexts stored in the current context.
+     */
+    List<ContextView> contexts();
+
+    /**
+     * Returns the first context of the given type.
+     *
+     * @param context The type of the context.
+     * @param <C> The type of the context.
+     * @return The first context of the given type.
+     */
+    <C extends ContextView> Option<C> firstContext(Class<C> context);
+
+    /**
+     * Returns all contexts of the given type. If no contexts of the given type are found, an empty list is returned.
+     *
+     * @param context The type of the context.
+     * @return All contexts of the given type.
+     * @param <C> The type of the context.
+     */
+    <C extends ContextView> List<C> contexts(Class<C> context);
+
+    /**
+     * Returns the first context matching the given identity. If no context is found, an attempt may be made to create
+     * a new context using the fallback function of the identity. If no fallback function is present, or it is not
+     * compatible with the current context, an empty option is returned.
+     *
+     * @param key The identity of the context.
+     * @return The first context matching the given identity.
+     * @param <C> The type of the context.
+     */
+    <C extends ContextView> Option<C> firstContext(ContextIdentity<C> key);
+
+    /**
+     * Returns all contexts matching the given identity. If no contexts are found, an empty list is returned.
+     *
+     * @param key The identity of the context.
+     * @return All contexts matching the given identity.
+     * @param <C> The type of the context.
+     */
+    <C extends ContextView> List<C> contexts(ContextIdentity<C> key);
+
+    /**
+     * Copies all child contexts from the current context to the given context. This will not copy the current context
+     * itself.
+     *
+     * @param context The context to copy to.
+     */
+    void copyContextTo(Context context);
+}

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/DefaultContext.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/DefaultContext.java
@@ -139,7 +139,7 @@ public abstract class DefaultContext implements Context {
     }
 
     @Override
-    public void copyContextTo(Context context) {
+    public void copyToContext(Context context) {
         this.unnamedContexts().forEach(context::addContext);
         this.namedContexts().forEach(context::addContext);
     }

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/SimpleContextIdentity.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/context/SimpleContextIdentity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ package org.dockbox.hartshorn.context;
  *
  * @since 0.5.0
  */
-public class SimpleContextIdentity<T extends Context> implements ContextIdentity<T> {
+public class SimpleContextIdentity<T extends ContextView> implements ContextIdentity<T> {
 
     private final Class<T> type;
     private final String name;

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/AbstractSingleElementContext.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/AbstractSingleElementContext.java
@@ -45,7 +45,7 @@ public abstract class AbstractSingleElementContext<I> extends DefaultContext imp
     @Override
     public <T> @NonNull SingleElementContext<@Nullable T> transform(@Nullable T input) {
         SingleElementContext<T> clonedContext = this.clone(input);
-        this.copyContextTo(clonedContext);
+        this.copyToContext(clonedContext);
         return clonedContext;
     }
 

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/AbstractSingleElementContext.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/AbstractSingleElementContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public abstract class AbstractSingleElementContext<I> extends DefaultContext imp
     @Override
     public <T> @NonNull SingleElementContext<@Nullable T> transform(@Nullable T input) {
         SingleElementContext<T> clonedContext = this.clone(input);
-        this.copyTo(clonedContext);
+        this.copyContextTo(clonedContext);
         return clonedContext;
     }
 

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/ContextualCustomizer.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/ContextualCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 package org.dockbox.hartshorn.util;
 
-import org.dockbox.hartshorn.context.Context;
+import org.dockbox.hartshorn.context.ContextView;
 
 /**
  * A functional interface for customizing objects with additional context. This interface is similar to
- * {@link Customizer} but allows for {@link Context} to be provided alongside the configuration target.
+ * {@link Customizer} but allows for {@link ContextView context} to be provided alongside the configuration
+ * target.
  *
  * @author Guus Lieben
  *
@@ -35,7 +36,7 @@ public interface ContextualCustomizer<T> {
      * @param context The context to use for configuration.
      * @param target The object to configure.
      */
-    void configure(Context context, T target);
+    void configure(ContextView context, T target);
 
     /**
      * Returns a customizer that composes this customizer with the given customizer. When the returned customizer is

--- a/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/ContextTests.java
+++ b/hartshorn-util/src/test/java/test/org/dockbox/hartshorn/util/ContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
 
 package test.org.dockbox.hartshorn.util;
 
+import java.util.List;
+
 import org.dockbox.hartshorn.context.Context;
 import org.dockbox.hartshorn.context.ContextIdentity;
+import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.context.DefaultContext;
 import org.dockbox.hartshorn.context.DefaultNamedContext;
 import org.dockbox.hartshorn.context.SimpleContextIdentity;
 import org.dockbox.hartshorn.util.option.Option;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 public class ContextTests {
 
@@ -34,10 +35,10 @@ public class ContextTests {
         Context context = new TestContext();
         Context child = new TestContext();
 
-        context.add(child);
+        context.addContext(child);
 
         ContextIdentity<TestContext> key = new SimpleContextIdentity<>(TestContext.class);
-        Option<TestContext> first = context.first(key);
+        Option<TestContext> first = context.firstContext(key);
         Assertions.assertTrue(first.present());
         Assertions.assertSame(child, first.get());
     }
@@ -47,10 +48,10 @@ public class ContextTests {
         Context context = new TestContext();
         Context child = new TestContext();
 
-        context.add(child);
+        context.addContext(child);
 
         ContextIdentity<TestContext> key = new SimpleContextIdentity<>(TestContext.class);
-        List<TestContext> all = context.all(key);
+        List<TestContext> all = context.contexts(key);
         Assertions.assertNotNull(all);
         Assertions.assertEquals(1, all.size());
     }
@@ -60,10 +61,10 @@ public class ContextTests {
         Context context = new TestContext();
         NamedTestContext named = new NamedTestContext();
 
-        context.add(named);
+        context.addContext(named);
 
-        ContextIdentity<Context> key = new SimpleContextIdentity<>(Context.class, NamedTestContext.NAME);
-        Option<Context> first = context.first(key);
+        ContextIdentity<ContextView> key = new SimpleContextIdentity<>(ContextView.class, NamedTestContext.NAME);
+        Option<ContextView> first = context.firstContext(key);
         Assertions.assertTrue(first.present());
         Assertions.assertSame(named, first.get());
     }
@@ -73,10 +74,10 @@ public class ContextTests {
         Context context = new TestContext();
         NamedTestContext named = new NamedTestContext();
 
-        context.add(named);
+        context.addContext(named);
 
         ContextIdentity<NamedTestContext> key = new SimpleContextIdentity<>(NamedTestContext.class, NamedTestContext.NAME);
-        Option<NamedTestContext> first = context.first(key);
+        Option<NamedTestContext> first = context.firstContext(key);
         Assertions.assertTrue(first.present());
         Assertions.assertSame(named, first.get());
     }
@@ -84,12 +85,12 @@ public class ContextTests {
     @Test
     void testManuallyNamedContextFirstByName() {
         Context context = new TestContext();
-        Context child = new TestContext();
+        ContextView child = new TestContext();
 
-        context.add(NamedTestContext.NAME, child);
+        context.addContext(NamedTestContext.NAME, child);
 
-        ContextIdentity<Context> key = new SimpleContextIdentity<>(Context.class, NamedTestContext.NAME);
-        Option<Context> first = context.first(key);
+        ContextIdentity<ContextView> key = new SimpleContextIdentity<>(ContextView.class, NamedTestContext.NAME);
+        Option<ContextView> first = context.firstContext(key);
         Assertions.assertTrue(first.present());
         Assertions.assertSame(child, first.get());
     }
@@ -99,10 +100,10 @@ public class ContextTests {
         Context context = new TestContext();
         NamedTestContext named = new NamedTestContext();
 
-        context.add(named);
+        context.addContext(named);
 
-        ContextIdentity<Context> key = new SimpleContextIdentity<>(Context.class, NamedTestContext.NAME);
-        List<Context> all = context.all(key);
+        ContextIdentity<ContextView> key = new SimpleContextIdentity<>(ContextView.class, NamedTestContext.NAME);
+        List<ContextView> all = context.contexts(key);
         Assertions.assertNotNull(all);
         Assertions.assertEquals(1, all.size());
     }
@@ -112,10 +113,10 @@ public class ContextTests {
         Context context = new TestContext();
         NamedTestContext named = new NamedTestContext();
 
-        context.add(named);
+        context.addContext(named);
 
         ContextIdentity<NamedTestContext> key = new SimpleContextIdentity<>(NamedTestContext.class, NamedTestContext.NAME);
-        List<NamedTestContext> all = context.all(key);
+        List<NamedTestContext> all = context.contexts(key);
         Assertions.assertNotNull(all);
         Assertions.assertEquals(1, all.size());
     }
@@ -123,12 +124,12 @@ public class ContextTests {
     @Test
     void testManuallyNamedContextAllByName() {
         Context context = new TestContext();
-        Context child = new TestContext();
+        ContextView child = new TestContext();
 
-        context.add(NamedTestContext.NAME, child);
+        context.addContext(NamedTestContext.NAME, child);
 
-        ContextIdentity<Context> key = new SimpleContextIdentity<>(Context.class, NamedTestContext.NAME);
-        List<Context> all = context.all(key);
+        ContextIdentity<ContextView> key = new SimpleContextIdentity<>(ContextView.class, NamedTestContext.NAME);
+        List<ContextView> all = context.contexts(key);
         Assertions.assertNotNull(all);
         Assertions.assertEquals(1, all.size());
     }


### PR DESCRIPTION
### Type of Change
- [x] Enhancement (non-breaking change that affects existing code)
- [x] Feature (non-breaking change that adds functionality)

### Description
Introduces 'context views', which are read-only views of contexts in which it is still possible to look up additional contexts, but without the ability to register additional context types. For convenience, as well as backwards compatibility, the existing `Context` type extends `ContextView`. This helps consolidate lookup methods in `ContextView`, without having to duplicate the definitions across types.

Additionally, several methods related to lookup, registration, and copying of context have been renamed, this includes:
- `add` -> `addContext`
- `first` -> `firstContext`
- `all` -> `contexts`
- `copyTo` -> `copyToContext`

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] I have added documentation that describes my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1075