### PR TITLE
#1136 Rename SimpleConstructorViewDrivenProvider to PrototypeConstructorInstantiationStrategy

### DIFF
--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/binding/HierarchyBindingFunction.java
@@ -28,7 +28,7 @@ import org.dockbox.hartshorn.inject.collection.HierarchyCollectorBindingFunction
 import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.LazySingletonInstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.ObjectContainer;
-import org.dockbox.hartshorn.inject.provider.SimpleConstructorViewDrivenProvider;
+import org.dockbox.hartshorn.inject.provider.PrototypeConstructorInstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.SingletonInstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.SupplierInstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.singleton.SingletonCache;
@@ -159,7 +159,7 @@ public class HierarchyBindingFunction<T> implements AliasBindingFunction<T> {
             throw new IllegalModificationException("Cannot overwrite singleton binding for %s in a hierarchy, ensure the new binding is a singleton".formatted(this.hierarchy().key()));
         }
         ComponentKey<? extends T> key = this.buildComponentKey(type);
-        return this.add(SimpleConstructorViewDrivenProvider.forPrototype(key));
+        return this.add(PrototypeConstructorInstantiationStrategy.forPrototype(key));
     }
 
     @NonNull
@@ -201,7 +201,7 @@ public class HierarchyBindingFunction<T> implements AliasBindingFunction<T> {
     @Override
     public Binder lazySingleton(Class<T> type) {
         ComponentKey<? extends T> key = this.buildComponentKey(type);
-        return this.add(SimpleConstructorViewDrivenProvider.forSingleton(key));
+        return this.add(PrototypeConstructorInstantiationStrategy.forSingleton(key));
     }
 
     @Override

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/collection/HierarchyCollectorBindingFunction.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/collection/HierarchyCollectorBindingFunction.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.inject.collection;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.binding.Binder;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
-import org.dockbox.hartshorn.inject.provider.SimpleConstructorViewDrivenProvider;
+import org.dockbox.hartshorn.inject.provider.PrototypeConstructorInstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.LazySingletonInstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.PrototypeInstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
@@ -74,7 +74,7 @@ public class HierarchyCollectorBindingFunction<T> implements CollectorBindingFun
     @Override
     public Binder type(Class<? extends T> type) {
         ComponentKey<? extends T> componentKey = this.hierarchy.key().mutable().type(type).build();
-        return this.provider(SimpleConstructorViewDrivenProvider.forPrototype(componentKey));
+        return this.provider(PrototypeConstructorInstantiationStrategy.forPrototype(componentKey));
     }
 
     @Override

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/provider/PrototypeConstructorInstantiationStrategy.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/provider/PrototypeConstructorInstantiationStrategy.java
@@ -29,9 +29,10 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 
 /**
- * A {@link SimpleConstructorViewDrivenProvider} is a {@link InstantiationStrategy} that uses a {@link ConstructorView} to
- * create a new instance of a class. The constructor is looked up based on its parameters, where the
- * constructor with the most parameters is chosen in order to satisfy as many dependencies as possible.
+ * A {@link PrototypeConstructorInstantiationStrategy} is a {@link InstantiationStrategy} that uses a
+ * {@link ConstructorView} to create a new instance of a class. The constructor is looked up based on
+ * its parameters, where the constructor with the most parameters is chosen in order to satisfy as many
+ * dependencies as possible.
  *
  * <p>If no injectable constructors can be found, the default constructor is used instead. If this
  * constructor is not injectable, an {@link IllegalStateException} is thrown.
@@ -45,7 +46,7 @@ import org.dockbox.hartshorn.util.option.Option;
  *
  * @author Guus Lieben
  */
-public final class SimpleConstructorViewDrivenProvider<C> implements TypeAwareInstantiationStrategy<C> {
+public final class PrototypeConstructorInstantiationStrategy<C> implements TypeAwareInstantiationStrategy<C> {
 
     private final ComponentKey<? extends C> componentKey;
     private final LifecycleType lifecycleType;
@@ -53,33 +54,33 @@ public final class SimpleConstructorViewDrivenProvider<C> implements TypeAwareIn
     private ConstructorView<? extends C> optimalConstructor;
     private boolean lazy = true;
 
-    private SimpleConstructorViewDrivenProvider(ComponentKey<? extends C> type, LifecycleType lifecycleType) {
+    private PrototypeConstructorInstantiationStrategy(ComponentKey<? extends C> type, LifecycleType lifecycleType) {
         this.componentKey = type;
         this.lifecycleType = lifecycleType;
     }
 
     /**
-     * Creates a new {@link SimpleConstructorViewDrivenProvider} for the given type, with a prototype lifecycle.
+     * Creates a new {@link PrototypeConstructorInstantiationStrategy} for the given type, with a prototype lifecycle.
      *
      * @param type the type of the component to create
      * @param <T> the type of the component to create
      *
-     * @return a new {@link SimpleConstructorViewDrivenProvider} for the given type
+     * @return a new {@link PrototypeConstructorInstantiationStrategy} for the given type
      */
-    public static <T> SimpleConstructorViewDrivenProvider<T> forPrototype(ComponentKey<? extends T> type) {
-        return new SimpleConstructorViewDrivenProvider<>(type, LifecycleType.PROTOTYPE);
+    public static <T> PrototypeConstructorInstantiationStrategy<T> forPrototype(ComponentKey<? extends T> type) {
+        return new PrototypeConstructorInstantiationStrategy<>(type, LifecycleType.PROTOTYPE);
     }
 
     /**
-     * Creates a new {@link SimpleConstructorViewDrivenProvider} for the given type, with a singleton lifecycle.
+     * Creates a new {@link PrototypeConstructorInstantiationStrategy} for the given type, with a singleton lifecycle.
      *
      * @param type the type of the component to create
      * @param <T> the type of the component to create
      *
-     * @return a new {@link SimpleConstructorViewDrivenProvider} for the given type
+     * @return a new {@link PrototypeConstructorInstantiationStrategy} for the given type
      */
-    public static <T> SimpleConstructorViewDrivenProvider<T> forSingleton(ComponentKey<? extends T> type) {
-        return new SimpleConstructorViewDrivenProvider<>(type, LifecycleType.SINGLETON);
+    public static <T> PrototypeConstructorInstantiationStrategy<T> forSingleton(ComponentKey<? extends T> type) {
+        return new PrototypeConstructorInstantiationStrategy<>(type, LifecycleType.SINGLETON);
     }
 
     /**
@@ -91,7 +92,7 @@ public final class SimpleConstructorViewDrivenProvider<C> implements TypeAwareIn
      * @param lazy whether the provider should be lazy
      * @return the provider
      */
-    public SimpleConstructorViewDrivenProvider<C> lazy(boolean lazy) {
+    public PrototypeConstructorInstantiationStrategy<C> lazy(boolean lazy) {
         this.lazy = lazy;
         return this;
     }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/provider/strategy/UnboundPrototypeComponentProviderStrategy.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/provider/strategy/UnboundPrototypeComponentProviderStrategy.java
@@ -21,7 +21,7 @@ import org.dockbox.hartshorn.inject.ComponentRequestContext;
 import org.dockbox.hartshorn.inject.ComponentResolutionException;
 import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.ObjectContainer;
-import org.dockbox.hartshorn.inject.provider.SimpleConstructorViewDrivenProvider;
+import org.dockbox.hartshorn.inject.provider.PrototypeConstructorInstantiationStrategy;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.option.Option;
 
@@ -29,7 +29,7 @@ import org.dockbox.hartshorn.util.option.Option;
  * A {@link ComponentProviderStrategy} that attempts to provide a component using a {@link InstantiationStrategy prototype instantiation
  * strategy}. If the strategy is unable to provide an instance, the chain is continued.
  *
- * @see SimpleConstructorViewDrivenProvider#forPrototype(ComponentKey)
+ * @see PrototypeConstructorInstantiationStrategy#forPrototype(ComponentKey)
  *
  * @since 0.7.0
  *
@@ -40,7 +40,7 @@ public class UnboundPrototypeComponentProviderStrategy implements ComponentProvi
     @Override
     public <T> ObjectContainer<T> get(ComponentKey<T> componentKey, ComponentRequestContext requestContext,
             ComponentProviderStrategyChain<T> chain) throws ComponentResolutionException, ApplicationException {
-        InstantiationStrategy<T> strategy = SimpleConstructorViewDrivenProvider.forPrototype(componentKey);
+        InstantiationStrategy<T> strategy = PrototypeConstructorInstantiationStrategy.forPrototype(componentKey);
         Option<ObjectContainer<T>> container = strategy.provide(chain.application(), requestContext);
         if (container.present()) {
             return container.get();

--- a/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/binding/BindingHierarchyTests.java
+++ b/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/binding/BindingHierarchyTests.java
@@ -23,16 +23,13 @@ import org.dockbox.hartshorn.inject.binding.HierarchicalBinder;
 import org.dockbox.hartshorn.inject.binding.NativePrunableBindingHierarchy;
 import org.dockbox.hartshorn.inject.provider.CompositeInstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
-import org.dockbox.hartshorn.inject.provider.SimpleConstructorViewDrivenProvider;
+import org.dockbox.hartshorn.inject.provider.PrototypeConstructorInstantiationStrategy;
 import org.dockbox.hartshorn.util.option.Option;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map.Entry;
 
-// TODO: Make non-integration test
-//@HartshornTest(includeBasePackages = false)
-//@Disabled("Starters are not yet implemented")
 public class BindingHierarchyTests {
 
     private HierarchicalBinder binder() {
@@ -42,9 +39,9 @@ public class BindingHierarchyTests {
     @Test
     void testIteratorIsSorted() {
         BindingHierarchy<Contract> hierarchy = new NativePrunableBindingHierarchy<>(ComponentKey.of(Contract.class));
-        hierarchy.add(0, SimpleConstructorViewDrivenProvider.forSingleton(ComponentKey.of(ImplementationA.class)));
-        hierarchy.add(1, SimpleConstructorViewDrivenProvider.forSingleton(ComponentKey.of(ImplementationB.class)));
-        hierarchy.add(2, SimpleConstructorViewDrivenProvider.forSingleton(ComponentKey.of(ImplementationC.class)));
+        hierarchy.add(0, PrototypeConstructorInstantiationStrategy.forSingleton(ComponentKey.of(ImplementationA.class)));
+        hierarchy.add(1, PrototypeConstructorInstantiationStrategy.forSingleton(ComponentKey.of(ImplementationB.class)));
+        hierarchy.add(2, PrototypeConstructorInstantiationStrategy.forSingleton(ComponentKey.of(ImplementationC.class)));
 
         int next = 2;
         for (Entry<Integer, InstantiationStrategy<Contract>> entry : hierarchy) {
@@ -60,11 +57,11 @@ public class BindingHierarchyTests {
         HierarchicalBinder binder = this.binder();
 
         BindingHierarchy<Contract> secondHierarchy = new NativePrunableBindingHierarchy<>(key);
-        secondHierarchy.add(2, SimpleConstructorViewDrivenProvider.forSingleton(ComponentKey.of(ImplementationC.class)));
+        secondHierarchy.add(2, PrototypeConstructorInstantiationStrategy.forSingleton(ComponentKey.of(ImplementationC.class)));
 
         binder.hierarchy(key)
-                .add(0, SimpleConstructorViewDrivenProvider.forSingleton(ComponentKey.of(ImplementationA.class)))
-                .add(1, SimpleConstructorViewDrivenProvider.forSingleton(ComponentKey.of(ImplementationB.class)))
+                .add(0, PrototypeConstructorInstantiationStrategy.forSingleton(ComponentKey.of(ImplementationA.class)))
+                .add(1, PrototypeConstructorInstantiationStrategy.forSingleton(ComponentKey.of(ImplementationB.class)))
                 .merge(secondHierarchy);
 
         BindingHierarchy<Contract> hierarchy = binder.hierarchy(key);
@@ -74,18 +71,18 @@ public class BindingHierarchyTests {
 
         Option<InstantiationStrategy<Contract>> priorityZero = hierarchy.get(0);
         Assertions.assertTrue(priorityZero.present());
-        Assertions.assertTrue(priorityZero.get() instanceof SimpleConstructorViewDrivenProvider);
-        Assertions.assertSame(((SimpleConstructorViewDrivenProvider<Contract>) priorityZero.get()).type(), ImplementationA.class);
+        Assertions.assertTrue(priorityZero.get() instanceof PrototypeConstructorInstantiationStrategy);
+        Assertions.assertSame(((PrototypeConstructorInstantiationStrategy<Contract>) priorityZero.get()).type(), ImplementationA.class);
 
         Option<InstantiationStrategy<Contract>> priorityOne = hierarchy.get(1);
         Assertions.assertTrue(priorityOne.present());
-        Assertions.assertTrue(priorityOne.get() instanceof SimpleConstructorViewDrivenProvider);
-        Assertions.assertSame(((SimpleConstructorViewDrivenProvider<Contract>) priorityOne.get()).type(), ImplementationB.class);
+        Assertions.assertTrue(priorityOne.get() instanceof PrototypeConstructorInstantiationStrategy);
+        Assertions.assertSame(((PrototypeConstructorInstantiationStrategy<Contract>) priorityOne.get()).type(), ImplementationB.class);
 
         Option<InstantiationStrategy<Contract>> priorityTwo = hierarchy.get(2);
         Assertions.assertTrue(priorityTwo.present());
-        Assertions.assertTrue(priorityTwo.get() instanceof SimpleConstructorViewDrivenProvider);
-        Assertions.assertSame(((SimpleConstructorViewDrivenProvider<Contract>) priorityTwo.get()).type(), ImplementationC.class);
+        Assertions.assertTrue(priorityTwo.get() instanceof PrototypeConstructorInstantiationStrategy);
+        Assertions.assertSame(((PrototypeConstructorInstantiationStrategy<Contract>) priorityTwo.get()).type(), ImplementationC.class);
     }
 
     @Test
@@ -106,8 +103,8 @@ public class BindingHierarchyTests {
             contractStrategy = composite.provider();
         }
 
-        Assertions.assertTrue(contractStrategy instanceof SimpleConstructorViewDrivenProvider);
-        Assertions.assertSame(((SimpleConstructorViewDrivenProvider<LocalContract>) contractStrategy).type(), LocalObject.class);
+        Assertions.assertTrue(contractStrategy instanceof PrototypeConstructorInstantiationStrategy);
+        Assertions.assertSame(((PrototypeConstructorInstantiationStrategy<LocalContract>) contractStrategy).type(), LocalObject.class);
     }
 
     interface LocalContract {


### PR DESCRIPTION
### Type of Change
- [x] Enhancement (non-breaking change that affects existing code)

### Description
Minor change to rename `SimpleConstructorViewDrivenProvider` to align with its parent interface `InstantiationStrategy`

### Checklist
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1136
