### PR TITLE
#1122 Add support for binding aliases

### DIFF
--- a/.github/workflows/prebuild.dependency.yml
+++ b/.github/workflows/prebuild.dependency.yml
@@ -19,7 +19,7 @@ jobs:
         shell: bash
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: mvn verify -Dexecution.owasp.skip=false -DnvdApiKey=$NVD_API_KEY -P ci
+        run: mvn verify -DskipTests -Dexecution.owasp.skip=false -DnvdApiKey=$NVD_API_KEY -P ci
       - name: Archive dependency reports
         uses: actions/upload-artifact@v4
         with:

--- a/hartshorn-assembly/pom.assembly.xml
+++ b/hartshorn-assembly/pom.assembly.xml
@@ -198,7 +198,6 @@
                         <package>@asciidoctor/tabs</package>
                         <package>asciidoctor-interdoc-reftext</package>
                     </packages>
-                    <!-- TODO: Change output location? -->
                 </configuration>
                 <executions>
                     <execution>

--- a/hartshorn-assembly/pom.platform.build.xml
+++ b/hartshorn-assembly/pom.platform.build.xml
@@ -20,6 +20,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
 
+        <!-- Shorthands for project paths -->
+        <path.assembly>${maven.multiModuleProjectDirectory}/hartshorn-assembly</path.assembly>
+
         <!-- Language versions, also inherited by BOM -->
         <groovy.version>4.0.18</groovy.version>
         <kotlin.version>2.0.0</kotlin.version>
@@ -32,6 +35,7 @@
         <plugin.jar.version>3.4.2</plugin.jar.version>
         <plugin.javadoc.version>3.8.0</plugin.javadoc.version>
         <plugin.kotlin.version>${kotlin.version}</plugin.kotlin.version>
+        <plugin.license.version>4.6</plugin.license.version>
         <plugin.scala.version>4.9.2</plugin.scala.version>
         <plugin.source.version>3.3.1</plugin.source.version>
     </properties>
@@ -71,6 +75,11 @@
                     <version>${plugin.kotlin.version}</version>
                 </plugin>
                 <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>${plugin.license.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
                     <version>${plugin.scala.version}</version>
@@ -84,6 +93,37 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <headerDefinitions>
+                        <headerDefinition>${path.assembly}/licenses/JavaBlockStyleHeader.xml</headerDefinition>
+                    </headerDefinitions>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>${path.assembly}/licenses/APACHE-2.txt</header>
+                            <useDefaultExcludes>true</useDefaultExcludes>
+                            <includes>
+                                <include>**/*.java</include>
+                                <include>**/*.kt</include>
+                                <include>**/*.groovy</include>
+                                <include>**/*.scala</include>
+                            </includes>
+                        </licenseSet>
+                    </licenseSets>
+                    <mapping>
+                        <java>JavaBlockStyleHeader</java>
+                    </mapping>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin-git</artifactId>
+                        <version>${plugin.license.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <!-- JavaDoc -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/hartshorn-assembly/pom.platform.support.xml
+++ b/hartshorn-assembly/pom.platform.support.xml
@@ -18,9 +18,6 @@
     <description>Common parent POM for all public facing Hartshorn modules</description>
 
     <properties>
-        <!-- Shorthands for project paths -->
-        <path.assembly>${maven.multiModuleProjectDirectory}/hartshorn-assembly</path.assembly>
-
         <!--
         Feature toggles for CI, most default to opt-out behavior.
         Use the 'ci' profile to disable by default, making this opt-in instead.
@@ -39,7 +36,6 @@
         <plugin.checkstyle.version>3.6.0</plugin.checkstyle.version>
         <plugin.versions.version>2.18.0</plugin.versions.version>
         <plugin.jacoco.version>0.8.12</plugin.jacoco.version>
-        <plugin.license.version>4.6</plugin.license.version>
         <plugin.owasp.version>11.1.1</plugin.owasp.version>
         <plugin.errorprone.version>2.28.0</plugin.errorprone.version>
 
@@ -296,11 +292,6 @@
                     <version>${plugin.jacoco.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>com.mycila</groupId>
-                    <artifactId>license-maven-plugin</artifactId>
-                    <version>${plugin.license.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
                     <version>${plugin.owasp.version}</version>
@@ -313,33 +304,6 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <configuration>
-                    <headerDefinitions>
-                        <headerDefinition>${path.assembly}/licenses/JavaBlockStyleHeader.xml</headerDefinition>
-                    </headerDefinitions>
-                    <licenseSets>
-                        <licenseSet>
-                            <header>${path.assembly}/licenses/APACHE-2.txt</header>
-                            <useDefaultExcludes>true</useDefaultExcludes>
-                            <includes>
-                                <include>**/*.java</include>
-                                <include>**/*.kt</include>
-                                <include>**/*.groovy</include>
-                                <include>**/*.scala</include>
-                            </includes>
-                        </licenseSet>
-                    </licenseSets>
-                    <mapping>
-                        <java>JavaBlockStyleHeader</java>
-                    </mapping>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.mycila</groupId>
-                        <artifactId>license-maven-plugin-git</artifactId>
-                        <version>${plugin.license.version}</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>license-check</id>

--- a/hartshorn-assembly/pom.platform.support.xml
+++ b/hartshorn-assembly/pom.platform.support.xml
@@ -36,7 +36,7 @@
         <plugin.checkstyle.version>3.6.0</plugin.checkstyle.version>
         <plugin.versions.version>2.18.0</plugin.versions.version>
         <plugin.jacoco.version>0.8.12</plugin.jacoco.version>
-        <plugin.owasp.version>11.1.1</plugin.owasp.version>
+        <plugin.owasp.version>12.1.0</plugin.owasp.version>
         <plugin.errorprone.version>2.28.0</plugin.errorprone.version>
 
         <!-- Maven plugin dependency versions, in alphabetical order -->

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/annotations/configuration/BindingAlias.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/annotations/configuration/BindingAlias.java
@@ -20,9 +20,51 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.dockbox.hartshorn.inject.binding.AliasBindingFunction;
+import org.dockbox.hartshorn.inject.binding.AliasCapableBinder;
+import org.dockbox.hartshorn.inject.binding.AliasableBindingHierarchy;
+import org.dockbox.hartshorn.inject.provider.AliasCapableComponentProviderOrchestrator;
 
+/**
+ * An annotation that can be used to define aliases for a binding. This allows multiple keys to be used to resolve the
+ * same provider. This can be useful when a provider can be reused for multiple logical keys that are not inherently
+ * related.
+ *
+ * <p>For example, consider a provider that returns a {@link String}. This provider could be aliased to also provide
+ * {@link CharSequence}.
+ *
+ * <p><pre>{@code
+ * @Singleton
+ * @BindingAlias(CharSequence.class)
+ * public String messageToTheWorld() {
+ *     return "Hello, World!";
+ * }
+ * }</pre>
+ *
+ * <p>When resolving a provider, the primary key will always take precedence over the aliases. If an alias overlaps
+ * with a primary key, the primary key will be used. Aliases are not allowed to overlap with each other, unless they
+ * have different priorities.
+ *
+ * <p>Note that this annotation is only useful when used in combination with an application that is configured to
+ * support aliases. Typically, this means that the application is using an {@link AliasCapableBinder} and an {@link
+ * AliasCapableComponentProviderOrchestrator}.
+ *
+ * @see AliasableBindingHierarchy
+ * @see AliasCapableBinder
+ * @see AliasBindingFunction#alias(Class)
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE })
 public @interface BindingAlias {
+
+    /**
+     * The types that should be aliased to the annotated provider.
+     *
+     * @return the types that should be aliased to the annotated provider
+     */
     Class<?>[] value();
 }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/annotations/configuration/BindingAlias.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/annotations/configuration/BindingAlias.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.annotations.configuration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+public @interface BindingAlias {
+    Class<?>[] value();
+}

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/AliasableConfigurableDependencyContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/AliasableConfigurableDependencyContext.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.graph;
+
+import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.QualifierKey;
+import org.dockbox.hartshorn.inject.binding.AliasBindingFunction;
+import org.dockbox.hartshorn.inject.binding.BindingFunction;
+import org.dockbox.hartshorn.inject.graph.declaration.AliasableDependencyContext;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class AliasableConfigurableDependencyContext<T> extends ConfigurableDependencyContext<T> implements AliasableDependencyContext<T> {
+
+    private final Set<Class<? super T>> aliasTypes;
+    private final Set<ComponentKey<? super T>> aliasKeys;
+    private final Set<QualifierKey<T>> aliasQualifiers;
+
+    protected AliasableConfigurableDependencyContext(AliasableConfigurableDependencyContextBuilder<T> builder) {
+        super(builder);
+        this.aliasTypes = Set.copyOf(builder.aliasTypes);
+        this.aliasKeys = Set.copyOf(builder.aliasKeys);
+        this.aliasQualifiers = Set.copyOf(builder.aliasQualifiers);
+    }
+
+    public static <T> AliasableConfigurableDependencyContextBuilder<T> builder(ComponentKey<T> componentKey) {
+        return new AliasableConfigurableDependencyContextBuilder<>(componentKey);
+    }
+
+
+    @Override
+    public void configure(BindingFunction<T> function) throws ComponentConfigurationException {
+        super.configure(function);
+        if (function instanceof AliasBindingFunction<T> aliasBindingFunction) {
+            this.aliasTypes().forEach(aliasBindingFunction::alias);
+            this.aliasKeys().forEach(aliasBindingFunction::alias);
+            this.aliasQualifiers().forEach(aliasBindingFunction::alias);
+        }
+        else if (!aliasTypes.isEmpty() || !aliasKeys.isEmpty() || !aliasQualifiers.isEmpty()) {
+            throw new ComponentConfigurationException("Attempted to configure aliases on a binding that does not support aliasing");
+        }
+    }
+
+    @Override
+    public Set<Class<? super T>> aliasTypes() {
+        return Set.copyOf(this.aliasTypes);
+    }
+
+    @Override
+    public Set<ComponentKey<? super T>> aliasKeys() {
+        return Set.copyOf(this.aliasKeys);
+    }
+
+    @Override
+    public Set<QualifierKey<T>> aliasQualifiers() {
+        return Set.copyOf(this.aliasQualifiers);
+    }
+
+    public static class AliasableConfigurableDependencyContextBuilder<T> extends AutoConfiguringDependencyContextBuilder<T> {
+
+        private final Set<Class<? super T>> aliasTypes = new HashSet<>();
+        private final Set<ComponentKey<? super T>> aliasKeys = new HashSet<>();
+        private final Set<QualifierKey<T>> aliasQualifiers = new HashSet<>();
+
+        protected AliasableConfigurableDependencyContextBuilder(ComponentKey<T> componentKey) {
+            super(componentKey);
+        }
+
+        public AliasableConfigurableDependencyContextBuilder<T> aliasType(Class<? super T> aliasType) {
+            this.aliasTypes.add(aliasType);
+            return this;
+        }
+
+        public AliasableConfigurableDependencyContextBuilder<T> aliasTypes(Set<Class<? super T>> aliasTypes) {
+            this.aliasTypes.addAll(aliasTypes);
+            return this;
+        }
+
+        public AliasableConfigurableDependencyContextBuilder<T> aliasKey(ComponentKey<? super T> aliasKey) {
+            this.aliasKeys.add(aliasKey);
+            return this;
+        }
+
+        public AliasableConfigurableDependencyContextBuilder<T> aliasKeys(Set<ComponentKey<? super T>> aliasKeys) {
+            this.aliasKeys.addAll(aliasKeys);
+            return this;
+        }
+
+        public AliasableConfigurableDependencyContextBuilder<T> aliasQualifier(QualifierKey<T> aliasQualifier) {
+            this.aliasQualifiers.add(aliasQualifier);
+            return this;
+        }
+
+        public AliasableConfigurableDependencyContextBuilder<T> aliasQualifiers(Set<QualifierKey<T>> aliasQualifiers) {
+            this.aliasQualifiers.addAll(aliasQualifiers);
+            return this;
+        }
+
+        @Override
+        public ConfigurableDependencyContext<T> build() {
+            return new AliasableConfigurableDependencyContext<>(this);
+        }
+    }
+}

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/AliasableConfigurableDependencyContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/AliasableConfigurableDependencyContext.java
@@ -24,6 +24,7 @@ import org.dockbox.hartshorn.inject.graph.declaration.AliasableDependencyContext
 
 import java.util.HashSet;
 import java.util.Set;
+import org.dockbox.hartshorn.util.ObjectDescriber;
 
 public class AliasableConfigurableDependencyContext<T> extends ConfigurableDependencyContext<T> implements AliasableDependencyContext<T> {
 
@@ -47,11 +48,11 @@ public class AliasableConfigurableDependencyContext<T> extends ConfigurableDepen
     public void configure(BindingFunction<T> function) throws ComponentConfigurationException {
         super.configure(function);
         if (function instanceof AliasBindingFunction<T> aliasBindingFunction) {
-            this.aliasTypes().forEach(aliasBindingFunction::alias);
-            this.aliasKeys().forEach(aliasBindingFunction::alias);
-            this.aliasQualifiers().forEach(aliasBindingFunction::alias);
+            this.aliasTypes.forEach(aliasBindingFunction::alias);
+            this.aliasKeys.forEach(aliasBindingFunction::alias);
+            this.aliasQualifiers.forEach(aliasBindingFunction::alias);
         }
-        else if (!aliasTypes.isEmpty() || !aliasKeys.isEmpty() || !aliasQualifiers.isEmpty()) {
+        else if (!this.aliasTypes.isEmpty() || !this.aliasKeys.isEmpty() || !this.aliasQualifiers.isEmpty()) {
             throw new ComponentConfigurationException("Attempted to configure aliases on a binding that does not support aliasing");
         }
     }
@@ -69,6 +70,14 @@ public class AliasableConfigurableDependencyContext<T> extends ConfigurableDepen
     @Override
     public Set<QualifierKey<T>> aliasQualifiers() {
         return Set.copyOf(this.aliasQualifiers);
+    }
+
+    @Override
+    protected void customizeDescriber(ObjectDescriber<?> describer) {
+        super.customizeDescriber(describer);
+        describer.field("aliasTypes", this.aliasTypes);
+        describer.field("aliasKeys", this.aliasKeys);
+        describer.field("aliasQualifiers", this.aliasQualifiers);
     }
 
     public static class AliasableConfigurableDependencyContextBuilder<T> extends AutoConfiguringDependencyContextBuilder<T> {

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/AliasableConfigurableDependencyContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/AliasableConfigurableDependencyContext.java
@@ -26,6 +26,18 @@ import java.util.HashSet;
 import java.util.Set;
 import org.dockbox.hartshorn.util.ObjectDescriber;
 
+/**
+ * A configurable dependency context that supports aliasing.
+ *
+ * @param <T> the type of the dependency
+ *
+ * @see AliasableDependencyContext
+ * @see ConfigurableDependencyContext
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public class AliasableConfigurableDependencyContext<T> extends ConfigurableDependencyContext<T> implements AliasableDependencyContext<T> {
 
     private final Set<Class<? super T>> aliasTypes;
@@ -80,6 +92,15 @@ public class AliasableConfigurableDependencyContext<T> extends ConfigurableDepen
         describer.field("aliasQualifiers", this.aliasQualifiers);
     }
 
+    /**
+     * A builder for {@link AliasableConfigurableDependencyContext} instances.
+     *
+     * @param <T> the type of the component that is auto-configured
+     *
+     * @since 0.7.0
+     *
+     * @author Guus Lieben
+     */
     public static class AliasableConfigurableDependencyContextBuilder<T> extends AutoConfiguringDependencyContextBuilder<T> {
 
         private final Set<Class<? super T>> aliasTypes = new HashSet<>();

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/ComponentContainerDependencyContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/ComponentContainerDependencyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,11 @@ public class ComponentContainerDependencyContext<T> extends ManagedComponentDepe
     @Override
     public boolean processAfterInitialization() {
         return this.container == null || this.container.permitsProcessing();
+    }
+
+    @Override
+    public String describe() {
+        return this.container.type().qualifiedName();
     }
 
     @Override

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/ConfigurableDependencyContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/ConfigurableDependencyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,12 +46,12 @@ import org.dockbox.hartshorn.util.introspect.view.View;
  *
  * @author Guus Lieben
  */
-public final class ConfigurableDependencyContext<T> extends AbstractDependencyContext<T> implements LifecycleAwareDependencyContext<T> {
+public class ConfigurableDependencyContext<T> extends AbstractDependencyContext<T> implements LifecycleAwareDependencyContext<T> {
 
     private final PrototypeInstantiationStrategy<T> supplier;
     private final View view;
 
-    private ConfigurableDependencyContext(AutoConfiguringDependencyContextBuilder<T> builder) {
+    protected ConfigurableDependencyContext(AutoConfiguringDependencyContextBuilder<T> builder) {
         super(builder);
         this.supplier = builder.supplier;
         this.view = builder.view;
@@ -145,12 +145,12 @@ public final class ConfigurableDependencyContext<T> extends AbstractDependencyCo
      *
      * @author Guus Lieben
      */
-    public static final class AutoConfiguringDependencyContextBuilder<T> extends AbstractDependencyContextBuilder<T, AutoConfiguringDependencyContextBuilder<T>> {
+    public static class AutoConfiguringDependencyContextBuilder<T> extends AbstractDependencyContextBuilder<T, AutoConfiguringDependencyContextBuilder<T>> {
 
         private PrototypeInstantiationStrategy<T> supplier;
         private View view;
 
-        private AutoConfiguringDependencyContextBuilder(ComponentKey<T> componentKey) {
+        protected AutoConfiguringDependencyContextBuilder(ComponentKey<T> componentKey) {
             super(componentKey);
         }
 
@@ -168,8 +168,6 @@ public final class ConfigurableDependencyContext<T> extends AbstractDependencyCo
             this.view = view;
             return this;
         }
-
-
 
         @Override
         public ConfigurableDependencyContext<T> build() {

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/ConfigurableDependencyContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/ConfigurableDependencyContext.java
@@ -26,6 +26,7 @@ import org.dockbox.hartshorn.inject.graph.declaration.DependencyContext;
 import org.dockbox.hartshorn.inject.graph.declaration.LifecycleAwareDependencyContext;
 import org.dockbox.hartshorn.inject.scope.ScopeKey;
 import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.ObjectDescriber;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.View;
 
@@ -117,6 +118,11 @@ public class ConfigurableDependencyContext<T> extends AbstractDependencyContext<
         return this.view;
     }
 
+    @Override
+    public String describe() {
+        return this.view.qualifiedName();
+    }
+
     private InstanceType instanceType() {
         return switch (this.lifecycleType()) {
             case PROTOTYPE -> InstanceType.SUPPLIER;
@@ -129,6 +135,12 @@ public class ConfigurableDependencyContext<T> extends AbstractDependencyContext<
                 }
             }
         };
+    }
+
+    @Override
+    protected void customizeDescriber(ObjectDescriber<?> describer) {
+        super.customizeDescriber(describer);
+        describer.field("view", this.view.qualifiedName());
     }
 
     /**

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/ManagedComponentKeyDependencyContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/ManagedComponentKeyDependencyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,11 @@ public final class ManagedComponentKeyDependencyContext<T> extends ManagedCompon
     @Override
     public boolean processAfterInitialization() {
         return this.processAfterInitialization;
+    }
+
+    @Override
+    public String describe() {
+        return this.type.qualifiedName();
     }
 
     /**

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/strategy/MethodInstanceBindingStrategy.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/graph/strategy/MethodInstanceBindingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,13 @@
 
 package org.dockbox.hartshorn.inject.graph.strategy;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.dockbox.hartshorn.inject.InjectionCapableApplication;
-import org.dockbox.hartshorn.inject.graph.ConfigurableDependencyContext;
+import org.dockbox.hartshorn.inject.annotations.configuration.BindingAlias;
+import org.dockbox.hartshorn.inject.graph.AliasableConfigurableDependencyContext;
 import org.dockbox.hartshorn.inject.graph.resolve.BindingAfterDeclarationDependencyResolver;
 import org.dockbox.hartshorn.inject.graph.resolve.BindingDeclarationDependencyResolver;
 import org.dockbox.hartshorn.inject.graph.resolve.CompositeBindingDependencyResolver;
@@ -95,17 +97,18 @@ public class MethodInstanceBindingStrategy implements BindingStrategy {
             }
         };
 
-        return ConfigurableDependencyContext.builder(componentKey)
-            .dependencies(DependencyMap.create().immediate(dependencies))
-            .scope(this.resolveComponentScope(declaration))
-            .priority(this.resolvePriority(declaration))
-            .memberType(this.resolveMemberType(declaration))
-            .view(declaration)
-            .supplier(supplier)
-            .lazy(bindingDecorator.lazy())
-            .lifecycleType(bindingDecorator.lifecycle())
-            .processAfterInitialization(bindingDecorator.processAfterInitialization())
-            .build();
+        return AliasableConfigurableDependencyContext.builder(componentKey)
+                .aliasTypes(this.resolveAliasTypes(declaration, componentKey.type()))
+                .dependencies(DependencyMap.create().immediate(dependencies))
+                .scope(this.resolveComponentScope(declaration))
+                .priority(this.resolvePriority(declaration))
+                .memberType(this.resolveMemberType(declaration))
+                .view(declaration)
+                .supplier(supplier)
+                .lazy(bindingDecorator.lazy())
+                .lifecycleType(bindingDecorator.lifecycle())
+                .processAfterInitialization(bindingDecorator.processAfterInitialization())
+                .build();
     }
 
     private int resolvePriority(AnnotatedElementView view) {
@@ -125,6 +128,22 @@ public class MethodInstanceBindingStrategy implements BindingStrategy {
         return bindsMethod.annotations().has(CompositeMember.class)
             ? ComponentMemberType.COMPOSITE
             : ComponentMemberType.STANDALONE;
+    }
+
+    private <T> Set<Class<? super T>> resolveAliasTypes(AnnotatedElementView view, Class<T> baseType) {
+        Set<Class<? super T>> types = new HashSet<>();
+        for (BindingAlias alias : view.annotations().all(BindingAlias.class)) {
+            Class<?>[] aliasTypes = alias.value();
+            for (Class<?> type : aliasTypes) {
+                if (type.isAssignableFrom(baseType)) {
+                    types.add((Class<? super T>) type);
+                }
+                else {
+                    throw new IllegalStateException("Binding alias " + type.getSimpleName() + " is not assignable from binding type " + baseType.getSimpleName());
+                }
+            }
+        }
+        return types;
     }
 
     @Override

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchicalAliasBinderAwareComponentProvider.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchicalAliasBinderAwareComponentProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.provider;
+
+import org.dockbox.hartshorn.inject.binding.HierarchicalAliasCapableBinder;
+
+public interface HierarchicalAliasBinderAwareComponentProvider extends HierarchicalBinderAwareComponentProvider {
+
+    @Override
+    HierarchicalAliasCapableBinder binder();
+}

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchicalAliasBinderAwareComponentProvider.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchicalAliasBinderAwareComponentProvider.java
@@ -18,6 +18,14 @@ package org.dockbox.hartshorn.inject.provider;
 
 import org.dockbox.hartshorn.inject.binding.HierarchicalAliasCapableBinder;
 
+/**
+ * Compatibility interface for {@link HierarchicalBinderAwareComponentProvider} that provides access to the
+ * {@link HierarchicalAliasCapableBinder}.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public interface HierarchicalAliasBinderAwareComponentProvider extends HierarchicalBinderAwareComponentProvider {
 
     @Override

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchicalComponentProviderOrchestrator.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchicalComponentProviderOrchestrator.java
@@ -30,7 +30,9 @@ import org.dockbox.hartshorn.inject.InjectionCapableApplication;
 import org.dockbox.hartshorn.inject.binding.AliasBindingFunction;
 import org.dockbox.hartshorn.inject.binding.AliasCapableBinder;
 import org.dockbox.hartshorn.inject.binding.Binder;
+import org.dockbox.hartshorn.inject.binding.BindingAliasNormalizer;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
+import org.dockbox.hartshorn.inject.binding.DefaultBindingAliasNormalizer;
 import org.dockbox.hartshorn.inject.binding.HierarchicalBinder;
 import org.dockbox.hartshorn.inject.component.ComponentRegistry;
 import org.dockbox.hartshorn.inject.processing.ComponentProcessorRegistry;
@@ -59,22 +61,29 @@ import org.dockbox.hartshorn.util.collections.MultiMap;
  */
 public class HierarchicalComponentProviderOrchestrator
         extends DefaultFallbackCompatibleContext
-        implements HierarchicalComponentProvider, ComponentRegistryAwareProviderOrchestrator, HierarchicalBinder, AliasCapableBinder {
+        implements HierarchicalComponentProvider, ComponentRegistryAwareProviderOrchestrator, AliasCapableComponentProviderOrchestrator, HierarchicalBinder, AliasCapableBinder {
 
     private final Map<Scope, HierarchicalAliasBinderAwareComponentProvider> scopedProviders = Collections.synchronizedMap(new WeakHashMap<>());
     private final Scope applicationScope;
 
-    private final transient InjectionCapableApplication application;
-    private final transient ComponentRegistry registry;
-    private final transient ComponentPostConstructor postConstructor;
+    private final InjectionCapableApplication application;
+    private final ComponentRegistry registry;
+    private final ComponentPostConstructor postConstructor;
+    private final BindingAliasNormalizer bindingAliasNormalizer;
 
     private final ComponentProcessorRegistry componentProcessorRegistry;
     private final HierarchicalBinderProcessorRegistry binderProcessorRegistry;
 
-    protected HierarchicalComponentProviderOrchestrator(InjectionCapableApplication application, ComponentRegistry registry, ComponentPostConstructor postConstructor) {
+    protected HierarchicalComponentProviderOrchestrator(
+        InjectionCapableApplication application,
+        ComponentRegistry registry,
+        ComponentPostConstructor postConstructor,
+        BindingAliasNormalizer bindingAliasNormalizer
+    ) {
         this.registry = registry;
         this.application = application;
         this.postConstructor = postConstructor;
+        this.bindingAliasNormalizer = bindingAliasNormalizer;
 
         this.applicationScope = ScopeAdapter.of(this);
         this.componentProcessorRegistry = new MultiMapComponentProcessorRegistry();
@@ -86,6 +95,7 @@ public class HierarchicalComponentProviderOrchestrator
         HierarchicalAliasBinderAwareComponentProvider provider = HierarchyAwareComponentProvider.create(
                 this,
                 this.postConstructor,
+                this.bindingAliasNormalizer,
                 this.application,
                 new ConcurrentHashSingletonCache(),
                 scope,
@@ -207,8 +217,15 @@ public class HierarchicalComponentProviderOrchestrator
 
             ComponentRegistry registry = context.input();
             ComponentPostConstructor postConstructor = configurer.componentPostConstructor.initialize(context.transform(application));
-            return new HierarchicalComponentProviderOrchestrator(application, registry, postConstructor);
+            BindingAliasNormalizer bindingAliasNormalizer = configurer.bindingAliasNormalizer.initialize(context.transform(application));
+
+            return new HierarchicalComponentProviderOrchestrator(application, registry, postConstructor, bindingAliasNormalizer);
         };
+    }
+
+    @Override
+    public BindingAliasNormalizer aliasNormalizer() {
+        return this.bindingAliasNormalizer;
     }
 
     /**
@@ -221,6 +238,7 @@ public class HierarchicalComponentProviderOrchestrator
     public static class Configurer {
 
         private ContextualInitializer<InjectionCapableApplication, ComponentPostConstructor> componentPostConstructor = AnnotatedMethodComponentPostConstructor.create(Customizer.useDefaults());
+        private ContextualInitializer<InjectionCapableApplication, BindingAliasNormalizer> bindingAliasNormalizer = ContextualInitializer.of(DefaultBindingAliasNormalizer::new);
 
         public Configurer componentPostConstructor(ComponentPostConstructor componentPostConstructor) {
             return this.componentPostConstructor(ContextualInitializer.of(componentPostConstructor));
@@ -228,6 +246,15 @@ public class HierarchicalComponentProviderOrchestrator
 
         public Configurer componentPostConstructor(ContextualInitializer<InjectionCapableApplication, ComponentPostConstructor> componentPostConstructor) {
             this.componentPostConstructor = componentPostConstructor;
+            return this;
+        }
+
+        public Configurer bindingAliasNormalizer(BindingAliasNormalizer bindingAliasNormalizer) {
+            return this.bindingAliasNormalizer(ContextualInitializer.of(bindingAliasNormalizer));
+        }
+
+        public Configurer bindingAliasNormalizer(ContextualInitializer<InjectionCapableApplication, BindingAliasNormalizer> bindingAliasNormalizer) {
+            this.bindingAliasNormalizer = bindingAliasNormalizer;
             return this;
         }
     }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchicalComponentProviderOrchestrator.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchicalComponentProviderOrchestrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,31 +20,31 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
-
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.ContextKey;
+import org.dockbox.hartshorn.inject.DefaultFallbackCompatibleContext;
 import org.dockbox.hartshorn.inject.InjectionCapableApplication;
+import org.dockbox.hartshorn.inject.binding.AliasBindingFunction;
+import org.dockbox.hartshorn.inject.binding.AliasCapableBinder;
+import org.dockbox.hartshorn.inject.binding.Binder;
+import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
 import org.dockbox.hartshorn.inject.binding.HierarchicalBinder;
+import org.dockbox.hartshorn.inject.component.ComponentRegistry;
 import org.dockbox.hartshorn.inject.processing.ComponentProcessorRegistry;
 import org.dockbox.hartshorn.inject.processing.CompositeHierarchicalBinderPostProcessor;
+import org.dockbox.hartshorn.inject.processing.ConcurrentHierarchicalBinderProcessorRegistry;
 import org.dockbox.hartshorn.inject.processing.HierarchicalBinderPostProcessor;
 import org.dockbox.hartshorn.inject.processing.HierarchicalBinderProcessorRegistry;
 import org.dockbox.hartshorn.inject.processing.MultiMapComponentProcessorRegistry;
-import org.dockbox.hartshorn.inject.processing.ConcurrentHierarchicalBinderProcessorRegistry;
+import org.dockbox.hartshorn.inject.processing.construction.AnnotatedMethodComponentPostConstructor;
+import org.dockbox.hartshorn.inject.processing.construction.ComponentPostConstructor;
 import org.dockbox.hartshorn.inject.provider.singleton.ConcurrentHashSingletonCache;
+import org.dockbox.hartshorn.inject.scope.Scope;
 import org.dockbox.hartshorn.inject.scope.ScopeAdapter;
 import org.dockbox.hartshorn.inject.scope.ScopeModuleContext;
-import org.dockbox.hartshorn.inject.ComponentKey;
-import org.dockbox.hartshorn.inject.component.ComponentRegistry;
-import org.dockbox.hartshorn.inject.DefaultFallbackCompatibleContext;
-import org.dockbox.hartshorn.inject.ComponentRequestContext;
-import org.dockbox.hartshorn.inject.binding.Binder;
-import org.dockbox.hartshorn.inject.binding.BindingFunction;
-import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
-import org.dockbox.hartshorn.inject.processing.construction.ComponentPostConstructor;
-import org.dockbox.hartshorn.inject.processing.construction.AnnotatedMethodComponentPostConstructor;
-import org.dockbox.hartshorn.inject.scope.Scope;
 import org.dockbox.hartshorn.util.ContextualInitializer;
 import org.dockbox.hartshorn.util.Customizer;
 import org.dockbox.hartshorn.util.collections.HashSetMultiMap;
@@ -59,9 +59,9 @@ import org.dockbox.hartshorn.util.collections.MultiMap;
  */
 public class HierarchicalComponentProviderOrchestrator
         extends DefaultFallbackCompatibleContext
-        implements HierarchicalComponentProvider, ComponentRegistryAwareProviderOrchestrator, HierarchicalBinder {
+        implements HierarchicalComponentProvider, ComponentRegistryAwareProviderOrchestrator, HierarchicalBinder, AliasCapableBinder {
 
-    private final Map<Scope, HierarchicalBinderAwareComponentProvider> scopedProviders = Collections.synchronizedMap(new WeakHashMap<>());
+    private final Map<Scope, HierarchicalAliasBinderAwareComponentProvider> scopedProviders = Collections.synchronizedMap(new WeakHashMap<>());
     private final Scope applicationScope;
 
     private final transient InjectionCapableApplication application;
@@ -82,8 +82,8 @@ public class HierarchicalComponentProviderOrchestrator
     }
 
     @NonNull
-    private HierarchicalBinderAwareComponentProvider createComponentProvider(Scope scope) {
-        HierarchicalBinderAwareComponentProvider provider = HierarchyAwareComponentProvider.create(
+    private HierarchicalAliasBinderAwareComponentProvider createComponentProvider(Scope scope) {
+        HierarchicalAliasBinderAwareComponentProvider provider = HierarchyAwareComponentProvider.create(
                 this,
                 this.postConstructor,
                 this.application,
@@ -108,15 +108,15 @@ public class HierarchicalComponentProviderOrchestrator
         return provider;
     }
 
-    private HierarchicalBinderAwareComponentProvider getOrDefaultProvider(Scope scope) {
+    private HierarchicalAliasBinderAwareComponentProvider getOrDefaultProvider(Scope scope) {
         return this.tryGetProvider(scope, s -> this.getOrCreateProvider(this.applicationScope));
     }
 
-    private HierarchicalBinderAwareComponentProvider getOrCreateProvider(Scope scope) {
+    private HierarchicalAliasBinderAwareComponentProvider getOrCreateProvider(Scope scope) {
         return this.tryGetProvider(scope, this::createComponentProvider);
     }
 
-    private HierarchicalBinderAwareComponentProvider tryGetProvider(Scope scope, Function<Scope, HierarchicalBinderAwareComponentProvider> fallbackValue) {
+    private HierarchicalAliasBinderAwareComponentProvider tryGetProvider(Scope scope, Function<Scope, HierarchicalAliasBinderAwareComponentProvider> fallbackValue) {
         if (scope == null) {
             scope = this.applicationScope;
         }
@@ -148,7 +148,7 @@ public class HierarchicalComponentProviderOrchestrator
     }
 
     @Override
-    public <C> BindingFunction<C> bind(ComponentKey<C> key) {
+    public <C> AliasBindingFunction<C> bind(ComponentKey<C> key) {
         Scope scope = key.scope().orElse(this.scope());
         return this.getOrCreateProvider(scope).binder().bind(key);
     }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchyAwareComponentProvider.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchyAwareComponentProvider.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.ComponentResolutionException;
 import org.dockbox.hartshorn.inject.InjectionCapableApplication;
+import org.dockbox.hartshorn.inject.binding.BindingAliasNormalizer;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
 import org.dockbox.hartshorn.inject.binding.HierarchicalAliasCapableBinder;
 import org.dockbox.hartshorn.inject.binding.NestedHierarchyLookup;
@@ -73,6 +74,7 @@ public class HierarchyAwareComponentProvider extends StrategyChainComponentProvi
     public HierarchyAwareComponentProvider(
         ComponentRegistryAwareProviderOrchestrator orchestrator,
         ComponentPostConstructor postConstructor,
+        BindingAliasNormalizer bindingAliasNormalizer,
         InjectionCapableApplication application,
         SingletonCache singletonCache,
         Scope scope
@@ -80,7 +82,7 @@ public class HierarchyAwareComponentProvider extends StrategyChainComponentProvi
         this(
                 application,
                 singletonCache,
-                new ScopeAwareHierarchicalBinder(application, singletonCache, scope),
+                new ScopeAwareHierarchicalBinder(application, bindingAliasNormalizer, singletonCache, scope),
                 createProviderPostProcessor(singletonCache, orchestrator, application, postConstructor),
                 scope
         );
@@ -170,6 +172,7 @@ public class HierarchyAwareComponentProvider extends StrategyChainComponentProvi
     public static HierarchyAwareComponentProvider create(
             ComponentRegistryAwareProviderOrchestrator orchestrator,
             ComponentPostConstructor postConstructor,
+            BindingAliasNormalizer bindingAliasNormalizer,
             InjectionCapableApplication application,
             SingletonCache singletonCache,
             Scope scope,
@@ -187,11 +190,12 @@ public class HierarchyAwareComponentProvider extends StrategyChainComponentProvi
                 .initialize(SimpleSingleElementContext.create(application));
 
         HierarchyAwareComponentProvider provider = new HierarchyAwareComponentProvider(
-                orchestrator,
-                postConstructor,
-                application,
-                singletonCache,
-                scope
+            orchestrator,
+            postConstructor,
+            bindingAliasNormalizer,
+            application,
+            singletonCache,
+            scope
         );
         provider.strategies(strategies);
         return provider;

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchyAwareComponentProvider.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/provider/HierarchyAwareComponentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,19 @@
 package org.dockbox.hartshorn.inject.provider;
 
 import java.util.List;
-
-import org.dockbox.hartshorn.inject.InjectionCapableApplication;
-import org.dockbox.hartshorn.inject.binding.NestedHierarchyLookup;
-import org.dockbox.hartshorn.inject.binding.HierarchicalBinder;
-import org.dockbox.hartshorn.inject.binding.ScopeAwareHierarchicalBinder;
-import org.dockbox.hartshorn.inject.processing.ComponentProviderPostProcessor;
-import org.dockbox.hartshorn.inject.processing.ComponentStoreCallback;
-import org.dockbox.hartshorn.inject.processing.PostConstructingComponentPostProcessor;
-import org.dockbox.hartshorn.inject.processing.SimpleComponentProviderPostProcessor;
-import org.dockbox.hartshorn.inject.processing.CompositeComponentPostProcessor;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.ComponentResolutionException;
+import org.dockbox.hartshorn.inject.InjectionCapableApplication;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
+import org.dockbox.hartshorn.inject.binding.HierarchicalAliasCapableBinder;
+import org.dockbox.hartshorn.inject.binding.NestedHierarchyLookup;
+import org.dockbox.hartshorn.inject.binding.ScopeAwareHierarchicalBinder;
+import org.dockbox.hartshorn.inject.processing.ComponentProviderPostProcessor;
+import org.dockbox.hartshorn.inject.processing.ComponentStoreCallback;
+import org.dockbox.hartshorn.inject.processing.CompositeComponentPostProcessor;
+import org.dockbox.hartshorn.inject.processing.PostConstructingComponentPostProcessor;
+import org.dockbox.hartshorn.inject.processing.SimpleComponentProviderPostProcessor;
 import org.dockbox.hartshorn.inject.processing.construction.ComponentPostConstructor;
 import org.dockbox.hartshorn.inject.provider.singleton.SingletonCache;
 import org.dockbox.hartshorn.inject.provider.strategy.ComponentProcessorComponentProviderStrategy;
@@ -64,19 +63,19 @@ import org.dockbox.hartshorn.util.collections.MultiMap;
  * @author Guus Lieben
  */
 public class HierarchyAwareComponentProvider extends StrategyChainComponentProvider
-        implements HierarchicalBinderAwareComponentProvider, SingletonCacheComponentProvider, NestedHierarchyLookup {
+        implements HierarchicalAliasBinderAwareComponentProvider, SingletonCacheComponentProvider, NestedHierarchyLookup {
 
     private final ComponentProviderPostProcessor processor;
-    private final HierarchicalBinder binder;
+    private final HierarchicalAliasCapableBinder binder;
     private final Scope scope;
     private final SingletonCache singletonCache;
 
     public HierarchyAwareComponentProvider(
-            ComponentRegistryAwareProviderOrchestrator orchestrator,
-            ComponentPostConstructor postConstructor,
-            InjectionCapableApplication application,
-            SingletonCache singletonCache,
-            Scope scope
+        ComponentRegistryAwareProviderOrchestrator orchestrator,
+        ComponentPostConstructor postConstructor,
+        InjectionCapableApplication application,
+        SingletonCache singletonCache,
+        Scope scope
     ) {
         this(
                 application,
@@ -88,11 +87,11 @@ public class HierarchyAwareComponentProvider extends StrategyChainComponentProvi
     }
 
     public HierarchyAwareComponentProvider(
-            InjectionCapableApplication application,
-            SingletonCache singletonCache,
-            HierarchicalBinder binder,
-            ComponentProviderPostProcessor postProcessor,
-            Scope scope
+        InjectionCapableApplication application,
+        SingletonCache singletonCache,
+        HierarchicalAliasCapableBinder binder,
+        ComponentProviderPostProcessor postProcessor,
+        Scope scope
     ) {
         super(application);
 
@@ -136,7 +135,7 @@ public class HierarchyAwareComponentProvider extends StrategyChainComponentProvi
     }
 
     @Override
-    public HierarchicalBinder binder() {
+    public HierarchicalAliasCapableBinder binder() {
         return this.binder;
     }
 

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/ComponentKey.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/ComponentKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -503,6 +503,11 @@ public final class ComponentKey<T> implements Reportable {
          */
         public Builder<T> qualifiers(Set<QualifierKey<?>> qualifiers) {
             this.qualifier.addAll(qualifiers);
+            return this;
+        }
+
+        public Builder<T> withoutQualifiers() {
+            this.qualifier.clear();
             return this;
         }
 

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/ComponentKey.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/ComponentKey.java
@@ -247,9 +247,10 @@ public final class ComponentKey<T> implements Reportable {
         String scopeName = this.scope()
                 .map(Scope::installableScopeType)
                 .map(ScopeKey::name)
-                .orElse("default");
+            .map(scope -> " @ " + scope)
+                .orElse("");
         String typeName = qualifyType ? this.type.toQualifiedString() : this.type.toString();
-        return typeName + qualifierSuffix + " @ " + scopeName;
+        return typeName + qualifierSuffix + scopeName;
     }
 
     @Override

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/CompositeQualifier.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/CompositeQualifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,6 +103,10 @@ public class CompositeQualifier implements Reportable {
 
     public boolean isEmpty() {
         return this.qualifiers.isEmpty();
+    }
+
+    public void clear() {
+        this.qualifiers.clear();
     }
 
     @Override

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AbstractBindingHierarchy.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AbstractBindingHierarchy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -180,5 +180,10 @@ public abstract class AbstractBindingHierarchy<T> implements BindingHierarchy<T>
      */
     protected String contractTypeToString() {
         return this.key().parameterizedType().toString();
+    }
+
+    @Override
+    public <T1> boolean isCompatible(ComponentKey<T1> key) {
+        return this.key().equals(key);
     }
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasBindingFunction.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasBindingFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.binding;
+
+import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.IllegalScopeException;
+import org.dockbox.hartshorn.inject.QualifierKey;
+import org.dockbox.hartshorn.inject.scope.ScopeKey;
+
+public interface AliasBindingFunction<T> extends BindingFunction<T> {
+
+    AliasBindingFunction<T> alias(Class<? super T> aliasType);
+
+    AliasBindingFunction<T> alias(ComponentKey<? super T> aliasKey);
+
+    AliasBindingFunction<T> alias(QualifierKey<T> aliasQualifier);
+
+    @Override
+    AliasBindingFunction<T> installTo(ScopeKey scope) throws IllegalScopeException;
+
+    @Override
+    AliasBindingFunction<T> processAfterInitialization(boolean processAfterInitialization);
+
+    @Override
+    AliasBindingFunction<T> priority(int priority);
+}

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasBindingFunction.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasBindingFunction.java
@@ -21,12 +21,50 @@ import org.dockbox.hartshorn.inject.IllegalScopeException;
 import org.dockbox.hartshorn.inject.QualifierKey;
 import org.dockbox.hartshorn.inject.scope.ScopeKey;
 
+/**
+ * A binding function that allows for the addition of aliases to a binding. Aliases are additional keys that can be used
+ * to reference the same binding. This is useful for example when a binding is defined in multiple modules, and you want
+ * to reference the same binding using different keys.
+ *
+ * @param <T> The type of the component that this binding is for.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public interface AliasBindingFunction<T> extends BindingFunction<T> {
 
+    /**
+     * Adds an alias to the current binding. Depending on the implementation, this may either choose to keep or discard
+     * qualifiers from the original binding key.
+     *
+     * @param aliasType The type to register as an alias.
+     * @return Itself, for chaining.
+     *
+     * @see BindingAliasNormalizer
+     */
     AliasBindingFunction<T> alias(Class<? super T> aliasType);
 
+    /**
+     * Adds an alias to the current binding. The given key is used exactly as-is, without any normalization. This means
+     * that any qualifiers that are part of the key are preserved, and any qualifiers on the original key are not explicitly
+     * retained unless present in the alias.
+     *
+     * @param aliasKey The key to register as an alias.
+     * @return Itself, for chaining.
+     */
     AliasBindingFunction<T> alias(ComponentKey<? super T> aliasKey);
 
+    /**
+     * Adds an alias to the current binding. Depending on the implementation, this may either choose to keep or discard
+     * existing qualifiers from the original binding key. This means that new qualifiers may either replace existing
+     * qualifiers, or be added to the existing qualifiers.
+     *
+     * @param aliasQualifier The qualifier to use for the alias.
+     * @return Itself, for chaining.
+     *
+     * @see BindingAliasNormalizer
+     */
     AliasBindingFunction<T> alias(QualifierKey<T> aliasQualifier);
 
     @Override

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasCapableBinder.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasCapableBinder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.binding;
+
+import org.dockbox.hartshorn.inject.ComponentKey;
+
+public interface AliasCapableBinder extends Binder {
+
+    @Override
+    default <C> AliasBindingFunction<C> bind(Class<C> type) {
+        return (AliasBindingFunction<C>) Binder.super.bind(type);
+    }
+
+    @Override
+    <C> AliasBindingFunction<C> bind(ComponentKey<C> key);
+}

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasCapableBinder.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasCapableBinder.java
@@ -18,6 +18,15 @@ package org.dockbox.hartshorn.inject.binding;
 
 import org.dockbox.hartshorn.inject.ComponentKey;
 
+/**
+ * A binder that is capable of binding aliases. This allows for the binding of components to multiple keys, which can
+ * be useful when a component is defined in multiple modules, and you want to reference the same component using
+ * different keys.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public interface AliasCapableBinder extends Binder {
 
     @Override

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasableBindingHierarchy.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasableBindingHierarchy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.binding;
+
+import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
+
+import java.util.Set;
+
+public interface AliasableBindingHierarchy<C> extends BindingHierarchy<C> {
+
+    void alias(ComponentKey<? super C> componentKey);
+
+    Set<ComponentKey<? super C>> aliases();
+
+    @Override
+    AliasableBindingHierarchy<C> add(InstantiationStrategy<C> strategy);
+
+    @Override
+    AliasableBindingHierarchy<C> add(int priority, InstantiationStrategy<C> strategy);
+
+    @Override
+    AliasableBindingHierarchy<C> addNext(InstantiationStrategy<C> strategy);
+
+    @Override
+    AliasableBindingHierarchy<C> merge(BindingHierarchy<C> hierarchy);
+}

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasableBindingHierarchy.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasableBindingHierarchy.java
@@ -21,10 +21,32 @@ import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
 
 import java.util.Set;
 
+/**
+ * A binding hierarchy that supports aliases. Aliases are additional keys that can be used to
+ * reference the same binding. This is useful for example when a binding is defined in multiple
+ * modules, and you want to reference the same binding using different keys.
+ *
+ * @param <C> The type of the component that this hierarchy is for.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public interface AliasableBindingHierarchy<C> extends BindingHierarchy<C> {
 
+    /**
+     * Add an alias to the current hierarchy. Note that this will affect all providers in the hierarchy,
+     * at all configured priorities.
+     *
+     * @param componentKey The key to register as an alias.
+     */
     void alias(ComponentKey<? super C> componentKey);
 
+    /**
+     * Returns all aliases that are registered for this hierarchy.
+     *
+     * @return All aliases.
+     */
     Set<ComponentKey<? super C>> aliases();
 
     @Override

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasableBindingHierarchyAdapter.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasableBindingHierarchyAdapter.java
@@ -19,7 +19,6 @@ package org.dockbox.hartshorn.inject.binding;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
 import org.dockbox.hartshorn.util.option.Option;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Iterator;
 import java.util.List;
@@ -28,6 +27,17 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * A delegating {@link AliasableBindingHierarchy} that delegates all calls to the wrapped {@link BindingHierarchy}, except
+ * for aliasing calls. This allows for the addition of aliases to an existing hierarchy, without affecting the underlying
+ * providers.
+ *
+ * @param <C> The type of the component that this hierarchy is for.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public class AliasableBindingHierarchyAdapter<C> implements AliasableBindingHierarchy<C> {
 
     private final Set<ComponentKey<? super C>> aliases = ConcurrentHashMap.newKeySet();
@@ -111,7 +121,6 @@ public class AliasableBindingHierarchyAdapter<C> implements AliasableBindingHier
         return this.delegate.isCompatible(key) || this.aliases.stream().anyMatch(alias -> alias.equals(key));
     }
 
-    @NotNull
     @Override
     public Iterator<Map.Entry<Integer, InstantiationStrategy<C>>> iterator() {
         return this.delegate.iterator();

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasableBindingHierarchyAdapter.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AliasableBindingHierarchyAdapter.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.binding;
+
+import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
+import org.dockbox.hartshorn.util.option.Option;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class AliasableBindingHierarchyAdapter<C> implements AliasableBindingHierarchy<C> {
+
+    private final Set<ComponentKey<? super C>> aliases = ConcurrentHashMap.newKeySet();
+    private final BindingHierarchy<C> delegate;
+
+    public AliasableBindingHierarchyAdapter(BindingHierarchy<C> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void alias(ComponentKey<? super C> componentKey) {
+        this.aliases.add(componentKey);
+    }
+
+    @Override
+    public Set<ComponentKey<? super C>> aliases() {
+        return Set.copyOf(this.aliases);
+    }
+
+    @Override
+    public List<InstantiationStrategy<C>> providers() {
+        return this.delegate.providers();
+    }
+
+    @Override
+    public AliasableBindingHierarchy<C> add(InstantiationStrategy<C> strategy) {
+        return this.currentOrNextAdapter(this.delegate.add(strategy));
+    }
+
+    @Override
+    public AliasableBindingHierarchy<C> add(int priority, InstantiationStrategy<C> strategy) {
+        return this.currentOrNextAdapter(this.delegate.add(priority, strategy));
+    }
+
+    @Override
+    public AliasableBindingHierarchy<C> addNext(InstantiationStrategy<C> strategy) {
+        return this.currentOrNextAdapter(this.delegate.addNext(strategy));
+    }
+
+    @Override
+    public AliasableBindingHierarchy<C> merge(BindingHierarchy<C> hierarchy) {
+        return this.currentOrNextAdapter(this.delegate.merge(hierarchy));
+    }
+
+    private AliasableBindingHierarchy<C> currentOrNextAdapter(BindingHierarchy<C> hierarchy) {
+        if (hierarchy == this.delegate) {
+            return this;
+        }
+        else {
+            return new AliasableBindingHierarchyAdapter<>(hierarchy);
+        }
+    }
+
+    @Override
+    public int size() {
+        return this.delegate.size();
+    }
+
+    @Override
+    public Option<InstantiationStrategy<C>> get(int priority) {
+        return this.delegate.get(priority);
+    }
+
+    @Override
+    public int highestPriority() {
+        return this.delegate.highestPriority();
+    }
+
+    @Override
+    public SortedSet<Integer> priorities() {
+        return this.delegate.priorities();
+    }
+
+    @Override
+    public ComponentKey<C> key() {
+        return this.delegate.key();
+    }
+
+    @Override
+    public <T> boolean isCompatible(ComponentKey<T> key) {
+        return this.delegate.isCompatible(key) || this.aliases.stream().anyMatch(alias -> alias.equals(key));
+    }
+
+    @NotNull
+    @Override
+    public Iterator<Map.Entry<Integer, InstantiationStrategy<C>>> iterator() {
+        return this.delegate.iterator();
+    }
+}

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AmbiguousComponentException.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/AmbiguousComponentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,11 +34,25 @@ import org.dockbox.hartshorn.util.ApplicationRuntimeException;
  * @author Guus Lieben
  */
 public class AmbiguousComponentException extends ApplicationRuntimeException {
+
+    private final ComponentKey<?> lookupKey;
+    private final Set<ComponentKey<?>> foundKeys;
+
     public AmbiguousComponentException(ComponentKey<?> lookupKey, Set<ComponentKey<?>> foundKeys) {
         super(
             "Ambiguous component lookup for key " + lookupKey
                 + ". Found " + foundKeys.size() + " components: " + foundKeys.stream()
                 .map(key -> key.qualifiedName(true))
                 .collect(Collectors.joining(", ")));
+        this.lookupKey = lookupKey;
+        this.foundKeys = foundKeys;
+    }
+
+    public ComponentKey<?> lookupKey() {
+        return this.lookupKey;
+    }
+
+    public Set<ComponentKey<?>> foundKeys() {
+        return this.foundKeys;
     }
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/BindingAliasNormalizer.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/BindingAliasNormalizer.java
@@ -14,22 +14,14 @@
  * limitations under the License.
  */
 
-package org.dockbox.hartshorn.inject.graph.declaration;
+package org.dockbox.hartshorn.inject.binding;
 
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.QualifierKey;
 
-import java.util.Set;
+public interface BindingAliasNormalizer {
 
-public interface AliasableDependencyContext<T> extends DependencyContext<T> {
+    <T> ComponentKey<? super T> alias(ComponentKey<T> baseKey, Class<? super T> aliasType);
 
-    default boolean hasConfiguredAliases() {
-        return !this.aliasTypes().isEmpty() || !this.aliasKeys().isEmpty() || !this.aliasQualifiers().isEmpty();
-    }
-
-    Set<Class<? super T>> aliasTypes();
-
-    Set<ComponentKey<? super T>> aliasKeys();
-
-    Set<QualifierKey<T>> aliasQualifiers();
+    <T> ComponentKey<T> alias(ComponentKey<T> baseKey, QualifierKey<T> aliasQualifier);
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/BindingAliasNormalizer.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/BindingAliasNormalizer.java
@@ -19,9 +19,38 @@ package org.dockbox.hartshorn.inject.binding;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.QualifierKey;
 
+/**
+ * A binding alias normalizer is responsible for transforming a base key into an alias key. This is typically only
+ * used directly by {@link AliasBindingFunction} implementations, or early in the binding process when a binding is
+ * not yet finalized.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public interface BindingAliasNormalizer {
 
+    /**
+     * Creates an alias key for the given base key, using the provided alias type. The alias key is a new key that
+     * is based on the base key, but with the type replaced by the alias type. Depending on the implementation, this
+     * may either choose to keep or discard qualifiers from the original key.
+     *
+     * @param baseKey The base key to create an alias for.
+     * @param aliasType The type to use as the alias.
+     * @return The alias key.
+     * @param <T> The type of the component.
+     */
     <T> ComponentKey<? super T> alias(ComponentKey<T> baseKey, Class<? super T> aliasType);
 
+    /**
+     * Creates an alias key for the given base key, using the provided alias key. The alias key is a new key that
+     * is based on the base key, but with the type replaced by the alias key. Depending on the implementation, this
+     * may either choose to keep or discard qualifiers from the original key.
+     *
+     * @param baseKey The base key to create an alias for.
+     * @param aliasQualifier The qualifier to use for the alias.
+     * @return The alias key.
+     * @param <T> The type of the component.
+     */
     <T> ComponentKey<T> alias(ComponentKey<T> baseKey, QualifierKey<T> aliasQualifier);
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/BindingHierarchy.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/BindingHierarchy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,4 +127,6 @@ public interface BindingHierarchy<C> extends Iterable<Entry<Integer, Instantiati
      * @see ComponentKey
      */
     ComponentKey<C> key();
+
+    <T> boolean isCompatible(ComponentKey<T> key);
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/DefaultBindingAliasNormalizer.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/DefaultBindingAliasNormalizer.java
@@ -14,22 +14,25 @@
  * limitations under the License.
  */
 
-package org.dockbox.hartshorn.inject.graph.declaration;
+package org.dockbox.hartshorn.inject.binding;
 
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.QualifierKey;
 
-import java.util.Set;
+public class DefaultBindingAliasNormalizer implements BindingAliasNormalizer {
 
-public interface AliasableDependencyContext<T> extends DependencyContext<T> {
-
-    default boolean hasConfiguredAliases() {
-        return !this.aliasTypes().isEmpty() || !this.aliasKeys().isEmpty() || !this.aliasQualifiers().isEmpty();
+    @Override
+    public <T> ComponentKey<? super T> alias(ComponentKey<T> baseKey, Class<? super T> aliasType) {
+        return baseKey.mutable()
+            .type(aliasType)
+            .build();
     }
 
-    Set<Class<? super T>> aliasTypes();
-
-    Set<ComponentKey<? super T>> aliasKeys();
-
-    Set<QualifierKey<T>> aliasQualifiers();
+    @Override
+    public <T> ComponentKey<T> alias(ComponentKey<T> baseKey, QualifierKey<T> aliasQualifier) {
+        return baseKey.mutable()
+            .withoutQualifiers()
+            .qualifier(aliasQualifier)
+            .build();
+    }
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/DefaultBindingAliasNormalizer.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/DefaultBindingAliasNormalizer.java
@@ -19,6 +19,20 @@ package org.dockbox.hartshorn.inject.binding;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.QualifierKey;
 
+/**
+ * Default implementation of the {@link BindingAliasNormalizer} interface. This implementation attempts to retain as much
+ * information from the base key as logically possible, while still creating a valid alias key.
+ *
+ * <p>Alias keys created from an alias type will retain all qualifiers from the base key, but will replace the type with the
+ * alias type.
+ *
+ * <p>Alias keys created from an alias qualifier will lose all qualifiers from the base key, but will retain all other
+ * information.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public class DefaultBindingAliasNormalizer implements BindingAliasNormalizer {
 
     @Override

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchicalAliasCapableBinder.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchicalAliasCapableBinder.java
@@ -16,5 +16,15 @@
 
 package org.dockbox.hartshorn.inject.binding;
 
+/**
+ * Compatability interface to combine {@link HierarchicalBinder} and {@link AliasCapableBinder}.
+ *
+ * @see HierarchicalBinder
+ * @see AliasCapableBinder
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public interface HierarchicalAliasCapableBinder extends HierarchicalBinder, AliasCapableBinder {
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchicalAliasCapableBinder.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchicalAliasCapableBinder.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.binding;
+
+public interface HierarchicalAliasCapableBinder extends HierarchicalBinder, AliasCapableBinder {
+}

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
@@ -56,6 +56,7 @@ public class HierarchyBindingFunction<T> implements AliasBindingFunction<T> {
     private final HierarchicalBinder binder;
     private final SingletonCache singletonCache;
     private final ScopeModuleContext moduleContext;
+    private final BindingAliasNormalizer bindingAliasNormalizer;
 
     private Scope scope;
     private ScopeKey scopeKey;
@@ -64,17 +65,20 @@ public class HierarchyBindingFunction<T> implements AliasBindingFunction<T> {
     private boolean processAfterInitialization = true;
 
     public HierarchyBindingFunction(
-            AliasableBindingHierarchy<T> hierarchy,
-            HierarchicalBinder binder,
-            SingletonCache singletonCache,
-            Scope scope,
-            ScopeModuleContext moduleContext) {
+        AliasableBindingHierarchy<T> hierarchy,
+        HierarchicalBinder binder,
+        SingletonCache singletonCache,
+        Scope scope,
+        ScopeModuleContext moduleContext,
+        BindingAliasNormalizer bindingAliasNormalizer
+    ) {
         this.hierarchy = hierarchy;
         this.binder = binder;
         this.singletonCache = singletonCache;
 
         this.scope = scope;
         this.moduleContext = moduleContext;
+        this.bindingAliasNormalizer = bindingAliasNormalizer;
     }
 
     protected BindingHierarchy<T> hierarchy() {
@@ -96,7 +100,12 @@ public class HierarchyBindingFunction<T> implements AliasBindingFunction<T> {
 
     @Override
     public AliasBindingFunction<T> alias(Class<? super T> aliasType) {
-        return this.alias(ComponentKey.of(aliasType));
+        return this.alias(this.bindingAliasNormalizer.alias(this.hierarchy().key(), aliasType));
+    }
+
+    @Override
+    public AliasBindingFunction<T> alias(QualifierKey<T> aliasQualifier) {
+        return this.alias(this.bindingAliasNormalizer.alias(this.hierarchy().key(), aliasQualifier));
     }
 
     @Override
@@ -109,15 +118,6 @@ public class HierarchyBindingFunction<T> implements AliasBindingFunction<T> {
             throw new UnsupportedOperationException("Delegate hierarchy does not support aliasing");
         }
         return this;
-    }
-
-    @Override
-    public AliasBindingFunction<T> alias(QualifierKey<T> aliasQualifier) {
-        ComponentKey<T> key = this.hierarchy().key().mutable()
-                .withoutQualifiers()
-                .qualifier(aliasQualifier)
-                .build();
-        return this.alias(key);
     }
 
     @Override

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.inject.binding;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.IllegalScopeException;
+import org.dockbox.hartshorn.inject.QualifierKey;
 import org.dockbox.hartshorn.inject.collection.CollectionBindingHierarchy;
 import org.dockbox.hartshorn.inject.collection.CollectorBindingFunction;
 import org.dockbox.hartshorn.inject.collection.ComponentCollection;
@@ -49,7 +50,7 @@ import org.dockbox.hartshorn.util.function.CheckedSupplier;
  *
  * @author Guus Lieben
  */
-public class HierarchyBindingFunction<T> implements BindingFunction<T> {
+public class HierarchyBindingFunction<T> implements AliasBindingFunction<T> {
 
     private final BindingHierarchy<T> hierarchy;
     private final HierarchicalBinder binder;
@@ -94,7 +95,22 @@ public class HierarchyBindingFunction<T> implements BindingFunction<T> {
     }
 
     @Override
-    public BindingFunction<T> installTo(ScopeKey scopeKey) throws IllegalScopeException {
+    public AliasBindingFunction<T> alias(Class<? super T> aliasType) {
+        throw new UnsupportedOperationException("Not yet implemented"); // TODO: Implement
+    }
+
+    @Override
+    public AliasBindingFunction<T> alias(ComponentKey<? super T> aliasKey) {
+        throw new UnsupportedOperationException("Not yet implemented"); // TODO: Implement
+    }
+
+    @Override
+    public AliasBindingFunction<T> alias(QualifierKey<T> aliasQualifier) {
+        throw new UnsupportedOperationException("Not yet implemented"); // TODO: Implement
+    }
+
+    @Override
+    public AliasBindingFunction<T> installTo(ScopeKey scopeKey) throws IllegalScopeException {
         boolean expandingApplicationScope = this.moduleContext.isApplicationScope(this.scopeKey)
                 || this.moduleContext.isApplicationScope(this.scope.installableScopeType());
 
@@ -110,13 +126,13 @@ public class HierarchyBindingFunction<T> implements BindingFunction<T> {
     }
 
     @Override
-    public BindingFunction<T> priority(int priority) {
+    public AliasBindingFunction<T> priority(int priority) {
         this.priority = priority;
         return this;
     }
 
     @Override
-    public BindingFunction<T> processAfterInitialization(boolean processAfterInitialization) {
+    public AliasBindingFunction<T> processAfterInitialization(boolean processAfterInitialization) {
         this.processAfterInitialization = processAfterInitialization;
         return this;
     }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
@@ -52,7 +52,7 @@ import org.dockbox.hartshorn.util.function.CheckedSupplier;
  */
 public class HierarchyBindingFunction<T> implements AliasBindingFunction<T> {
 
-    private final BindingHierarchy<T> hierarchy;
+    private final AliasableBindingHierarchy<T> hierarchy;
     private final HierarchicalBinder binder;
     private final SingletonCache singletonCache;
     private final ScopeModuleContext moduleContext;
@@ -64,7 +64,7 @@ public class HierarchyBindingFunction<T> implements AliasBindingFunction<T> {
     private boolean processAfterInitialization = true;
 
     public HierarchyBindingFunction(
-            BindingHierarchy<T> hierarchy,
+            AliasableBindingHierarchy<T> hierarchy,
             HierarchicalBinder binder,
             SingletonCache singletonCache,
             Scope scope,
@@ -96,17 +96,28 @@ public class HierarchyBindingFunction<T> implements AliasBindingFunction<T> {
 
     @Override
     public AliasBindingFunction<T> alias(Class<? super T> aliasType) {
-        throw new UnsupportedOperationException("Not yet implemented"); // TODO: Implement
+        return this.alias(ComponentKey.of(aliasType));
     }
 
     @Override
     public AliasBindingFunction<T> alias(ComponentKey<? super T> aliasKey) {
-        throw new UnsupportedOperationException("Not yet implemented"); // TODO: Implement
+        BindingHierarchy<T> hierarchy = this.hierarchy();
+        if (hierarchy instanceof AliasableBindingHierarchy<T> aliasableBindingHierarchy) {
+            aliasableBindingHierarchy.alias(aliasKey);
+        }
+        else {
+            throw new UnsupportedOperationException("Delegate hierarchy does not support aliasing");
+        }
+        return this;
     }
 
     @Override
     public AliasBindingFunction<T> alias(QualifierKey<T> aliasQualifier) {
-        throw new UnsupportedOperationException("Not yet implemented"); // TODO: Implement
+        ComponentKey<T> key = this.hierarchy().key().mutable()
+                .withoutQualifiers()
+                .qualifier(aliasQualifier)
+                .build();
+        return this.alias(key);
     }
 
     @Override
@@ -175,6 +186,9 @@ public class HierarchyBindingFunction<T> implements AliasBindingFunction<T> {
         else {
             // If no processing should happen, then we can immediately cache the instance
             this.singletonCache.put(this.hierarchy.key(), instance);
+            for (ComponentKey<? super T> alias : this.hierarchy.aliases()) {
+                this.singletonCache.put(alias, instance);
+            }
             return this.binder();
         }
     }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyCache.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,8 +82,19 @@ public class HierarchyCache {
             return this.hierarchies.get(view);
         }
         else {
-            return this.computeHierarchy(key, useGlobalIfAbsent);
+            List<BindingHierarchy<?>> compatibleAliases = this.hierarchies.values().stream()
+                    .filter(hierarchy -> hierarchy.isCompatible(key))
+                    .toList();
+            if (compatibleAliases.size() > 1) {
+                throw new AmbiguousComponentException(key, compatibleAliases.stream()
+                        .map(BindingHierarchy::key)
+                        .collect(Collectors.toSet()));
+            }
+            else if (compatibleAliases.size() == 1) {
+                return compatibleAliases.getFirst();
+            }
         }
+        return this.computeHierarchy(key, useGlobalIfAbsent);
     }
 
     @NonNull
@@ -103,7 +114,7 @@ public class HierarchyCache {
                         .build();
                 return this.globalBinder.hierarchy(unscopedKey);
             }
-            return new NativePrunableBindingHierarchy<>(key);
+            return new AliasableBindingHierarchyAdapter<>(new NativePrunableBindingHierarchy<>(key));
         });
     }
 

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/ScopeAwareHierarchicalBinder.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/ScopeAwareHierarchicalBinder.java
@@ -95,6 +95,9 @@ public class ScopeAwareHierarchicalBinder implements HierarchicalAliasCapableBin
                     "Cannot bind to a different scope. Expected %s, got %s for key %s".formatted(this.scope(), componentScope, key));
         }
         BindingHierarchy<C> hierarchy = this.hierarchy(key);
+        AliasableBindingHierarchy<C> aliasableHierarchy = hierarchy instanceof AliasableBindingHierarchy<C> aliasable
+                ? aliasable
+                : new AliasableBindingHierarchyAdapter<>(hierarchy);
 
         ContextIdentity<ScopeModuleContext> scopeModuleContextKey = ScopeModuleContext.createKey(() -> {
             return this.applicationScope().installableScopeType();
@@ -104,8 +107,7 @@ public class ScopeAwareHierarchicalBinder implements HierarchicalAliasCapableBin
         if (scopeModuleContext.absent() && this.scope() != this.applicationScope()) {
             throw new IllegalModificationException("Cannot add binding to non-application hierarchy without a module context");
         }
-
-        return new HierarchyBindingFunction<>(hierarchy, this, this.singletonCache, this.scope(), scopeModuleContext.orNull());
+        return new HierarchyBindingFunction<>(aliasableHierarchy, this, this.singletonCache, this.scope(), scopeModuleContext.orNull());
     }
 
     @Override

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/ScopeAwareHierarchicalBinder.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/ScopeAwareHierarchicalBinder.java
@@ -42,13 +42,20 @@ import org.dockbox.hartshorn.util.option.Option;
 public class ScopeAwareHierarchicalBinder implements HierarchicalAliasCapableBinder, NestedHierarchyLookup {
 
     private final InjectionCapableApplication application;
+    private final BindingAliasNormalizer bindingAliasNormalizer;
     private final SingletonCache singletonCache;
     private final Scope scope;
 
     private HierarchyCache hierarchyCache;
 
-    public ScopeAwareHierarchicalBinder(InjectionCapableApplication application, SingletonCache singletonCache, Scope scope) {
+    public ScopeAwareHierarchicalBinder(
+        InjectionCapableApplication application,
+        BindingAliasNormalizer bindingAliasNormalizer,
+        SingletonCache singletonCache,
+        Scope scope
+    ) {
         this.application = application;
+        this.bindingAliasNormalizer = bindingAliasNormalizer;
         this.singletonCache = singletonCache;
         this.scope = scope;
     }
@@ -107,7 +114,11 @@ public class ScopeAwareHierarchicalBinder implements HierarchicalAliasCapableBin
         if (scopeModuleContext.absent() && this.scope() != this.applicationScope()) {
             throw new IllegalModificationException("Cannot add binding to non-application hierarchy without a module context");
         }
-        return new HierarchyBindingFunction<>(aliasableHierarchy, this, this.singletonCache, this.scope(), scopeModuleContext.orNull());
+        return new HierarchyBindingFunction<>(
+            aliasableHierarchy, this, this.singletonCache,
+            this.scope(), scopeModuleContext.orNull(),
+            this.bindingAliasNormalizer
+        );
     }
 
     @Override

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/ScopeAwareHierarchicalBinder.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/ScopeAwareHierarchicalBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import org.dockbox.hartshorn.util.option.Option;
  *
  * @author Guus Lieben
  */
-public class ScopeAwareHierarchicalBinder implements HierarchicalBinder, NestedHierarchyLookup {
+public class ScopeAwareHierarchicalBinder implements HierarchicalAliasCapableBinder, NestedHierarchyLookup {
 
     private final InjectionCapableApplication application;
     private final SingletonCache singletonCache;
@@ -70,7 +70,7 @@ public class ScopeAwareHierarchicalBinder implements HierarchicalBinder, NestedH
     }
 
     @Override
-    public <C> BindingFunction<C> bind(Class<C> type) {
+    public <C> AliasBindingFunction<C> bind(Class<C> type) {
         // Strict, so new hierarchies are created if needed, rather than using loose lookup
         ComponentKey<C> componentKey = ComponentKey.builder(type)
                 .strict(true)
@@ -84,7 +84,7 @@ public class ScopeAwareHierarchicalBinder implements HierarchicalBinder, NestedH
     }
 
     @Override
-    public <C> BindingFunction<C> bind(ComponentKey<C> key) {
+    public <C> AliasBindingFunction<C> bind(ComponentKey<C> key) {
         Scope componentScope = key.scope().orNull();
         if (componentScope == null) {
             componentScope = this.applicationScope();

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/SubscribableBindingHierarchy.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/SubscribableBindingHierarchy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.inject.binding;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.function.Consumer;
 
@@ -38,21 +39,23 @@ import org.dockbox.hartshorn.util.option.Option;
  *
  * @author Guus Lieben
  */
-public class SubscribableBindingHierarchy<C> implements PrunableBindingHierarchy<C> {
+public class SubscribableBindingHierarchy<C> implements PrunableBindingHierarchy<C>, AliasableBindingHierarchy<C> {
 
     private final Consumer<BindingHierarchy<C>> onUpdate;
 
-    private BindingHierarchy<C> real;
+    private AliasableBindingHierarchy<C> real;
 
     public SubscribableBindingHierarchy(BindingHierarchy<C> real, Consumer<BindingHierarchy<C>> onUpdate) {
-        this.real = real;
+        this.real = real instanceof AliasableBindingHierarchy<C> aliasable
+                ? aliasable
+                : new AliasableBindingHierarchyAdapter<>(real);
         this.onUpdate = onUpdate;
     }
 
     /**
      * @return The wrapped {@link BindingHierarchy}.
      */
-    protected BindingHierarchy<C> real() {
+    protected AliasableBindingHierarchy<C> real() {
         return this.real;
     }
 
@@ -62,25 +65,35 @@ public class SubscribableBindingHierarchy<C> implements PrunableBindingHierarchy
     }
 
     @Override
-    public BindingHierarchy<C> add(InstantiationStrategy<C> strategy) {
+    public void alias(ComponentKey<? super C> componentKey) {
+        this.real().alias(componentKey);
+    }
+
+    @Override
+    public Set<ComponentKey<? super C>> aliases() {
+        return Set.of();
+    }
+
+    @Override
+    public AliasableBindingHierarchy<C> add(InstantiationStrategy<C> strategy) {
         this.real = this.real().add(strategy);
         return this.hierarchyUpdated();
     }
 
     @Override
-    public BindingHierarchy<C> add(int priority, InstantiationStrategy<C> strategy) {
+    public AliasableBindingHierarchy<C> add(int priority, InstantiationStrategy<C> strategy) {
         this.real = this.real().add(priority, strategy);
         return this.hierarchyUpdated();
     }
 
     @Override
-    public BindingHierarchy<C> addNext(InstantiationStrategy<C> strategy) {
+    public AliasableBindingHierarchy<C> addNext(InstantiationStrategy<C> strategy) {
         this.real = this.real().addNext(strategy);
         return this.hierarchyUpdated();
     }
 
     @Override
-    public BindingHierarchy<C> merge(BindingHierarchy<C> hierarchy) {
+    public AliasableBindingHierarchy<C> merge(BindingHierarchy<C> hierarchy) {
         this.real = this.real().merge(hierarchy);
         return this.hierarchyUpdated();
     }
@@ -110,12 +123,17 @@ public class SubscribableBindingHierarchy<C> implements PrunableBindingHierarchy
         return this.real().key();
     }
 
+    @Override
+    public <T> boolean isCompatible(ComponentKey<T> key) {
+        return this.real.isCompatible(key);
+    }
+
     /**
      * Notifies the subscriber of a change in the hierarchy.
      *
      * @return Itself, for chaining.
      */
-    private BindingHierarchy<C> hierarchyUpdated() {
+    private AliasableBindingHierarchy<C> hierarchyUpdated() {
         this.onUpdate.accept(this.real());
         return this;
     }
@@ -133,7 +151,7 @@ public class SubscribableBindingHierarchy<C> implements PrunableBindingHierarchy
 
     @Override
     public boolean prune(int priority) {
-        if (this.real() instanceof PrunableBindingHierarchy<C> prunableBindingHierarchy) {
+        if (((BindingHierarchy<C>) this.real()) instanceof PrunableBindingHierarchy<C> prunableBindingHierarchy) {
             return prunableBindingHierarchy.prune(priority);
         }
         return false;
@@ -141,7 +159,7 @@ public class SubscribableBindingHierarchy<C> implements PrunableBindingHierarchy
 
     @Override
     public int pruneAbove(int priority) {
-        if (this.real() instanceof PrunableBindingHierarchy<C> prunableBindingHierarchy) {
+        if (((BindingHierarchy<C>) this.real()) instanceof PrunableBindingHierarchy<C> prunableBindingHierarchy) {
             return prunableBindingHierarchy.pruneAbove(priority);
         }
         return 0;
@@ -149,7 +167,7 @@ public class SubscribableBindingHierarchy<C> implements PrunableBindingHierarchy
 
     @Override
     public int pruneBelow(int priority) {
-        if (this.real() instanceof PrunableBindingHierarchy<C> prunableBindingHierarchy) {
+        if (((BindingHierarchy<C>) this.real()) instanceof PrunableBindingHierarchy<C> prunableBindingHierarchy) {
             return prunableBindingHierarchy.pruneBelow(priority);
         }
         return 0;

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/collection/ImmutableCompositeBindingHierarchy.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/collection/ImmutableCompositeBindingHierarchy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +118,11 @@ public class ImmutableCompositeBindingHierarchy<T> implements BindingHierarchy<C
     @Override
     public ComponentKey<ComponentCollection<T>> key() {
         return this.componentKey;
+    }
+
+    @Override
+    public <T> boolean isCompatible(ComponentKey<T> key) {
+        return this.key().equals(key);
     }
 
     @NonNull

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/CompositeDependencyGraphValidator.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/CompositeDependencyGraphValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.inject.graph;
 
 import org.dockbox.hartshorn.inject.graph.declaration.DependencyContext;
+import org.dockbox.hartshorn.inject.provider.ComponentProviderOrchestrator;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.graph.GraphNode;
 import org.dockbox.hartshorn.util.introspect.Introspector;
@@ -52,16 +53,18 @@ public class CompositeDependencyGraphValidator implements DependencyGraphValidat
     }
 
     @Override
-    public void validateBeforeConfiguration(DependencyGraph dependencyGraph, Introspector introspector) throws ApplicationException {
+    public void validateBeforeConfiguration(DependencyGraph dependencyGraph, Introspector introspector,
+        ComponentProviderOrchestrator orchestrator) throws ApplicationException {
         for (DependencyGraphValidator validator : this.validators) {
-            validator.validateBeforeConfiguration(dependencyGraph, introspector);
+            validator.validateBeforeConfiguration(dependencyGraph, introspector, orchestrator);
         }
     }
 
     @Override
-    public void validateAfterConfiguration(DependencyGraph dependencyGraph, Introspector introspector, Set<GraphNode<DependencyContext<?>>> visited) throws ApplicationException {
+    public void validateAfterConfiguration(DependencyGraph dependencyGraph, Introspector introspector, Set<GraphNode<DependencyContext<?>>> visited,
+        ComponentProviderOrchestrator orchestrator) throws ApplicationException {
         for (DependencyGraphValidator validator : this.validators) {
-            validator.validateAfterConfiguration(dependencyGraph, introspector, visited);
+            validator.validateAfterConfiguration(dependencyGraph, introspector, visited, orchestrator);
         }
     }
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/DependencyGraphInitializer.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/DependencyGraphInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import org.dockbox.hartshorn.inject.graph.declaration.DependencyContext;
 import org.dockbox.hartshorn.inject.graph.declaration.DependencyDeclarationContext;
 import org.dockbox.hartshorn.inject.graph.support.CyclicDependencyGraphValidator;
 import org.dockbox.hartshorn.inject.graph.support.DependenciesVisitedGraphValidator;
+import org.dockbox.hartshorn.inject.graph.support.OverlappingAliasDependencyGraphValidator;
+import org.dockbox.hartshorn.inject.provider.ComponentProviderOrchestrator;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.ContextualInitializer;
 import org.dockbox.hartshorn.util.Customizer;
@@ -77,15 +79,21 @@ public final class DependencyGraphInitializer {
      * anything other than validation.
      *
      * @param containers the dependency declarations
+     * @param orchestrator
+     *
      * @return the initialized dependency graph
+     *
      * @throws ApplicationException when the graph is invalid, or when the validation fails
      */
-    public DependencyGraph initializeDependencyGraph(Collection<DependencyDeclarationContext<?>> containers) throws ApplicationException {
+    public DependencyGraph initializeDependencyGraph(
+        Collection<DependencyDeclarationContext<?>> containers,
+        ComponentProviderOrchestrator orchestrator
+    ) throws ApplicationException {
         DependencyGraph dependencyGraph = this.buildDependencyGraph(containers);
-        this.graphValidator.validateBeforeConfiguration(dependencyGraph, this.introspector);
+        this.graphValidator.validateBeforeConfiguration(dependencyGraph, this.introspector, orchestrator);
 
         Set<GraphNode<DependencyContext<?>>> visitedDependencies = this.dependencyVisitor.iterate(dependencyGraph);
-        this.graphValidator.validateAfterConfiguration(dependencyGraph, this.introspector, visitedDependencies);
+        this.graphValidator.validateAfterConfiguration(dependencyGraph, this.introspector, visitedDependencies, orchestrator);
 
         LOG.debug("Validated %d dependencies".formatted(visitedDependencies.size()));
         return dependencyGraph;
@@ -126,7 +134,8 @@ public final class DependencyGraphInitializer {
         private ContextualInitializer<InjectionCapableApplication, ConfigurationDependencyVisitor> dependencyVisitor = ContextualInitializer.of(SkipConfigurationDependencyVisitor::new);
         private final LazyStreamableConfigurer<InjectionCapableApplication, DependencyGraphValidator> graphValidator = LazyStreamableConfigurer.of(Set.of(
             new DependenciesVisitedGraphValidator(),
-            new CyclicDependencyGraphValidator()
+            new CyclicDependencyGraphValidator(),
+            new OverlappingAliasDependencyGraphValidator()
         ));
 
         /**

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/DependencyGraphValidator.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/DependencyGraphValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
 import org.dockbox.hartshorn.inject.graph.declaration.DependencyContext;
+import org.dockbox.hartshorn.inject.provider.ComponentProviderOrchestrator;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.Customizer;
 import org.dockbox.hartshorn.util.graph.GraphNode;
@@ -43,9 +44,12 @@ public interface DependencyGraphValidator {
      *
      * @param dependencyGraph the dependency graph to validate
      * @param introspector the introspector to use introspection of types
+     * @param orchestrator the orchestrator to use for component management
+     *
      * @throws ApplicationException when the graph is invalid, or when the validation fails
      */
-    default void validateBeforeConfiguration(DependencyGraph dependencyGraph, Introspector introspector) throws ApplicationException {
+    default void validateBeforeConfiguration(DependencyGraph dependencyGraph, Introspector introspector,
+        ComponentProviderOrchestrator orchestrator) throws ApplicationException {
         // NOOP, override if needed
     }
 
@@ -56,9 +60,12 @@ public interface DependencyGraphValidator {
      * @param dependencyGraph the dependency graph to validate
      * @param introspector the introspector to use introspection of types
      * @param visited the set of visited nodes
+     * @param orchestrator the orchestrator to use for component management
+     *
      * @throws ApplicationException when the graph is invalid, or when the validation fails
      */
-    default void validateAfterConfiguration(DependencyGraph dependencyGraph, Introspector introspector, Set<GraphNode<DependencyContext<?>>> visited) throws ApplicationException {
+    default void validateAfterConfiguration(DependencyGraph dependencyGraph, Introspector introspector, Set<GraphNode<DependencyContext<?>>> visited,
+        ComponentProviderOrchestrator orchestrator) throws ApplicationException {
         // NOOP, override if needed
     }
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/AbstractDependencyContext.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/AbstractDependencyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.dockbox.hartshorn.inject.graph.DependencyResolutionType;
 import org.dockbox.hartshorn.inject.processing.ComponentPostProcessor;
 import org.dockbox.hartshorn.inject.provider.LifecycleType;
 import org.dockbox.hartshorn.inject.scope.ScopeKey;
+import org.dockbox.hartshorn.util.ObjectDescriber;
 import org.dockbox.hartshorn.util.option.Option;
 
 /**
@@ -202,6 +203,22 @@ public abstract class AbstractDependencyContext<T> implements DependencyContext<
     @Override
     public boolean processAfterInitialization() {
         return this.processAfterInitialization;
+    }
+
+    @Override
+    public String toString() {
+        ObjectDescriber<AbstractDependencyContext<T>> describer = ObjectDescriber.of(this);
+        this.customizeDescriber(describer);
+        return describer.describe();
+    }
+
+    protected void customizeDescriber(ObjectDescriber<?> describer) {
+        describer.field("key", this.componentKey)
+            .field("priority", this.priority)
+            .field("scope", this.scope)
+            .field("memberType", this.memberType)
+            .field("lifecycleType", this.lifecycleType)
+            .field("lazy", this.lazy);
     }
 
     /**

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/AliasableDependencyContext.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/AliasableDependencyContext.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.graph.declaration;
+
+import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.QualifierKey;
+
+import java.util.Set;
+
+public interface AliasableDependencyContext<T> extends DependencyContext<T> {
+
+    Set<Class<? super T>> aliasTypes();
+    Set<ComponentKey<? super T>> aliasKeys();
+    Set<QualifierKey<T>> aliasQualifiers();
+}

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/AliasableDependencyContext.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/AliasableDependencyContext.java
@@ -21,15 +21,47 @@ import org.dockbox.hartshorn.inject.QualifierKey;
 
 import java.util.Set;
 
+/**
+ * A {@link DependencyContext} that supports aliases. Aliases are additional keys that can be used to
+ * reference the same binding. This is useful for example when a binding is defined in multiple
+ * modules, and you want to reference the same binding using different keys.
+ *
+ * @param <T> The type of the component that this context is for.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public interface AliasableDependencyContext<T> extends DependencyContext<T> {
 
+    /**
+     * Indicates whether this context has any aliases configured.
+     *
+     * @return {@code true} if this context has any aliases configured, {@code false} otherwise.
+     */
     default boolean hasConfiguredAliases() {
         return !this.aliasTypes().isEmpty() || !this.aliasKeys().isEmpty() || !this.aliasQualifiers().isEmpty();
     }
 
+    /**
+     * Returns all types that are registered as aliases for this context.
+     *
+     * @return All alias types.
+     */
     Set<Class<? super T>> aliasTypes();
 
+    /**
+     * Returns all keys that are registered as aliases for this context. Note that this does not contain
+     * normalized keys from {@link #aliasTypes() types} or {@link #aliasQualifiers() qualifiers}.
+     *
+     * @return All alias keys.
+     */
     Set<ComponentKey<? super T>> aliasKeys();
 
+    /**
+     * Returns all qualifiers that are registered as aliases for this context.
+     *
+     * @return All alias qualifiers.
+     */
     Set<QualifierKey<T>> aliasQualifiers();
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/DependencyContext.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/DependencyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,4 +149,12 @@ public interface DependencyContext<T> {
      * @return whether the dependency should be processed after initialization
      */
     boolean processAfterInitialization();
+
+    /**
+     * Returns a description of the dependency context. This description is typically used for
+     * logging purposes, to identify the origin of the dependency.
+     *
+     * @return a description of the dependency context
+     */
+    String describe();
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/ImplementationDependencyContext.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/ImplementationDependencyContext.java
@@ -23,10 +23,11 @@ import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
 import org.dockbox.hartshorn.util.introspect.view.View;
 
 /**
- * A {@link DependencyContext} implementation that is used for implementation components. Implementation components are
- * components that have a known implementation specification for which a {@link DependencyContext} is available. Typically,
- * these are obtained through {@link TypeAwareInstantiationStrategy}s that are registered with the {@link BindingHierarchy} of the
- * container.
+ * A {@link DependencyContext} implementation that is used for implementation-aware components. Components are considered
+ * implementation-aware when their primary binding's strategy is an implementation of {@link TypeAwareInstantiationStrategy}.
+ *
+ * <p>Implementation-aware {@link DependencyContext}s allow for more fine-grained validation and configuration of the
+ * component, as this typically allows better dependency resolution and more accurate component descriptions.
  *
  * @param <T> the type of the component that is implemented
  * @param <I> the type of the component that is the implementation

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/ImplementationDependencyContext.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/declaration/ImplementationDependencyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,5 +79,10 @@ public class ImplementationDependencyContext<T, I extends T> extends AbstractDep
     @Override
     public View origin() {
         return this.implementationContext.origin();
+    }
+
+    @Override
+    public String describe() {
+        return this.implementationContext().describe() + " (implementation of " + this.declarationContext().describe() + ")";
     }
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/AmbiguousAliasException.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/AmbiguousAliasException.java
@@ -22,6 +22,14 @@ import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.graph.declaration.DependencyContext;
 import org.dockbox.hartshorn.util.ApplicationException;
 
+/**
+ * Thrown when an alias is ambiguous, meaning that the same alias is defined in multiple locations. This is not allowed
+ * as it would make it impossible to determine which binding should be used when resolving the alias.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public class AmbiguousAliasException extends ApplicationException {
 
     private final ComponentKey<?> componentKey;

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/AmbiguousAliasException.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/AmbiguousAliasException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.graph.support;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.graph.declaration.DependencyContext;
+import org.dockbox.hartshorn.util.ApplicationException;
+
+public class AmbiguousAliasException extends ApplicationException {
+
+    private final ComponentKey<?> componentKey;
+    private final Collection<DependencyContext<?>> contexts;
+
+    public AmbiguousAliasException(ComponentKey<?> componentKey, Collection<DependencyContext<?>> contexts) {
+        super("Ambiguous alias " + componentKey + " found. The alias was defined in the following locations: " + contexts.stream()
+            .map(DependencyContext::describe)
+            .collect(Collectors.joining(", ")));
+        this.componentKey = componentKey;
+        this.contexts = contexts;
+    }
+
+    public ComponentKey<?> componentKey() {
+        return this.componentKey;
+    }
+
+    public Collection<DependencyContext<?>> contexts() {
+        return this.contexts;
+    }
+}

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/CyclicDependencyGraphValidator.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/CyclicDependencyGraphValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.dockbox.hartshorn.inject.graph.DependencyGraphValidator;
 import org.dockbox.hartshorn.inject.graph.TypePathNode;
 import org.dockbox.hartshorn.inject.graph.declaration.DependencyContext;
 import org.dockbox.hartshorn.inject.graph.declaration.ImplementationDependencyContext;
+import org.dockbox.hartshorn.inject.provider.ComponentProviderOrchestrator;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.graph.ContainableGraphNode;
 import org.dockbox.hartshorn.util.graph.GraphNode;
@@ -56,7 +57,8 @@ import org.dockbox.hartshorn.util.introspect.view.View;
 public class CyclicDependencyGraphValidator implements DependencyGraphValidator {
 
     @Override
-    public void validateBeforeConfiguration(DependencyGraph dependencyGraph, Introspector introspector) throws ApplicationException {
+    public void validateBeforeConfiguration(DependencyGraph dependencyGraph, Introspector introspector,
+        ComponentProviderOrchestrator orchestrator) throws ApplicationException {
         Set<GraphNode<DependencyContext<?>>> nodes = dependencyGraph.nodes();
         for (GraphNode<DependencyContext<?>> node : nodes) {
             if (node.isLeaf()) {

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/DependenciesVisitedGraphValidator.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/DependenciesVisitedGraphValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Set;
 import org.dockbox.hartshorn.inject.graph.DependencyGraph;
 import org.dockbox.hartshorn.inject.graph.DependencyGraphValidator;
 import org.dockbox.hartshorn.inject.graph.declaration.DependencyContext;
+import org.dockbox.hartshorn.inject.provider.ComponentProviderOrchestrator;
 import org.dockbox.hartshorn.util.graph.GraphException;
 import org.dockbox.hartshorn.util.graph.GraphNode;
 import org.dockbox.hartshorn.util.introspect.Introspector;
@@ -36,7 +37,8 @@ import org.dockbox.hartshorn.util.introspect.Introspector;
 public class DependenciesVisitedGraphValidator implements DependencyGraphValidator {
 
     @Override
-    public void validateAfterConfiguration(DependencyGraph dependencyGraph, Introspector introspector, Set<GraphNode<DependencyContext<?>>> visited) throws GraphException {
+    public void validateAfterConfiguration(DependencyGraph dependencyGraph, Introspector introspector, Set<GraphNode<DependencyContext<?>>> visited,
+        ComponentProviderOrchestrator orchestrator) throws GraphException {
         DependencyPresenceValidationVisitor validationVisitor = new DependencyPresenceValidationVisitor(visited);
         validationVisitor.iterate(dependencyGraph);
         Set<GraphNode<DependencyContext<?>>> missingDependencies = validationVisitor.missingDependencies();

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/OverlappingAliasDependencyGraphValidator.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/OverlappingAliasDependencyGraphValidator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.graph.support;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.QualifierKey;
+import org.dockbox.hartshorn.inject.binding.BindingAliasNormalizer;
+import org.dockbox.hartshorn.inject.graph.DependencyGraph;
+import org.dockbox.hartshorn.inject.graph.DependencyGraphValidator;
+import org.dockbox.hartshorn.inject.graph.declaration.AliasableDependencyContext;
+import org.dockbox.hartshorn.inject.graph.declaration.DependencyContext;
+import org.dockbox.hartshorn.inject.provider.AliasCapableComponentProviderOrchestrator;
+import org.dockbox.hartshorn.inject.provider.ComponentProviderOrchestrator;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.collections.HashSetMultiMap;
+import org.dockbox.hartshorn.util.collections.MultiMap;
+import org.dockbox.hartshorn.util.introspect.Introspector;
+
+public class OverlappingAliasDependencyGraphValidator implements DependencyGraphValidator {
+
+    @Override
+    public void validateBeforeConfiguration(
+        DependencyGraph dependencyGraph,
+        Introspector introspector,
+        ComponentProviderOrchestrator orchestrator
+    ) throws ApplicationException {
+        if (orchestrator instanceof AliasCapableComponentProviderOrchestrator aliasCapableOrchestrator) {
+            BindingAliasNormalizer aliasNormalizer = aliasCapableOrchestrator.aliasNormalizer();
+            List<? extends AliasableDependencyContext<?>> aliasedDependencyContexts = dependencyGraph.nodes().stream()
+                .filter(node -> node.value() instanceof AliasableDependencyContext<?> context && context.hasConfiguredAliases())
+                .map(node -> (AliasableDependencyContext<?>) node.value())
+                .toList();
+
+            // Collect all ambiguous locations, rather than just failing on the first one
+            MultiMap<ComponentKey<?>, DependencyContext<?>> contextsByAlias = new HashSetMultiMap<>();
+            for (AliasableDependencyContext<?> dependencyContext : aliasedDependencyContexts) {
+                for (ComponentKey<?> componentKey : this.normalizeComponentKeys(dependencyContext, aliasNormalizer)) {
+                    contextsByAlias.put(componentKey, dependencyContext);
+                }
+            }
+
+            for (ComponentKey<?> componentKey : contextsByAlias.keySet()) {
+                Collection<DependencyContext<?>> contexts = contextsByAlias.get(componentKey);
+                if (contexts.size() > 1) {
+                    throw new AmbiguousAliasException(componentKey, contexts);
+                }
+            }
+        }
+    }
+
+    private <T> Set<ComponentKey<? super T>> normalizeComponentKeys(
+        AliasableDependencyContext<T> dependencyContext,
+        BindingAliasNormalizer aliasNormalizer
+    ) {
+        Set<ComponentKey<? super T>> componentKeys = dependencyContext.aliasKeys();
+        Set<QualifierKey<T>> qualifierKeys = dependencyContext.aliasQualifiers();
+        Set<Class<? super T>> types = dependencyContext.aliasTypes();
+
+        Set<ComponentKey<? super T>> normalizedKeys = new HashSet<>(componentKeys);
+        for (QualifierKey<T> qualifierKey : qualifierKeys) {
+            normalizedKeys.add(aliasNormalizer.alias(dependencyContext.componentKey(), qualifierKey));
+        }
+        for (Class<? super T> type : types) {
+            normalizedKeys.add(aliasNormalizer.alias(dependencyContext.componentKey(), type));
+        }
+        return normalizedKeys;
+    }
+}

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/OverlappingAliasDependencyGraphValidator.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/graph/support/OverlappingAliasDependencyGraphValidator.java
@@ -34,6 +34,18 @@ import org.dockbox.hartshorn.util.collections.HashSetMultiMap;
 import org.dockbox.hartshorn.util.collections.MultiMap;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 
+/**
+ * A {@link DependencyGraphValidator} that checks for overlapping aliases in a {@link DependencyGraph}. An overlapping
+ * alias is an alias that is defined in multiple locations at the same priority. This is not allowed as it would make it
+ * impossible to determine which binding should be used when resolving the alias.
+ *
+ * <p>Note that an alias that overlaps with a primary key is not considered an overlapping alias, as the primary key
+ * will always take precedence over the alias.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public class OverlappingAliasDependencyGraphValidator implements DependencyGraphValidator {
 
     @Override
@@ -50,21 +62,24 @@ public class OverlappingAliasDependencyGraphValidator implements DependencyGraph
                 .toList();
 
             // Collect all ambiguous locations, rather than just failing on the first one
-            MultiMap<ComponentKey<?>, DependencyContext<?>> contextsByAlias = new HashSetMultiMap<>();
+            MultiMap<PrioritizedComponentKey<?>, DependencyContext<?>> contextsByAlias = new HashSetMultiMap<>();
             for (AliasableDependencyContext<?> dependencyContext : aliasedDependencyContexts) {
                 for (ComponentKey<?> componentKey : this.normalizeComponentKeys(dependencyContext, aliasNormalizer)) {
-                    contextsByAlias.put(componentKey, dependencyContext);
+                    PrioritizedComponentKey<?> key = new PrioritizedComponentKey<>(componentKey, dependencyContext.priority());
+                    contextsByAlias.put(key, dependencyContext);
                 }
             }
 
-            for (ComponentKey<?> componentKey : contextsByAlias.keySet()) {
+            for (PrioritizedComponentKey<?> componentKey : contextsByAlias.keySet()) {
                 Collection<DependencyContext<?>> contexts = contextsByAlias.get(componentKey);
                 if (contexts.size() > 1) {
-                    throw new AmbiguousAliasException(componentKey, contexts);
+                    throw new AmbiguousAliasException(componentKey.key(), contexts);
                 }
             }
         }
     }
+
+    record PrioritizedComponentKey<T>(ComponentKey<? super T> key, int priority) {}
 
     private <T> Set<ComponentKey<? super T>> normalizeComponentKeys(
         AliasableDependencyContext<T> dependencyContext,

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/provider/AliasCapableComponentProviderOrchestrator.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/provider/AliasCapableComponentProviderOrchestrator.java
@@ -18,6 +18,16 @@ package org.dockbox.hartshorn.inject.provider;
 
 import org.dockbox.hartshorn.inject.binding.BindingAliasNormalizer;
 
+/**
+ * An orchestrator that is capable of handling aliases.
+ *
+ * @see ComponentProviderOrchestrator
+ * @see BindingAliasNormalizer
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public interface AliasCapableComponentProviderOrchestrator extends ComponentProviderOrchestrator {
 
     BindingAliasNormalizer aliasNormalizer();

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/provider/AliasCapableComponentProviderOrchestrator.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/provider/AliasCapableComponentProviderOrchestrator.java
@@ -14,22 +14,11 @@
  * limitations under the License.
  */
 
-package org.dockbox.hartshorn.inject.graph.declaration;
+package org.dockbox.hartshorn.inject.provider;
 
-import org.dockbox.hartshorn.inject.ComponentKey;
-import org.dockbox.hartshorn.inject.QualifierKey;
+import org.dockbox.hartshorn.inject.binding.BindingAliasNormalizer;
 
-import java.util.Set;
+public interface AliasCapableComponentProviderOrchestrator extends ComponentProviderOrchestrator {
 
-public interface AliasableDependencyContext<T> extends DependencyContext<T> {
-
-    default boolean hasConfiguredAliases() {
-        return !this.aliasTypes().isEmpty() || !this.aliasKeys().isEmpty() || !this.aliasQualifiers().isEmpty();
-    }
-
-    Set<Class<? super T>> aliasTypes();
-
-    Set<ComponentKey<? super T>> aliasKeys();
-
-    Set<QualifierKey<T>> aliasQualifiers();
+    BindingAliasNormalizer aliasNormalizer();
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/scope/ScopeModuleContext.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/scope/ScopeModuleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ package org.dockbox.hartshorn.inject.scope;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.dockbox.hartshorn.context.DefaultContext;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.ContextKey;
+import org.dockbox.hartshorn.inject.binding.AliasableBindingHierarchy;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
 import org.dockbox.hartshorn.inject.binding.NativePrunableBindingHierarchy;
 import org.dockbox.hartshorn.util.TypeUtils;
@@ -57,7 +59,7 @@ public class ScopeModuleContext extends DefaultContext {
 
     public <T> BindingHierarchy<T> hierarchy(ScopeKey scope, ComponentKey<T> key) {
         BindingHierarchy<?> bindingHierarchy = this.scopeModules.get(scope).stream()
-                .filter(hierarchy -> hierarchy.key().equals(key))
+                .filter(hierarchy -> hierarchy.isCompatible(key))
                 .findFirst()
                 .orElseGet(() -> {
                     BindingHierarchy<T> hierarchy = new NativePrunableBindingHierarchy<>(key);

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/scope/ScopeModuleContext.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/scope/ScopeModuleContext.java
@@ -18,12 +18,10 @@ package org.dockbox.hartshorn.inject.scope;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.function.Supplier;
 import org.dockbox.hartshorn.context.DefaultContext;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.ContextKey;
-import org.dockbox.hartshorn.inject.binding.AliasableBindingHierarchy;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
 import org.dockbox.hartshorn.inject.binding.NativePrunableBindingHierarchy;
 import org.dockbox.hartshorn.util.TypeUtils;

--- a/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/binding/BindingHierarchyTests.java
+++ b/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/binding/BindingHierarchyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package test.org.dockbox.hartshorn.inject.binding;
 
 import org.dockbox.hartshorn.inject.QualifierKey;
 import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.binding.DefaultBindingAliasNormalizer;
 import org.dockbox.hartshorn.inject.binding.HierarchicalBinder;
 import org.dockbox.hartshorn.inject.binding.ScopeAwareHierarchicalBinder;
 import org.dockbox.hartshorn.inject.provider.CompositeInstantiationStrategy;
@@ -42,9 +43,10 @@ public class BindingHierarchyTests {
 
     private HierarchicalBinder binder() {
         return new ScopeAwareHierarchicalBinder(
-                null,
-                new ConcurrentHashSingletonCache(),
-                ScopeAdapter.of("test")
+            null,
+            new DefaultBindingAliasNormalizer(),
+            new ConcurrentHashSingletonCache(),
+            ScopeAdapter.of("test")
         );
     }
 

--- a/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/graph/support/OverlappingAliasDependencyGraphValidatorTests.java
+++ b/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/graph/support/OverlappingAliasDependencyGraphValidatorTests.java
@@ -33,7 +33,7 @@ import org.mockito.Mockito;
 public class OverlappingAliasDependencyGraphValidatorTests {
 
     @Test
-    void testOverlappingAliasPrioritiesFromConfigurationFails() {
+    void testOverlappingAliasWithSamePriorityFails() {
         DependencyGraphValidator validator = new OverlappingAliasDependencyGraphValidator();
         DependencyGraph graph = new DependencyGraph();
 
@@ -54,6 +54,25 @@ public class OverlappingAliasDependencyGraphValidatorTests {
         Assertions.assertEquals(ComponentKey.of(CharSequence.class), exception.componentKey());
     }
 
+    @Test
+    void testOverlappingAliasWithDifferentPrioritiesPasses() {
+        DependencyGraphValidator validator = new OverlappingAliasDependencyGraphValidator();
+        DependencyGraph graph = new DependencyGraph();
+
+        AliasableDependencyContext<String> declarationString = createDeclarationMock(String.class);
+        Mockito.when(declarationString.priority()).thenReturn(1);
+
+        AliasableDependencyContext<StringBuilder> declarationStringBuilder = createDeclarationMock(StringBuilder.class);
+        Mockito.when(declarationStringBuilder.priority()).thenReturn(2);
+
+        graph.addRoot(new SimpleGraphNode<>(declarationString));
+        graph.addRoot(new SimpleGraphNode<>(declarationStringBuilder));
+
+        AliasCapableComponentProviderOrchestrator orchestrator = Mockito.mock(AliasCapableComponentProviderOrchestrator.class);
+        Mockito.when(orchestrator.aliasNormalizer()).thenReturn(new DefaultBindingAliasNormalizer());
+        Assertions.assertDoesNotThrow(() -> validator.validateBeforeConfiguration(graph, null, orchestrator));
+    }
+
     private static <T extends CharSequence> AliasableDependencyContext<T> createDeclarationMock(Class<T> keyType) {
         AliasableDependencyContext<T> declarationString = Mockito.mock(AliasableDependencyContext.class);
         Mockito.when(declarationString.componentKey()).thenReturn(ComponentKey.of(keyType));
@@ -62,6 +81,7 @@ public class OverlappingAliasDependencyGraphValidatorTests {
         Mockito.when(declarationString.aliasQualifiers()).thenReturn(Set.of());
         Mockito.when(declarationString.aliasKeys()).thenReturn(Set.of());
         Mockito.when(declarationString.hasConfiguredAliases()).thenReturn(true);
+        Mockito.when(declarationString.priority()).thenReturn(0);
         return declarationString;
     }
 }

--- a/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/graph/support/OverlappingAliasDependencyGraphValidatorTests.java
+++ b/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/graph/support/OverlappingAliasDependencyGraphValidatorTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.dockbox.hartshorn.inject.graph.support;
+
+import java.util.Set;
+import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.binding.DefaultBindingAliasNormalizer;
+import org.dockbox.hartshorn.inject.graph.DependencyGraph;
+import org.dockbox.hartshorn.inject.graph.DependencyGraphValidator;
+import org.dockbox.hartshorn.inject.graph.declaration.AliasableDependencyContext;
+import org.dockbox.hartshorn.inject.graph.support.AmbiguousAliasException;
+import org.dockbox.hartshorn.inject.graph.support.OverlappingAliasDependencyGraphValidator;
+import org.dockbox.hartshorn.inject.provider.AliasCapableComponentProviderOrchestrator;
+import org.dockbox.hartshorn.util.graph.SimpleGraphNode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class OverlappingAliasDependencyGraphValidatorTests {
+
+    @Test
+    void testOverlappingAliasPrioritiesFromConfigurationFails() {
+        DependencyGraphValidator validator = new OverlappingAliasDependencyGraphValidator();
+        DependencyGraph graph = new DependencyGraph();
+
+        AliasableDependencyContext<String> declarationString = createDeclarationMock(String.class);
+        AliasableDependencyContext<StringBuilder> declarationStringBuilder = createDeclarationMock(StringBuilder.class);
+
+        graph.addRoot(new SimpleGraphNode<>(declarationString));
+        graph.addRoot(new SimpleGraphNode<>(declarationStringBuilder));
+
+        AliasCapableComponentProviderOrchestrator orchestrator = Mockito.mock(AliasCapableComponentProviderOrchestrator.class);
+        Mockito.when(orchestrator.aliasNormalizer()).thenReturn(new DefaultBindingAliasNormalizer());
+        AmbiguousAliasException exception = Assertions.assertThrows(
+            AmbiguousAliasException.class,
+            () -> validator.validateBeforeConfiguration(graph, null, orchestrator)
+        );
+
+        Assertions.assertEquals(2, exception.contexts().size());
+        Assertions.assertEquals(ComponentKey.of(CharSequence.class), exception.componentKey());
+    }
+
+    private static <T extends CharSequence> AliasableDependencyContext<T> createDeclarationMock(Class<T> keyType) {
+        AliasableDependencyContext<T> declarationString = Mockito.mock(AliasableDependencyContext.class);
+        Mockito.when(declarationString.componentKey()).thenReturn(ComponentKey.of(keyType));
+        Mockito.when(declarationString.describe()).thenReturn("mockLocation");
+        Mockito.when(declarationString.aliasTypes()).thenReturn(Set.of(CharSequence.class));
+        Mockito.when(declarationString.aliasQualifiers()).thenReturn(Set.of());
+        Mockito.when(declarationString.aliasKeys()).thenReturn(Set.of());
+        Mockito.when(declarationString.hasConfiguredAliases()).thenReturn(true);
+        return declarationString;
+    }
+}

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/aliases/BindingAliasingTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/aliases/BindingAliasingTests.java
@@ -17,6 +17,7 @@
 package test.org.dockbox.hartshorn.inject.aliases;
 
 import org.dockbox.hartshorn.inject.annotations.Inject;
+import org.dockbox.hartshorn.inject.annotations.Priority;
 import org.dockbox.hartshorn.inject.annotations.configuration.BindingAlias;
 import org.dockbox.hartshorn.inject.annotations.configuration.Configuration;
 import org.dockbox.hartshorn.inject.annotations.configuration.Singleton;
@@ -51,6 +52,12 @@ public class BindingAliasingTests {
         Assertions.assertSame(helloWorldString, helloWorldCharSequence);
     }
 
+    @Test
+    void testOverlappingDefaultAndAliasBindingsFromConfigurationCanResolve(@Inject ComponentProvider provider) {
+        Assertions.assertDoesNotThrow(() -> provider.get(String.class));
+        Assertions.assertDoesNotThrow(() -> provider.get(CharSequence.class));
+    }
+
     @Configuration
     public static class BindingAliasingConfiguration {
 
@@ -58,6 +65,39 @@ public class BindingAliasingTests {
         @BindingAlias(CharSequence.class)
         public String helloWorld() {
             return "Hello world";
+        }
+    }
+
+    @Configuration
+    public static class OverlappingPriorityBindingAliasingConfiguration {
+
+        @Singleton
+        @Priority(1)
+        @BindingAlias(CharSequence.class)
+        public String helloWorld() {
+            return "Hello world";
+        }
+
+        @Singleton
+        @Priority(1)
+        @BindingAlias(CharSequence.class)
+        public StringBuilder helloWorldBuilder() {
+            return new StringBuilder("Hello world");
+        }
+    }
+
+    @Configuration
+    public static class OverlappingDefaultAndAliasBindingConfiguration {
+
+        @Singleton
+        @BindingAlias(CharSequence.class)
+        public String helloWorld() {
+            return "Hello world";
+        }
+
+        @Singleton
+        public CharSequence helloWorldSequence() {
+            return "Hello world sequence";
         }
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/aliases/BindingAliasingTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/aliases/BindingAliasingTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.dockbox.hartshorn.inject.aliases;
+
+import org.dockbox.hartshorn.inject.annotations.Inject;
+import org.dockbox.hartshorn.inject.annotations.configuration.BindingAlias;
+import org.dockbox.hartshorn.inject.annotations.configuration.Configuration;
+import org.dockbox.hartshorn.inject.annotations.configuration.Singleton;
+import org.dockbox.hartshorn.inject.provider.ComponentProvider;
+import org.dockbox.hartshorn.launchpad.ApplicationContext;
+import org.dockbox.hartshorn.test.annotations.TestComponents;
+import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@HartshornIntegrationTest(includeBasePackages = false)
+public class BindingAliasingTests {
+
+    @Test
+    void testAliasBindingsCanBeResolved(@Inject ApplicationContext applicationContext) {
+        applicationContext.bind(String.class)
+                .alias(CharSequence.class)
+                .singleton("Hello world");
+
+        String helloWorldString = applicationContext.get(String.class);
+        CharSequence helloWorldCharSequence = applicationContext.get(CharSequence.class);
+
+        Assertions.assertSame(helloWorldString, helloWorldCharSequence);
+    }
+
+    @Test
+    @TestComponents(components = BindingAliasingConfiguration.class)
+    void testAliasBindingsFromConfigurationCanBeResolved(@Inject ComponentProvider provider) {
+        String helloWorldString = provider.get(String.class);
+        CharSequence helloWorldCharSequence = provider.get(CharSequence.class);
+
+        Assertions.assertSame(helloWorldString, helloWorldCharSequence);
+    }
+
+    @Configuration
+    public static class BindingAliasingConfiguration {
+
+        @Singleton
+        @BindingAlias(CharSequence.class)
+        public String helloWorld() {
+            return "Hello world";
+        }
+    }
+}

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/ApplicationContext.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/ApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 package org.dockbox.hartshorn.launchpad;
 
-import org.dockbox.hartshorn.inject.binding.HierarchicalBinder;
-import org.dockbox.hartshorn.launchpad.launch.ApplicationBuilder;
 import org.dockbox.hartshorn.inject.ExceptionHandler;
+import org.dockbox.hartshorn.inject.binding.HierarchicalAliasCapableBinder;
 import org.dockbox.hartshorn.inject.provider.HierarchicalComponentProvider;
 import org.dockbox.hartshorn.launchpad.context.ApplicationContextCarrier;
 import org.dockbox.hartshorn.launchpad.environment.ApplicationEnvironment;
+import org.dockbox.hartshorn.launchpad.launch.ApplicationBuilder;
 import org.dockbox.hartshorn.util.ApplicationException;
 
 /**
@@ -43,10 +43,10 @@ import org.dockbox.hartshorn.util.ApplicationException;
  */
 public interface ApplicationContext extends
     ConfigurableActivationInjectionCapableApplication,
-        HierarchicalComponentProvider,
-        HierarchicalBinder,
-        ExceptionHandler,
-        AutoCloseable {
+    HierarchicalComponentProvider,
+    HierarchicalAliasCapableBinder,
+    ExceptionHandler,
+    AutoCloseable {
 
     /**
      * Gets the active {@link ApplicationEnvironment} for the application.

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/DelegatingApplicationAliasBindingFunction.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/DelegatingApplicationAliasBindingFunction.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.launchpad;
+
+import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.IllegalScopeException;
+import org.dockbox.hartshorn.inject.QualifierKey;
+import org.dockbox.hartshorn.inject.binding.AliasBindingFunction;
+import org.dockbox.hartshorn.inject.binding.Binder;
+import org.dockbox.hartshorn.inject.binding.BindingFunction;
+import org.dockbox.hartshorn.inject.scope.ScopeKey;
+
+/**
+ * A {@link BindingFunction} that delegates all calls to the provided {@link BindingFunction delegate}, but returns the
+ * {@link ApplicationContext} instead of the {@link Binder} to allow for chaining. This is used to allow for the
+ * {@link ApplicationContext} to use custom binders, while still allowing for the {@link ApplicationContext} to be
+ * returned.
+ *
+ * @param <T> the type of the binding
+ *
+ * @see ApplicationContext
+ * @see BindingFunction
+ *
+ * @since 0.4.11
+ *
+ * @author Guus Lieben
+ */
+public class DelegatingApplicationAliasBindingFunction<T> extends DelegatingApplicationBindingFunction<T> implements AliasBindingFunction<T> {
+
+    public DelegatingApplicationAliasBindingFunction(ApplicationContext applicationContext, AliasBindingFunction<T> delegate) {
+        super(applicationContext, delegate);
+    }
+
+    @Override
+    protected AliasBindingFunction<T> delegate() {
+        return (AliasBindingFunction<T>) super.delegate();
+    }
+
+    @Override
+    public AliasBindingFunction<T> alias(Class<? super T> aliasType) {
+        return this.delegate().alias(aliasType);
+    }
+
+    @Override
+    public AliasBindingFunction<T> alias(ComponentKey<? super T> aliasKey) {
+        return this.delegate().alias(aliasKey);
+    }
+
+    @Override
+    public AliasBindingFunction<T> alias(QualifierKey<T> aliasQualifier) {
+        return this.delegate().alias(aliasQualifier);
+    }
+
+    @Override
+    public AliasBindingFunction<T> installTo(ScopeKey scope) throws IllegalScopeException {
+        return (AliasBindingFunction<T>) super.installTo(scope);
+    }
+
+    @Override
+    public AliasBindingFunction<T> priority(int priority) {
+        return (AliasBindingFunction<T>) super.priority(priority);
+    }
+
+    @Override
+    public AliasBindingFunction<T> processAfterInitialization(boolean processAfterInitialization) {
+        return (AliasBindingFunction<T>) super.processAfterInitialization(processAfterInitialization);
+    }
+}

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/DelegatingApplicationBindingFunction.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/DelegatingApplicationBindingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package org.dockbox.hartshorn.launchpad;
 
-import org.dockbox.hartshorn.inject.scope.ScopeKey;
-import org.dockbox.hartshorn.launchpad.context.ApplicationContextCarrier;
-import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
+import org.dockbox.hartshorn.inject.IllegalScopeException;
 import org.dockbox.hartshorn.inject.binding.Binder;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
 import org.dockbox.hartshorn.inject.collection.CollectorBindingFunction;
-import org.dockbox.hartshorn.inject.IllegalScopeException;
+import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
+import org.dockbox.hartshorn.inject.scope.ScopeKey;
+import org.dockbox.hartshorn.launchpad.context.ApplicationContextCarrier;
 import org.dockbox.hartshorn.util.Customizer;
 import org.dockbox.hartshorn.util.function.CheckedSupplier;
 
@@ -49,6 +49,10 @@ public class DelegatingApplicationBindingFunction<T> implements BindingFunction<
     public DelegatingApplicationBindingFunction(ApplicationContext applicationContext, BindingFunction<T> delegate) {
         this.applicationContext = applicationContext;
         this.delegate = delegate;
+    }
+
+    protected BindingFunction<T> delegate() {
+        return this.delegate;
     }
 
     @Override

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/DelegatingApplicationContext.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/DelegatingApplicationContext.java
@@ -243,7 +243,7 @@ public abstract class DelegatingApplicationContext
     /**
      * @return the {@link ComponentProvider} that is used by this {@link ApplicationContext} to provide components
      */
-    public PostProcessingComponentProvider componentProvider() {
+    public ComponentProviderOrchestrator componentProvider() {
         return this.componentProvider;
     }
 

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/DelegatingApplicationContext.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/DelegatingApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,14 @@
 
 package org.dockbox.hartshorn.launchpad;
 
+import java.util.Set;
+import java.util.function.BiConsumer;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.DefaultFallbackCompatibleContext;
 import org.dockbox.hartshorn.inject.ExceptionHandler;
+import org.dockbox.hartshorn.inject.binding.AliasBindingFunction;
+import org.dockbox.hartshorn.inject.binding.AliasCapableBinder;
 import org.dockbox.hartshorn.inject.binding.Binder;
 import org.dockbox.hartshorn.inject.binding.BindingFunction;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
@@ -48,9 +52,6 @@ import org.dockbox.hartshorn.util.collections.ArrayListMultiMap;
 import org.dockbox.hartshorn.util.collections.MultiMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Set;
-import java.util.function.BiConsumer;
 
 /**
  * A {@link ApplicationContext} implementation that delegates to a {@link PostProcessingComponentProvider}. This
@@ -169,10 +170,15 @@ public abstract class DelegatingApplicationContext
     }
 
     @Override
-    public <C> BindingFunction<C> bind(ComponentKey<C> key) {
-        if (this.componentProvider instanceof Binder binder) {
+    public <C> AliasBindingFunction<C> bind(ComponentKey<C> key) {
+        if (this.componentProvider instanceof AliasCapableBinder binder) {
+            AliasBindingFunction<C> function = binder.bind(key);
+            return new DelegatingApplicationAliasBindingFunction<>(this, function);
+        }
+        else if (this.componentProvider instanceof Binder binder) {
             BindingFunction<C> function = binder.bind(key);
-            return new DelegatingApplicationBindingFunction<>(this, function);
+            BindingFunction<C> delegate = new DelegatingApplicationBindingFunction<>(this, function);
+            return new NonAliasBindingFunctionAdapter<>(delegate);
         }
         throw new UnsupportedOperationException("This application does not support binding hierarchies");
     }

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/NonAliasBindingFunctionAdapter.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/NonAliasBindingFunctionAdapter.java
@@ -28,6 +28,18 @@ import org.dockbox.hartshorn.inject.scope.ScopeKey;
 import org.dockbox.hartshorn.util.Customizer;
 import org.dockbox.hartshorn.util.function.CheckedSupplier;
 
+/**
+ * An adapter for {@link BindingFunction} that does not support aliasing. This may be used to adapt a binding function
+ * to an environment that requires the usage of {@link AliasBindingFunction}. This adapter will delegate all calls to
+ * the original binding function, but will throw an {@link UnsupportedOperationException} when an aliasing method is
+ * called.
+ *
+ * @param <T> the type of the binding
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
 public class NonAliasBindingFunctionAdapter<T> implements AliasBindingFunction<T> {
 
     private final BindingFunction<T> delegate;

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/NonAliasBindingFunctionAdapter.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/NonAliasBindingFunctionAdapter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.launchpad;
+
+import org.dockbox.hartshorn.inject.ComponentKey;
+import org.dockbox.hartshorn.inject.IllegalScopeException;
+import org.dockbox.hartshorn.inject.QualifierKey;
+import org.dockbox.hartshorn.inject.binding.AliasBindingFunction;
+import org.dockbox.hartshorn.inject.binding.Binder;
+import org.dockbox.hartshorn.inject.binding.BindingFunction;
+import org.dockbox.hartshorn.inject.collection.CollectorBindingFunction;
+import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
+import org.dockbox.hartshorn.inject.scope.ScopeKey;
+import org.dockbox.hartshorn.util.Customizer;
+import org.dockbox.hartshorn.util.function.CheckedSupplier;
+
+public class NonAliasBindingFunctionAdapter<T> implements AliasBindingFunction<T> {
+
+    private final BindingFunction<T> delegate;
+
+    public NonAliasBindingFunctionAdapter(BindingFunction<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public AliasBindingFunction<T> alias(Class<? super T> aliasType) {
+        throw new UnsupportedOperationException("Binding function does not support aliasing");
+    }
+
+    @Override
+    public AliasBindingFunction<T> alias(ComponentKey<? super T> aliasKey) {
+        throw new UnsupportedOperationException("Binding function does not support aliasing");
+    }
+
+    @Override
+    public AliasBindingFunction<T> alias(QualifierKey<T> aliasQualifier) {
+        throw new UnsupportedOperationException("Binding function does not support aliasing");
+    }
+
+    private AliasBindingFunction<T> currentOrNextAdapter(BindingFunction<T> function) {
+        if (function == this.delegate) {
+            return this;
+        }
+        else {
+            return new NonAliasBindingFunctionAdapter<>(function);
+        }
+    }
+
+    @Override
+    public AliasBindingFunction<T> installTo(ScopeKey scope) throws IllegalScopeException {
+        return this.currentOrNextAdapter(this.delegate.installTo(scope));
+    }
+
+    @Override
+    public AliasBindingFunction<T> processAfterInitialization(boolean processAfterInitialization) {
+        return this.currentOrNextAdapter(this.delegate.processAfterInitialization(processAfterInitialization));
+    }
+
+    @Override
+    public Binder to(Class<? extends T> type) {
+        return this.delegate.to(type);
+    }
+
+    @Override
+    public Binder to(CheckedSupplier<T> supplier) {
+        return this.delegate.to(supplier);
+    }
+
+    @Override
+    public Binder to(InstantiationStrategy<T> strategy) {
+        return this.delegate.to(strategy);
+    }
+
+    @Override
+    public Binder singleton(T instance) {
+        return this.delegate.singleton(instance);
+    }
+
+    @Override
+    public Binder lazySingleton(Class<T> type) {
+        return this.delegate.lazySingleton(type);
+    }
+
+    @Override
+    public Binder lazySingleton(CheckedSupplier<T> supplier) {
+        return this.delegate.lazySingleton(supplier);
+    }
+
+    @Override
+    public Binder collect(Customizer<CollectorBindingFunction<T>> collector) {
+        return this.delegate.collect(collector);
+    }
+
+    @Override
+    public AliasBindingFunction<T> priority(int priority) {
+        return this.currentOrNextAdapter(this.delegate.priority(priority));
+    }
+}

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/SimpleApplicationContext.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/SimpleApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ public class SimpleApplicationContext extends DelegatingApplicationContext {
                     .toList();
             declarationContexts.addAll(componentContexts);
 
-            this.dependencyGraphInitializer.initializeDependencyGraph(declarationContexts);
+            this.dependencyGraphInitializer.initializeDependencyGraph(declarationContexts, this.componentProvider());
         }
         catch (DependencyResolutionException e) {
             throw new ComponentInitializationException("Failed to resolve dependencies", e);


### PR DESCRIPTION
### Type of Change
- [x] Feature (non-breaking change that adds functionality)

### Description
Introduces the ability to alias bindings at the hierarchy level, allowing a single provider to be targeted by multiple component keys.

#### Changes to binders and hierarchies
At the lowest level, the addition of aliases expands the binding functionality. The existing `Binder` interface has gone unchanged, with the addition of the `AliasCapableBinder` adding aliasing capabilities to the API.

The only difference between `Binder` and `AliasCapableBinder` is that `AliasCapableBinder` returns a `AliasBindingFunction` rather than a standard `BindingFunction`. The `AliasBindingFunction` is the primary entrypoint for configuring aliases.

The `AliasBindingFunction` supports three different types of aliases:
- Type aliasing: providing an alternative (weaker) type to add as alias. For example `CharSequence` to a `String` binding.
- Qualifier aliasing: providing an alternative qualifier to add as alias.
- Key aliasing: providing an entirely different (weaker) component key.

Both type- and qualifier aliases are translated to key aliases in the background, using the configured `BindingAliasNormalizer` (by default configured in the `HierarchicalComponentProviderOrchestrator`). Depending on the normalizer implementation, the way these keys are translated may differ. By default:
- Alias keys created from an alias type will retain all qualifiers from the base key, but will replace the type with the alias type.
- Alias keys created from an alias qualifier will lose all qualifiers from the base key, but will retain all other information.

```java
AliasCapableBinder binder = ...;
binder.bind(ComponentKey.of(String.class))
    .alias(ComponentKey.of(CharSequence.class)) // Type alias
    .alias(QualifierKey.of("named")) // Qualifier alias
    .alias(ComponentKey.builder(CharSequence.class).qualifier(QualifierKey.of(Qualifier.class)).build()) // Key alias
    .singleton("Hello world!");
```

#### Changes to binding methods
To support aliasing on binding methods, the `BindingAlias` annotation was introduced. This annotation only supports type aliasing. For more complex aliasing you should use binders directly (preferably through `HierarchicalBinderPostProcessor` implementations).
```java
@Singleton
@BindingAlias(CharSequence.class)
public String messageToTheWorld() {
    return "Hello, World!";
}
```

#### Changes to dependency graph validation
As aliases are not primary keys, the way they are validated is slightly different to normal binding keys. Aliases serve as a weaker binding, and will not yield errors if they overlap with a primary key. In such cases the primary key will take precendence, and the alias key will be otherwise ignored.

If two aliases overlap, validation is in place to fail early through a `AmbiguousAliasException`.

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] I have added documentation that describes my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1122