### PR TITLE
#1111 Automate dependency version upgrades. Update dependencies for 0.6.0

### DIFF
--- a/hartshorn-bom/pom.xml
+++ b/hartshorn-bom/pom.xml
@@ -20,18 +20,18 @@
     <properties>
         <!-- Versions in alphabetical order -->
         <compile-testing.version>0.21.0</compile-testing.version>
-        <checker.version>3.42.0</checker.version>
-        <hamcrest.version>2.2</hamcrest.version>
-        <jackson.version>2.16.1</jackson.version>
-        <jakarta.annotations.version>2.1.1</jakarta.annotations.version>
+        <checker.version>3.45.0</checker.version>
+        <hamcrest.version>3.0</hamcrest.version>
+        <jackson.version>2.17.2</jackson.version>
+        <jakarta.annotations.version>3.0.0</jakarta.annotations.version>
         <jakarta.inject.version>2.0.1</jakarta.inject.version>
         <javassist.version>3.30.2-GA</javassist.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.annotations.version>1.3.2</javax.annotations.version>
-        <junit.version>5.10.1</junit.version>
-        <logback.version>1.4.14</logback.version>
-        <mockito.version>5.10.0</mockito.version>
-        <slf4j.version>2.0.11</slf4j.version>
+        <junit.version>5.10.3</junit.version>
+        <logback.version>1.5.6</logback.version>
+        <mockito.version>5.12.0</mockito.version>
+        <slf4j.version>2.0.13</slf4j.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
         <!-- Language versions, also inherited by BOM -->
         <groovy.version>4.0.18</groovy.version>
-        <kotlin.version>1.9.22</kotlin.version>
+        <kotlin.version>2.0.0</kotlin.version>
         <scala.version>3.3.1</scala.version>
 
         <!-- Maven plugin versions, in alphabetical order -->

--- a/pom.xml
+++ b/pom.xml
@@ -72,22 +72,22 @@
         <scala.version>3.3.1</scala.version>
 
         <!-- Maven plugin versions, in alphabetical order -->
-        <plugin.buildhelper.version>3.5.0</plugin.buildhelper.version>
-        <plugin.compiler.version>3.12.1</plugin.compiler.version>
-        <plugin.checkstyle.version>3.3.1</plugin.checkstyle.version>
-        <plugin.deploy.version>3.1.1</plugin.deploy.version>
-        <plugin.gpg.version>1.6</plugin.gpg.version>
+        <plugin.buildhelper.version>3.6.0</plugin.buildhelper.version>
+        <plugin.compiler.version>3.13.0</plugin.compiler.version>
+        <plugin.checkstyle.version>3.4.0</plugin.checkstyle.version>
+        <plugin.deploy.version>3.1.2</plugin.deploy.version>
+        <plugin.gpg.version>3.2.4</plugin.gpg.version>
         <plugin.versions.version>2.17.1</plugin.versions.version>
         <plugin.groovy.version>2.1.1</plugin.groovy.version>
-        <plugin.jacoco.version>0.8.11</plugin.jacoco.version>
-        <plugin.jar.version>3.3.0</plugin.jar.version>
-        <plugin.javadoc.version>3.6.3</plugin.javadoc.version>
+        <plugin.jacoco.version>0.8.12</plugin.jacoco.version>
+        <plugin.jar.version>3.4.2</plugin.jar.version>
+        <plugin.javadoc.version>3.8.0</plugin.javadoc.version>
         <plugin.kotlin.version>${kotlin.version}</plugin.kotlin.version>
-        <plugin.license.version>4.3</plugin.license.version>
-        <plugin.owasp.version>9.0.9</plugin.owasp.version>
-        <plugin.scala.version>4.8.1</plugin.scala.version>
-        <plugin.source.version>3.3.0</plugin.source.version>
-        <plugin.staging.version>1.6.13</plugin.staging.version>
+        <plugin.license.version>4.5</plugin.license.version>
+        <plugin.owasp.version>10.0.3</plugin.owasp.version>
+        <plugin.scala.version>4.9.2</plugin.scala.version>
+        <plugin.source.version>3.3.1</plugin.source.version>
+        <plugin.staging.version>1.7.0</plugin.staging.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <plugin.checkstyle.version>3.3.1</plugin.checkstyle.version>
         <plugin.deploy.version>3.1.1</plugin.deploy.version>
         <plugin.gpg.version>1.6</plugin.gpg.version>
