### PR TITLE
Update actions/upload-artifact to v4 in dependency check workflow

### DIFF
--- a/.github/workflows/prebuild.dependency.yml
+++ b/.github/workflows/prebuild.dependency.yml
@@ -21,8 +21,9 @@ jobs:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: mvn dependency-check:check -Dowasp.skip=false -DnvdApiKey=$NVD_API_KEY -P ci
       - name: Archive dependency reports
-        uses: actions/upload-artifact@v2
-        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          name: dependency-check-report
-          path: /hartshorn-*/target/dependency-check-report.html
+          name: OWASP dependency check report
+          path: '**/target/dependency-check-report.html'
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
### Type of Change
- [x] Chore (changes to the build process or auxiliary tools)

### Description
Version 2 of actions/upload-artifact has been deprecated. These changes update to version 4 to ensure the workflow step remains working.

### Checklist
- [x] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch