### PR TITLE
#1093 Update GPG key for JAR signing

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+## JAR signing (as of July 2024)
+All JAR files released on Maven Central are signed with the following GPG key:
+```plaintext
+Key ID: build@dockbox.org
+Fingerprint: 6F34 6237 5920 3A7C 0E97 1D9E 979A 72D9 DFAB F6A2
+Key size: RSA 4096
+Date: 2024-07-30T16:53:39Z
+```
+
+You can import this key using the public key server:
+```shell
+$ gpg --keyserver keyserver.ubuntu.com --recv 6F34623759203A7C0E971D9E979A72D9DFABF6A2
+```
+
+## JAR signing (before July 2024)
+JAR files released before July 2024 (up to and including release 0.5.0) were signed with the following GPG key:
+```plaintext
+Key ID: guuslieben@xendox.com
+Fingerprint: CCC8 A24E D300 4EF6 22DE 752E F180 83C0 F99D 2EFB
+Key size: RSA 4096
+Date: 2021-11-11T18:13:20Z
+```
+
+```shell
+$ gpg --keyserver keyserver.ubuntu.com --recv CCC8A24ED3004EF622DE752EF18083C0F99D2EFB
+```
+
+> [!NOTE]
+> You can find a permanent copy of this notice at https://dockbox.org/gpg-key-hartshorn.txt

--- a/pom.xml
+++ b/pom.xml
@@ -9,14 +9,22 @@
     <version>${revision}</version>
 
     <name>Hartshorn Framework</name>
-    <description>Hartshorn is a modern JVM-based full stack Java framework</description>
+    <description>Hartshorn Framework</description>
     <url>https://hartshorn.dockbox.org/</url>
+    <inceptionYear>2019</inceptionYear>
 
     <organization>
         <name>Dockbox OSS</name>
         <url>https://dockbox.org/</url>
     </organization>
-    <inceptionYear>2019</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <scm>
         <url>https://github.com/Dockbox-OSS/Hartshorn</url>
@@ -27,18 +35,10 @@
     <developers>
         <developer>
             <name>Guus Lieben</name>
-            <email>guuslieben@xendox.com</email>
-            <url>https://guuslieben.nl/</url>
+            <email>guuslieben@dockbox.org</email>
+            <url>https://github.com/GuusLieben</url>
             <organization>Dockbox OSS</organization>
             <organizationUrl>https://dockbox.org/</organizationUrl>
-        </developer>
-        <developer>
-            <name>Josh Jeffers</name>
-            <url>https://www.pumbas.net/</url>
-        </developer>
-        <developer>
-            <name>Simon Bolduc</name>
-            <url>https://github.com/simbolduc</url>
         </developer>
     </developers>
 
@@ -88,15 +88,6 @@
         <plugin.source.version>3.3.0</plugin.source.version>
         <plugin.staging.version>1.6.13</plugin.staging.version>
     </properties>
-
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
 
     <profiles>
         <profile>


### PR DESCRIPTION
### Type of Change
- [x] Chore (changes to the build process or auxiliary tools)

### Description
Up until this point all JAR releases were signed with my personal GPG key (see below). However, going forward this should be done with a GPG key specific to Hartshorn releases outside of my personal management.

This PR adds a SECURITY.md to explain the security policy around JAR signing. An important notice is that releases up to and including 0.5.0 are signed with the old key, and any releases after this point are released with a project-specific key.

**Previous key**
```plaintext
Key ID: guuslieben@xendox.com
Fingerprint: CCC8 A24E D300 4EF6 22DE 752E F180 83C0 F99D 2EFB
Key size: RSA 4096
Date: 2021-11-11T18:13:20Z
```
Verification:
* Keyserver: https://keyserver.ubuntu.com/pks/lookup?search=CCC8A24ED3004EF622DE752EF18083C0F99D2EFB&fingerprint=on&op=index
* Key notice: https://guuslieben.nl/gpg.txt

**Updated key**
```plaintext
Key ID: build@dockbox.org
Fingerprint: 6F34 6237 5920 3A7C 0E97 1D9E 979A 72D9 DFAB F6A2
Key size: RSA 4096
Date: 2024-07-30T16:53:39Z
```
Verification:
* Keyserver: https://keyserver.ubuntu.com/pks/lookup?search=6F34623759203A7C0E971D9E979A72D9DFABF6A2&fingerprint=on&op=index
* Key notice: https://dockbox.org/gpg-key-hartshorn.txt
* Updated key (`build@dockbox.org`) has been signed with previous active key (`guuslieben@xendox.com`)

### Checklist
- [x] I have performed a self-review of my own code
- [x] Related issue number is linked in pull request title
- [x] I have added documentation that describes my changes

### Related Issue
Closes #1093