+        <plugin.versions.version>2.17.1</plugin.versions.version>
         <plugin.groovy.version>2.1.1</plugin.groovy.version>
         <plugin.jacoco.version>0.8.11</plugin.jacoco.version>
         <plugin.jar.version>3.3.0</plugin.jar.version>
@@ -163,6 +164,11 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${plugin.buildhelper.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>${plugin.versions.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -367,12 +373,23 @@
                 </executions>
             </plugin>
 
+            <!-- Deployment configuration -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <!-- Skip root pom, re-enabled in hartshorn-assembly/pom.staging.xml -->
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <!-- Dependency version upgrades -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredVersions>.*[-_\.](alpha|Alpha|ALPHA|b|beta|Beta|BETA|rc|RC|M|MR|EA)[-_\.]?[0-9]*</ignoredVersions>
+                    <generateBackupPoms>false</generateBackupPoms>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -390,6 +390,12 @@
                 <configuration>
                     <ignoredVersions>.*[-_\.](alpha|Alpha|ALPHA|b|beta|Beta|BETA|rc|RC|M|MR|EA)[-_\.]?[0-9]*</ignoredVersions>
                     <generateBackupPoms>false</generateBackupPoms>
+
+                    <!--
+                    Exclude Kotlin plugin version from being updated, as this should always reference the kotlin.version property
+                    instead of being directly updated by the versions plugin.
+                    -->
+                    <excludeProperties>plugin.kotlin.version</excludeProperties>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
### Type of Change
- [x] Chore (changes to the build process or auxiliary tools)
- [x] Feature (non-breaking change that adds functionality)

### Description
**Dependency updates**
- `org.jetbrains.kotlin:kotlin-stdlib`: 1.9.22 -> 2.0.0
- `org.checkerframework:checker-qual`: 3.42.0 -> 3.45.0
- `com.fasterxml.jackson.core`: 2.16.1 -> 2.17.2
    - `jackson-core`
    - `jackson-dataformat-properties`
    - `jackson-dataformat-toml`
    - `jackson-dataformat-xml`
    - `jackson-dataformat-yaml`
- `jakarta.annotation:jakarta.annotation-api`: 2.1.1 -> 3.0.0
- `org.junit.jupiter`: 5.10.1 -> 5.10.3
    - `junit-jupiter-api`
    - `junit-jupiter-engine`
    - `junit-jupiter-params`
- `ch.qos.logback:logback-classic`: 1.4.14 -> 1.5.6
- `org.mockito:mockito-core`: 5.10.0 -> 5.12.0
- `org.slf4j:slf4j-api`: 2.0.11 -> 2.0.13

**Maven plugin updates**
- `build-helper-maven-plugin`: 3.5.0 -> 3.6.0
- `maven-compiler-plugin`: 3.12.1 -> 3.13.0
- `maven-checkstyle-plugin`: 3.3.1 -> 3.4.0
- `maven-deploy-plugin`: 3.1.1 -> 3.1.2
- `maven-gpg-plugin`: 1.6 -> 3.2.4
- `jacoco-maven-plugin`: 0.8.11 -> 0.8.12
- `license-maven-plugin`: 4.3 -> 4.5
- `dependency-check-maven`: 9.0.9 -> 10.0.3
- `scala-maven-plugin`: 4.8.1 -> 4.9.2
- `kotlin-maven-plugin`: 1.9.22 -> 2.0.0
- `maven-source-plugin`: 3.3.0 -> 3.3.1
- `nexus-staging-maven-plugin`: 1.6.13 -> 1.7.0

### Checklist
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1111