### PR TITLE
Update to Java 25 (LTS)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up source JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
       - name: "Build (source JDK)"
         run: mvn clean install -DskipTests -P ci

--- a/.github/workflows/postbuild.docs.yml
+++ b/.github/workflows/postbuild.docs.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up source JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
       - name: Build developer documentation
         run: mvn clean install -DskipTests -P ci,local -Dantora.skip=false -Dantora.playbook=playbook-local.yml

--- a/.github/workflows/postbuild.tests.yml
+++ b/.github/workflows/postbuild.tests.yml
@@ -4,14 +4,14 @@ on: workflow_call
 
 jobs:
   coverage:
-    name: Code coverage (JDK 21, Ubuntu)
+    name: Code coverage (JDK 25, Ubuntu)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up source JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
       - name: Run tests
         id: test
@@ -26,14 +26,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-    name: Unit tests (Compatibility, JDK 21, ${{ matrix.os }})
+    name: Unit tests (Compatibility, JDK 25, ${{ matrix.os }})
     runs-on: "${{ matrix.os }}"
     steps:
       - uses: actions/checkout@v3
       - name: Set up source JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
       - name: "Unit testing (OS: ${{ matrix.os }}, source JDK)"
         # Note that coverage should still be enabled here, as specific instructions may differ per platform

--- a/.github/workflows/prebuild.codestyle.yml
+++ b/.github/workflows/prebuild.codestyle.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
       - name: Check code style
         run: mvn clean verify -DskipTests -P ci -Dcheckstyle.skip=false -Derrorprone.skip=false

--- a/.github/workflows/prebuild.dependency.yml
+++ b/.github/workflows/prebuild.dependency.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
       - name: Prepare for dependency check
         run: mvn clean install -DskipTests -P ci

--- a/.github/workflows/prebuild.license.yml
+++ b/.github/workflows/prebuild.license.yml
@@ -11,10 +11,10 @@ jobs:
         with:
           # We need the full history to check the year on license headers
           fetch-depth: 0
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
       - name: Check license headers
         run: mvn clean verify -DskipTests -P ci -Dlicense-check.skip=false

--- a/hartshorn-assembly/pom.assembly.xml
+++ b/hartshorn-assembly/pom.assembly.xml
@@ -32,7 +32,7 @@
     <!-- Antora playbook for documentation build. Set to playbook-local.yml for local builds -->
     <antora.playbook>playbook-release.yml</antora.playbook>
 
-    <plugin.jacoco.version>0.8.12</plugin.jacoco.version>
+    <plugin.jacoco.version>0.8.14</plugin.jacoco.version>
   </properties>
 
   <profiles>

--- a/hartshorn-assembly/pom.platform.build.xml
+++ b/hartshorn-assembly/pom.platform.build.xml
@@ -19,23 +19,22 @@
 
     <!-- Project properties, inherited by all submodules -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
 
     <!-- Language versions, also inherited by BOM -->
-    <groovy.version>4.0.18</groovy.version>
-    <kotlin.version>2.0.0</kotlin.version>
-    <scala.version>3.3.1</scala.version>
+    <groovy.version>5.0.3</groovy.version>
+    <kotlin.version>2.3.0</kotlin.version>
+    <scala.version>3.3.7</scala.version>
 
     <!-- Maven plugin versions, in alphabetical order -->
-    <plugin.buildhelper.version>3.6.0</plugin.buildhelper.version>
-    <plugin.compiler.version>3.13.0</plugin.compiler.version>
-    <plugin.gmaven.version>3.0.2</plugin.gmaven.version>
-    <plugin.groovy.version>2.1.1</plugin.groovy.version>
-    <plugin.jar.version>3.4.2</plugin.jar.version>
-    <plugin.javadoc.version>3.8.0</plugin.javadoc.version>
+    <plugin.buildhelper.version>3.6.1</plugin.buildhelper.version>
+    <plugin.compiler.version>3.14.1</plugin.compiler.version>
+    <plugin.gmaven.version>4.2.1</plugin.gmaven.version>
+    <plugin.jar.version>3.5.0</plugin.jar.version>
+    <plugin.javadoc.version>3.12.0</plugin.javadoc.version>
     <plugin.kotlin.version>${kotlin.version}</plugin.kotlin.version>
-    <plugin.scala.version>4.9.2</plugin.scala.version>
-    <plugin.openrewrite.version>5.42.0</plugin.openrewrite.version>
+    <plugin.scala.version>4.9.8</plugin.scala.version>
+    <plugin.openrewrite.version>6.26.0</plugin.openrewrite.version>
   </properties>
 
   <profiles>
@@ -203,6 +202,9 @@
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
+        <configuration>
+          <targetBytecode>25</targetBytecode>
+        </configuration>
         <executions>
           <execution>
             <id>compile</id>

--- a/hartshorn-assembly/pom.platform.support.xml
+++ b/hartshorn-assembly/pom.platform.support.xml
@@ -279,7 +279,6 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>${kotlin.version}</version>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/hartshorn-assembly/pom.platform.support.xml
+++ b/hartshorn-assembly/pom.platform.support.xml
@@ -264,12 +264,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/hartshorn-assembly/pom.platform.updates.xml
+++ b/hartshorn-assembly/pom.platform.updates.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <updates.skip>false</updates.skip>
-    <plugin.versions.version>2.19.1</plugin.versions.version>
+    <plugin.versions.version>2.20.1</plugin.versions.version>
   </properties>
 
   <build>
@@ -40,8 +40,7 @@
         <artifactId>versions-maven-plugin</artifactId>
         <configuration>
           <skip>${updates.skip}</skip>
-          <ignoredVersions>.*[-_\.](alpha|Alpha|ALPHA|b|beta|Beta|BETA|rc|RC|M|MR|EA)[-_\.]?[0-9]*
-          </ignoredVersions>
+          <ignoredVersions>.*[-_\.](alpha|Alpha|ALPHA|b|beta|Beta|BETA|rc|RC|M|MR|EA)[-_\.]?[0-9]*</ignoredVersions>
           <generateBackupPoms>false</generateBackupPoms>
 
           <!--

--- a/hartshorn-assembly/pom.platform.updates.xml
+++ b/hartshorn-assembly/pom.platform.updates.xml
@@ -45,8 +45,8 @@
           <generateBackupPoms>false</generateBackupPoms>
 
           <!--
-          Exclude Kotlin plugin version from being updated, as this should always reference the kotlin.version property
-          instead of being directly updated by the versions plugin.
+           Exclude Kotlin plugin version from being updated, as this should always reference the
+           kotlin.version property instead of being directly updated by the versions plugin.
           -->
           <excludeProperties>plugin.kotlin.version</excludeProperties>
         </configuration>

--- a/hartshorn-bom/pom.xml
+++ b/hartshorn-bom/pom.xml
@@ -142,6 +142,11 @@
         <type>pom</type>
       </dependency>
       <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
         <groupId>jakarta.annotation</groupId>
         <artifactId>jakarta.annotation-api</artifactId>
         <version>${jakarta.annotations.version}</version>

--- a/hartshorn-bom/pom.xml
+++ b/hartshorn-bom/pom.xml
@@ -20,27 +20,19 @@
 
   <properties>
     <!-- Versions in alphabetical order -->
-    <assertj.version>3.27.2</assertj.version>
-    <compile-testing.version>0.21.0</compile-testing.version>
     <checker.version>3.45.0</checker.version>
-    <hamcrest.version>3.0</hamcrest.version>
-    <jackson.version>2.17.2</jackson.version>
-    <jakarta.annotations.version>3.0.0</jakarta.annotations.version>
-    <checker.version>3.48.4</checker.version>
-    <hamcrest.version>3.0</hamcrest.version>
-    <jackson.version>2.18.2</jackson.version>
+    <assertj.version>3.27.6</assertj.version>
+    <compile-testing.version>0.23.0</compile-testing.version>
+    <jackson.version>3.0.3</jackson.version>
     <jakarta.annotations.version>3.0.0</jakarta.annotations.version>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <javassist.version>3.30.2-GA</javassist.version>
     <javax.inject.version>1</javax.inject.version>
     <javax.annotations.version>1.3.2</javax.annotations.version>
-    <junit.version>5.10.3</junit.version>
-    <logback.version>1.5.15</logback.version>
-    <mockito.version>5.12.0</mockito.version>
-    <junit.version>5.11.4</junit.version>
-    <logback.version>1.5.15</logback.version>
-    <mockito.version>5.15.2</mockito.version>
-    <slf4j.version>2.0.16</slf4j.version>
+    <junit.version>6.0.1</junit.version>
+    <logback.version>1.5.22</logback.version>
+    <mockito.version>5.21.0</mockito.version>
+    <slf4j.version>2.0.17</slf4j.version>
   </properties>
 
   <dependencyManagement>
@@ -191,39 +183,33 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-core</artifactId>
-        <version>${hamcrest.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
+        <groupId>tools.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <groupId>tools.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-properties</artifactId>
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <groupId>tools.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-toml</artifactId>
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <groupId>tools.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-xml</artifactId>
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <groupId>tools.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
         <version>${jackson.version}</version>
       </dependency>

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/ClassCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/ClassCondition.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.inject.condition.support;
 import org.dockbox.hartshorn.inject.condition.Condition;
 import org.dockbox.hartshorn.inject.condition.ConditionContext;
 import org.dockbox.hartshorn.inject.condition.ConditionResult;
+import org.dockbox.hartshorn.util.types.TypeUtils;
 
 /**
  * A condition that matches when a class is present on the classpath. Due to the nature of this
@@ -37,10 +38,7 @@ public class ClassCondition implements Condition {
     public ConditionResult matches(ConditionContext context) {
         return context.annotatedElement().annotations().get(RequiresClass.class).map(condition -> {
             for (String name : condition.value()) {
-                try {
-                    Class.forName(name);
-                }
-                catch (ClassNotFoundException e) {
+                if (!TypeUtils.exists(name)) {
                     return ConditionResult.notFound("class", name);
                 }
             }

--- a/hartshorn-inject/pom.xml
+++ b/hartshorn-inject/pom.xml
@@ -56,6 +56,12 @@
       <artifactId>groovy-all</artifactId>
       <type>pom</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>groovy-test-junit5</artifactId>
+          <groupId>org.apache.groovy</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/hartshorn-integration-tests/pom.xml
+++ b/hartshorn-integration-tests/pom.xml
@@ -90,6 +90,7 @@
               <goal>compileTests</goal>
             </goals>
             <configuration>
+              <targetBytecode>25</targetBytecode>
               <testSources>
                 <testSource>
                   <directory>${project.basedir}/src/integration-test/groovy</directory>

--- a/hartshorn-integration-tests/pom.xml
+++ b/hartshorn-integration-tests/pom.xml
@@ -39,6 +39,12 @@
       <artifactId>groovy-all</artifactId>
       <type>pom</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>groovy-test-junit5</artifactId>
+          <groupId>org.apache.groovy</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- API Compatibility -->

--- a/hartshorn-integration-tests/pom.xml
+++ b/hartshorn-integration-tests/pom.xml
@@ -68,6 +68,21 @@
       <artifactId>javax.annotation-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>tools.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>tools.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-properties</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/collection/CollectionScopeTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/collection/CollectionScopeTests.java
@@ -16,9 +16,11 @@
 
 package test.org.dockbox.hartshorn.inject.collection;
 
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.annotations.Inject;
-import org.dockbox.hartshorn.inject.binding.Binder;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
 import org.dockbox.hartshorn.inject.collection.CollectionBindingHierarchy;
 import org.dockbox.hartshorn.inject.collection.CollectionInstantiationStrategy;
@@ -32,10 +34,6 @@ import org.dockbox.hartshorn.util.option.Option;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class CollectionScopeTests {
@@ -115,7 +113,7 @@ public class CollectionScopeTests {
     @TestComponents(ComponentWithCollectionDependencies.class)
     void testComponentInjectionWithExplicitCollection() {
         ComponentKey<Integer> ageKey = ComponentKey.of(Integer.class, "ages");
-        Binder collect = this.applicationContext.bind(ageKey).collect(collector -> {
+        this.applicationContext.bind(ageKey).collect(collector -> {
             collector.singleton(1);
             collector.singleton(2);
         });

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/observer/LifecycleObserverTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/observer/LifecycleObserverTests.java
@@ -28,6 +28,7 @@ import org.dockbox.hartshorn.launchpad.lifecycle.LifecycleObservable;
 import org.dockbox.hartshorn.launchpad.lifecycle.LifecycleObserver;
 import org.dockbox.hartshorn.launchpad.lifecycle.ObservableApplicationEnvironment;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
+import org.dockbox.hartshorn.test.annotations.TestProperties;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.stream.CollectorUtilities;
 import org.junit.jupiter.api.Assertions;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 @TestComponents(LifecycleObserverTests.ObserverConfiguration.class)
+@TestProperties("hartshorn.container.close.reentry-policy=IGNORE")
 public class LifecycleObserverTests {
 
     @Configuration

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/classpath/ClassPathScanner.java
@@ -382,7 +382,7 @@ public final class ClassPathScanner {
      * @return The scanner instance
      */
     public synchronized ClassPathScanner filterPrefix(String prefix) {
-        if (prefix != null) {
+        if (prefix != null && !prefix.trim().isEmpty()) {
             this.prefixFilters.add(prefix);
         }
         return this;

--- a/hartshorn-launchpad-samples/basic-hello-world-kotlin/pom.xml
+++ b/hartshorn-launchpad-samples/basic-hello-world-kotlin/pom.xml
@@ -23,7 +23,6 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>2.1.21</version>
     </dependency>
   </dependencies>
 
@@ -48,7 +47,7 @@
           </execution>
         </executions>
         <groupId>org.jetbrains.kotlin</groupId>
-        <version>2.1.21</version>
+        <version>2.3.0</version>
       </plugin>
     </plugins>
   </build>

--- a/hartshorn-launchpad-starter/pom.xml
+++ b/hartshorn-launchpad-starter/pom.xml
@@ -55,12 +55,12 @@
 
     <!-- Default supported property formats -->
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-properties</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <optional>true</optional>
     </dependency>

--- a/hartshorn-launchpad-starter/pom.xml
+++ b/hartshorn-launchpad-starter/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <revision>0.7.0</revision>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <hartshorn.version>${project.version}</hartshorn.version>
   </properties>
 

--- a/hartshorn-launchpad/pom.xml
+++ b/hartshorn-launchpad/pom.xml
@@ -20,7 +20,7 @@
     TODO: Remove once coverage target of 80% is reached.
      In meantime, increase coverage target whenever possible (to avoid regression).
     -->
-    <coverage.target>73%</coverage.target>
+    <coverage.target>71%</coverage.target>
   </properties>
 
   <dependencies>
@@ -64,16 +64,6 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>tools.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>tools.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-properties</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hartshorn-launchpad/pom.xml
+++ b/hartshorn-launchpad/pom.xml
@@ -67,7 +67,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <scope>test</scope>
     </dependency>

--- a/hartshorn-launchpad/pom.xml
+++ b/hartshorn-launchpad/pom.xml
@@ -71,5 +71,10 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>tools.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-properties</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/ApplicationReentryPolicy.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/ApplicationReentryPolicy.java
@@ -1,0 +1,19 @@
+package org.dockbox.hartshorn.launchpad;
+
+/**
+ * Behavior policies for re-entry of a closed {@link ApplicationContext}.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
+public enum ApplicationReentryPolicy {
+    /**
+     * Ignore re-entry, and do not take further action (including the requested operation).
+     */
+    IGNORE,
+    /**
+     * Fail on re-entry, throwing a {@link ContextClosedException}.
+     */
+    FAIL,
+}

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/DelegatingApplicationContext.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/DelegatingApplicationContext.java
@@ -246,7 +246,19 @@ public abstract class DelegatingApplicationContext
     @Override
     public void close() {
         if (this.isClosed()) {
-            throw new ContextClosedException(ApplicationContext.class);
+            ApplicationReentryPolicy reentryPolicy = this.environment().propertyRegistry()
+                    .value("hartshorn.container.close.reentry-policy")
+                    .map(ApplicationReentryPolicy::valueOf)
+                    .orElse(ApplicationReentryPolicy.FAIL);
+            switch (reentryPolicy) {
+                case IGNORE -> {
+                    return;
+                }
+                case FAIL -> throw new ContextClosedException(ApplicationContext.class);
+                case null, default -> {
+                    assert false : "Unsupported reentry policy: " + reentryPolicy;
+                }
+            }
         }
         ApplicationEnvironment environment = this.environment();
         if (environment instanceof ObservableApplicationEnvironment observable) {

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/environment/ConfigurableApplicationEnvironment.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/environment/ConfigurableApplicationEnvironment.java
@@ -184,13 +184,9 @@ public final class ConfigurableApplicationEnvironment
         );
 
         Class<?> mainClass = bootstrapContext.mainClass();
-        // Potentially started from an unnamed class, in which case there will be no constructors.
-        // In such scenarios we do not support the main 'class' as an application component.
-        if (mainClass.getConstructors().length > 0) {
-            TypeView<?> mainType = this.introspector().introspect(mainClass);
-            this.componentRegistry()
-                .addCustomContainer(new ApplicationMainComponentContainer<>(mainType));
-        }
+        TypeView<?> mainType = this.introspector().introspect(mainClass);
+        this.componentRegistry()
+            .addCustomContainer(new ApplicationMainComponentContainer<>(mainType));
 
         this.resourceLookup = this.configure(
             environmentInitializerContext,

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/launch/StandardApplicationBuilder.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/launch/StandardApplicationBuilder.java
@@ -110,9 +110,13 @@ public final class StandardApplicationBuilder implements ApplicationBuilder<Appl
         }
 
         Class<?> mainClass = configurer.mainClass.initialize();
-        if (!this.isValidActivator(mainClass)) {
+        String violation = this.getActivatorClassViolation(mainClass);
+        if (violation != null) {
             throw new InvalidActivationSourceException(
-                "Main class (%s) must be a valid activator".formatted(mainClass.getName())
+                "Main class (%s) is not a valid activator: %s".formatted(
+                    mainClass.getName(),
+                    violation
+                )
             );
         }
 
@@ -139,31 +143,33 @@ public final class StandardApplicationBuilder implements ApplicationBuilder<Appl
      *
      * @param mainClass The class to validate.
      *
-     * @return {@code true} if the provided class is a valid activator, {@code false} otherwise.
+     * @return a message describing the violation, or <code>null</code> if the class is a valid
+     * activator.
      *
      * @see #RESERVED_PACKAGES
      */
-    private boolean isValidActivator(Class<?> mainClass) {
+    private String getActivatorClassViolation(Class<?> mainClass) {
         boolean isConcrete = !(mainClass.isPrimitive()
             || Modifier.isAbstract(mainClass.getModifiers())
             || mainClass.isInterface()
             || mainClass.isArray());
         if (!isConcrete) {
-            return false;
+            return "Main class must be a concrete class.";
         }
 
         if (mainClass.isLocalClass() || mainClass.isMemberClass()) {
-            return false;
+            return "Main class must not be a local or member class.";
         }
 
         String packageName = mainClass.getPackageName();
         for (String reservedPackage : RESERVED_PACKAGES) {
             if (packageName.startsWith(reservedPackage)) {
-                return false;
+                return "Main class must not be part of reserved package '%s'."
+                    .formatted(reservedPackage);
             }
         }
 
-        return true;
+        return null;
     }
 
     @Override
@@ -354,7 +360,7 @@ public final class StandardApplicationBuilder implements ApplicationBuilder<Appl
          *
          * @return This {@link Configurer} instance.
          *
-         * @see #isValidActivator(Class)
+         * @see #getActivatorClassViolation(Class)
          */
         public Configurer mainClass(Class<?> mainClass) {
             return this.mainClass(Initializer.of(mainClass));

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/launch/StandardApplicationContextFactory.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/launch/StandardApplicationContextFactory.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.launchpad.launch;
 
+import java.util.function.Predicate;
 import org.dockbox.hartshorn.context.SingleElementContext;
 import org.dockbox.hartshorn.inject.binding.DefaultBindingConfigurer;
 import org.dockbox.hartshorn.inject.binding.DefaultBindingConfigurerContext;
@@ -261,6 +262,7 @@ public class StandardApplicationContextFactory implements ApplicationContextFact
     ) {
         Set<String> prefixes = this.collectPrefixesForRegistering(bootstrapContext, activators);
         prefixes.stream()
+            .filter(Predicate.not(String::isEmpty))
             .map(ClassPathScannerTypeReferenceCollector::new)
             .forEach(collectorContext::register);
 
@@ -288,8 +290,9 @@ public class StandardApplicationContextFactory implements ApplicationContextFact
         Set<Annotation> activators
     ) {
         Set<String> prefixes = new HashSet<>();
-        prefixes.addAll(this.configurer.scanPackages.initialize(this.initializerContext.transform(
-            bootstrapContext)));
+        prefixes.addAll(this.configurer.scanPackages.initialize(
+            this.initializerContext.transform(bootstrapContext)
+        ));
 
         // Application may prefer to use alternative packages for scanning. This is configured by
         // the application bootstrap context.

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/properties/EnvironmentProfilesPropertyRegistryFactory.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/properties/EnvironmentProfilesPropertyRegistryFactory.java
@@ -35,11 +35,10 @@ import org.dockbox.hartshorn.properties.ConfiguredProperty;
 import org.dockbox.hartshorn.properties.MapPropertyRegistry;
 import org.dockbox.hartshorn.properties.PropertyRegistry;
 import org.dockbox.hartshorn.properties.SingleConfiguredProperty;
+import org.dockbox.hartshorn.properties.loader.FilePropertyRegistryLoader;
 import org.dockbox.hartshorn.properties.loader.PredicatePropertyRegistryLoader;
 import org.dockbox.hartshorn.properties.loader.PropertyRegistryPathLoader;
 import org.dockbox.hartshorn.properties.loader.support.CompositePredicatePropertyRegistryLoader;
-import org.dockbox.hartshorn.properties.loader.support.JacksonJavaPropsPropertyRegistryLoader;
-import org.dockbox.hartshorn.properties.loader.support.JacksonYamlPropertyRegistryLoader;
 import org.dockbox.hartshorn.spi.DiscoveryService;
 import org.dockbox.hartshorn.spi.ServiceDiscoveryException;
 import org.dockbox.hartshorn.util.ApplicationRuntimeException;
@@ -176,8 +175,8 @@ public class EnvironmentProfilesPropertyRegistryFactory implements PropertyRegis
     private Set<PropertyRegistryPathLoader> resolveRegistryLoaders() {
         Set<PropertyRegistryPathLoader> propertyRegistryLoaders;
         try {
-            propertyRegistryLoaders =
-                DiscoveryService.instance().discoverAll(PropertyRegistryPathLoader.class);
+            propertyRegistryLoaders = DiscoveryService.instance()
+                    .discoverAll(PropertyRegistryPathLoader.class);
         }
         catch (ServiceDiscoveryException e) {
             throw new ComponentInitializationException(
@@ -266,21 +265,39 @@ public class EnvironmentProfilesPropertyRegistryFactory implements PropertyRegis
      * @return a set of possible sources
      */
     protected static SequencedSet<String> getSources(String name) {
+        Set<PropertyRegistryPathLoader> loaders = getActivePathLoaders();
+        Set<String> extensions = loaders.stream()
+                .filter(FilePropertyRegistryLoader.class::isInstance)
+                .map(FilePropertyRegistryLoader.class::cast)
+                .flatMap(loader -> loader.supportedExtensions().stream())
+                .collect(Collectors.toSet());
+
+        if (extensions.isEmpty()) {
+            return new LinkedHashSet<>();
+        }
         return new LinkedHashSet<>(StringUtilities.matrix()
             .segment(FileSystemLookupStrategy.NAME, ClassPathResourceLookupStrategy.NAME)
             .segment(StrategyResourceLookup.STRATEGY_SEPARATOR)
             .segment(name)
             .segment(".")
-            .segment(CollectionUtilities.merge(
-                // TODO: Make conditional on class presence. If dataformat-yaml is absent, this
-                //  will fail at runtime.
-                JacksonYamlPropertyRegistryLoader.DEFAULT_EXTENSIONS,
-                // TODO: Make conditional on class presence. If dataformat-javaprops is absent,
-                //  this will fail at runtime.
-                JacksonJavaPropsPropertyRegistryLoader.DEFAULT_EXTENSIONS
-            ))
+            .segment(extensions)
             .build()
         );
+    }
+
+    /**
+     * Attempts to load available {@link PropertyRegistryPathLoader} from the discovery service. If
+     * discovery fails for any reason whatsoever, an empty {@link Set} is returned instead.
+     *
+     * @return available {@link PropertyRegistryPathLoader}, or an empty {@link Set}.
+     */
+    protected static Set<PropertyRegistryPathLoader> getActivePathLoaders() {
+        try {
+            return DiscoveryService.instance()
+                    .discoverAll(PropertyRegistryPathLoader.class);
+        } catch (ServiceDiscoveryException e) {
+            return Set.of();
+        }
     }
 
     /**

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/properties/EnvironmentProfilesPropertyRegistryFactory.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/properties/EnvironmentProfilesPropertyRegistryFactory.java
@@ -272,7 +272,11 @@ public class EnvironmentProfilesPropertyRegistryFactory implements PropertyRegis
             .segment(name)
             .segment(".")
             .segment(CollectionUtilities.merge(
+                // TODO: Make conditional on class presence. If dataformat-yaml is absent, this
+                //  will fail at runtime.
                 JacksonYamlPropertyRegistryLoader.DEFAULT_EXTENSIONS,
+                // TODO: Make conditional on class presence. If dataformat-javaprops is absent,
+                //  this will fail at runtime.
                 JacksonJavaPropsPropertyRegistryLoader.DEFAULT_EXTENSIONS
             ))
             .build()

--- a/hartshorn-profiles/pom.xml
+++ b/hartshorn-profiles/pom.xml
@@ -34,17 +34,17 @@
       <artifactId>hartshorn-introspect</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-properties</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <scope>test</scope>
     </dependency>

--- a/hartshorn-properties/pom.xml
+++ b/hartshorn-properties/pom.xml
@@ -30,17 +30,17 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+          <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-properties</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <optional>true</optional>
         </dependency>

--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/FilePropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/FilePropertyRegistryLoader.java
@@ -1,0 +1,23 @@
+package org.dockbox.hartshorn.properties.loader;
+
+import java.util.Set;
+
+/**
+ * {@link PropertyRegistryPathLoader} that loads properties from a {@link java.io.File} or
+ * equivalent type which represents a file on the filesystem, and is therefore aware of
+ * supported file extensions.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
+public interface FilePropertyRegistryLoader extends PropertyRegistryPathLoader {
+
+    /**
+     * Returns a set of file extensions that this loader supports. The file extension of the file
+     * that is being loaded must be one of the extensions in this set.
+     *
+     * @return a set of file extensions that this loader supports
+     */
+    Set<String> supportedExtensions();
+}

--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonJavaPropsPropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonJavaPropsPropertyRegistryLoader.java
@@ -16,12 +16,13 @@
 
 package org.dockbox.hartshorn.properties.loader.support;
 
-import java.util.Set;
 import org.dockbox.hartshorn.properties.loader.StylePropertyPathFormatter;
 import org.dockbox.hartshorn.properties.loader.path.PropertyPathFormatter;
 import org.dockbox.hartshorn.util.configure.Customizer;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.dataformat.javaprop.JavaPropsMapper;
+
+import java.util.Set;
 
 /**
  * A {@link JacksonPropertyRegistryLoader} that loads properties from Java properties files. This
@@ -60,7 +61,7 @@ public class JacksonJavaPropsPropertyRegistryLoader extends JacksonPropertyRegis
     }
 
     @Override
-    protected Set<String> supportedExtensions() {
+    public Set<String> supportedExtensions() {
         return DEFAULT_EXTENSIONS;
     }
 }

--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonJavaPropsPropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonJavaPropsPropertyRegistryLoader.java
@@ -16,14 +16,12 @@
 
 package org.dockbox.hartshorn.properties.loader.support;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper;
-
+import java.util.Set;
 import org.dockbox.hartshorn.properties.loader.StylePropertyPathFormatter;
 import org.dockbox.hartshorn.properties.loader.path.PropertyPathFormatter;
 import org.dockbox.hartshorn.util.configure.Customizer;
-
-import java.util.Set;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.javaprop.JavaPropsMapper;
 
 /**
  * A {@link JacksonPropertyRegistryLoader} that loads properties from Java properties files. This

--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonPropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonPropertyRegistryLoader.java
@@ -16,11 +16,11 @@
 
 package org.dockbox.hartshorn.properties.loader.support;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.ValueNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ValueNode;
 import org.dockbox.hartshorn.properties.ConfiguredProperty;
 import org.dockbox.hartshorn.properties.PropertyRegistry;
 import org.dockbox.hartshorn.properties.SingleConfiguredProperty;
@@ -183,7 +183,7 @@ public abstract class JacksonPropertyRegistryLoader implements PredicateProperty
         ObjectNode objectNode
     ) {
         List<ConfiguredProperty> properties = new ArrayList<>();
-        EntryStream.of(CollectionUtilities.iterableOf(objectNode.fields()))
+        EntryStream.of(objectNode.properties())
             .forEach((name, value) -> {
                 PropertyPathNode nextPath = path.property(name);
                 properties.addAll(this.loadProperties(nextPath, value));
@@ -202,7 +202,7 @@ public abstract class JacksonPropertyRegistryLoader implements PredicateProperty
      * @throws IOException if an error occurs while reading the file
      */
     protected JsonNode loadGraph(URI path) throws IOException {
-        return this.objectMapper().readTree(path.toURL());
+        return this.objectMapper().readTree(path.toURL().openStream());
     }
 
     /**

--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonPropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonPropertyRegistryLoader.java
@@ -16,14 +16,10 @@
 
 package org.dockbox.hartshorn.properties.loader.support;
 
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.node.ArrayNode;
-import tools.jackson.databind.node.ObjectNode;
-import tools.jackson.databind.node.ValueNode;
 import org.dockbox.hartshorn.properties.ConfiguredProperty;
 import org.dockbox.hartshorn.properties.PropertyRegistry;
 import org.dockbox.hartshorn.properties.SingleConfiguredProperty;
+import org.dockbox.hartshorn.properties.loader.FilePropertyRegistryLoader;
 import org.dockbox.hartshorn.properties.loader.PredicatePropertyRegistryLoader;
 import org.dockbox.hartshorn.properties.loader.path.PropertyPathFormatter;
 import org.dockbox.hartshorn.properties.loader.path.PropertyPathNode;
@@ -31,12 +27,16 @@ import org.dockbox.hartshorn.properties.loader.path.PropertyRootPathNode;
 import org.dockbox.hartshorn.util.IOUtilities;
 import org.dockbox.hartshorn.util.collections.CollectionUtilities;
 import org.dockbox.hartshorn.util.stream.EntryStream;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ValueNode;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 /**
  * A {@link PredicatePropertyRegistryLoader} that loads properties using a Jackson
@@ -50,7 +50,8 @@ import java.util.Set;
  * 
  * @author Guus Lieben
  */
-public abstract class JacksonPropertyRegistryLoader implements PredicatePropertyRegistryLoader {
+public abstract class JacksonPropertyRegistryLoader
+        implements PredicatePropertyRegistryLoader, FilePropertyRegistryLoader {
 
     private final PropertyPathFormatter formatter;
     private ObjectMapper objectMapper;
@@ -218,14 +219,6 @@ public abstract class JacksonPropertyRegistryLoader implements PredicateProperty
         }
         return this.objectMapper;
     }
-
-    /**
-     * Returns a set of file extensions that this loader supports. The file extension of the file
-     * that is being loaded must be one of the extensions in this set.
-     *
-     * @return a set of file extensions that this loader supports
-     */
-    protected abstract Set<String> supportedExtensions();
 
     @Override
     public boolean isCompatible(URI path) {

--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonYamlPropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonYamlPropertyRegistryLoader.java
@@ -16,11 +16,11 @@
 
 package org.dockbox.hartshorn.properties.loader.support;
 
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.dataformat.yaml.YAMLMapper;
 import org.dockbox.hartshorn.properties.loader.StylePropertyPathFormatter;
 import org.dockbox.hartshorn.properties.loader.path.PropertyPathFormatter;
 import org.dockbox.hartshorn.util.configure.Customizer;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import java.util.Set;
 
@@ -46,8 +46,8 @@ public class JacksonYamlPropertyRegistryLoader extends JacksonPropertyRegistryLo
     }
 
     public JacksonYamlPropertyRegistryLoader(
-        PropertyPathFormatter formatter,
-        Customizer<YAMLMapper.Builder> customizer
+            PropertyPathFormatter formatter,
+            Customizer<YAMLMapper.Builder> customizer
     ) {
         super(formatter);
         this.customizer = customizer;
@@ -61,7 +61,7 @@ public class JacksonYamlPropertyRegistryLoader extends JacksonPropertyRegistryLo
     }
 
     @Override
-    protected Set<String> supportedExtensions() {
+    public Set<String> supportedExtensions() {
         return DEFAULT_EXTENSIONS;
     }
 }

--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonYamlPropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonYamlPropertyRegistryLoader.java
@@ -16,8 +16,8 @@
 
 package org.dockbox.hartshorn.properties.loader.support;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 import org.dockbox.hartshorn.properties.loader.StylePropertyPathFormatter;
 import org.dockbox.hartshorn.properties.loader.path.PropertyPathFormatter;
 import org.dockbox.hartshorn.util.configure.Customizer;

--- a/hartshorn-reporting/pom.xml
+++ b/hartshorn-reporting/pom.xml
@@ -22,11 +22,11 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
     </dependency>
 

--- a/hartshorn-reporting/pom.xml
+++ b/hartshorn-reporting/pom.xml
@@ -28,6 +28,7 @@
     <dependency>
       <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -44,6 +45,15 @@
       <artifactId>hartshorn-proxy-javassist</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>tools.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>tools.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-properties</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/hartshorn-reporting/pom.xml
+++ b/hartshorn-reporting/pom.xml
@@ -45,15 +45,5 @@
       <artifactId>hartshorn-proxy-javassist</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>tools.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>tools.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-properties</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/serialize/NodeToJacksonVisitor.java
+++ b/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/serialize/NodeToJacksonVisitor.java
@@ -24,9 +24,9 @@ import org.dockbox.hartshorn.util.properties.GroupNode;
 import org.dockbox.hartshorn.util.properties.Node;
 import org.dockbox.hartshorn.util.properties.NodeVisitor;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * A {@link NodeVisitor} which converts a {@link Node} to a {@link JsonNode}. This is useful for

--- a/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/serialize/ObjectMapperReportSerializer.java
+++ b/hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/serialize/ObjectMapperReportSerializer.java
@@ -16,11 +16,11 @@
 
 package org.dockbox.hartshorn.reporting.serialize;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.xml.XmlMapper;
 import org.dockbox.hartshorn.reporting.DiagnosticsReport;
 import org.dockbox.hartshorn.reporting.ReportSerializationException;
 import org.dockbox.hartshorn.reporting.ReportSerializer;
@@ -46,7 +46,7 @@ public abstract class ObjectMapperReportSerializer implements ReportSerializer<S
             return this.objectMapper()
                     .writerWithDefaultPrettyPrinter()
                     .writeValueAsString(node);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new ReportSerializationException(e);
         }
     }

--- a/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/collections/CollectionUtilities.java
+++ b/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/collections/CollectionUtilities.java
@@ -282,6 +282,22 @@ public final class CollectionUtilities {
     }
 
     /**
+     * Iterates over the given iterable and applies the given consumer to each element. A counter
+     * is used to keep track of the index of the element in the iterable. The counter starts at 0
+     * and is incremented for each element in the iterable.
+     *
+     * @param iterable The iterable to iterate over
+     * @param consumer The consumer to apply to each element
+     * @param <T> The type of the elements in the iterable
+     */
+    public static <T> void indexed(Iterable<T> iterable, BiConsumer<Integer, T> consumer) {
+        int index = 0;
+        for (T element : iterable) {
+            consumer.accept(index++, element);
+        }
+    }
+
+    /**
      * Returns an {@link Iterable} that wraps the given {@link Iterator}, to allow the iterator to
      * be used in e.g. for-each loops.
      *

--- a/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/TypeUtils.java
+++ b/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/TypeUtils.java
@@ -565,4 +565,19 @@ public class TypeUtils {
         }
         return getRootCause(cause);
     }
+
+    /**
+     * Returns whether a class with the given name is available on the current classpath.
+     *
+     * @param className the fully qualified name of the class, e.g. {@code java.lang.String}
+     * @return {@code true} if the class exists, or else {@code false}
+     */
+    public static boolean exists(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
 }

--- a/hartshorn-spi/src/main/java/org/dockbox/hartshorn/spi/DiscoveryService.java
+++ b/hartshorn-spi/src/main/java/org/dockbox/hartshorn/spi/DiscoveryService.java
@@ -292,11 +292,10 @@ public final class DiscoveryService {
     private <T> Set<T> tryLoadFromSPI(Class<T> type) throws NoAvailableImplementationException {
         for (ClassLoader classLoader : this.classLoaders) {
             ServiceLoader<T> serviceLoader = this.getServiceLoader(type, classLoader);
-            Set<? extends ServiceLoader.Provider<T>> providers =
-                serviceLoader.stream().collect(Collectors.toSet());
-            return providers.stream()
-                .map(ServiceLoader.Provider::get)
-                .collect(Collectors.toSet());
+            return serviceLoader
+                    .stream()
+                    .map(ServiceLoader.Provider::get)
+                    .collect(Collectors.toSet());
         }
         throw new NoAvailableImplementationException("No implementation found for type "
             + type.getName());

--- a/hartshorn-spi/src/main/java/org/dockbox/hartshorn/spi/DiscoveryService.java
+++ b/hartshorn-spi/src/main/java/org/dockbox/hartshorn/spi/DiscoveryService.java
@@ -25,11 +25,11 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * A service that allows for the discovery of implementations of a given type. This service is a
@@ -290,15 +290,23 @@ public final class DiscoveryService {
     }
 
     private <T> Set<T> tryLoadFromSPI(Class<T> type) throws NoAvailableImplementationException {
+        Set<T> instances = new HashSet<>();
         for (ClassLoader classLoader : this.classLoaders) {
             ServiceLoader<T> serviceLoader = this.getServiceLoader(type, classLoader);
-            return serviceLoader
-                    .stream()
-                    .map(ServiceLoader.Provider::get)
-                    .collect(Collectors.toSet());
+            Iterator<T> it = serviceLoader.iterator();
+            while (true) {
+                try {
+                    if (!it.hasNext()) {
+                        break;
+                    }
+                    instances.add(it.next());
+                } catch (NoClassDefFoundError ignored) {
+                    // Ignored, class is either not compatible, or is missing dependencies. In both
+                    // cases we don't want to make further attempts to load it further.
+                }
+            }
         }
-        throw new NoAvailableImplementationException("No implementation found for type "
-            + type.getName());
+        return instances;
     }
 
     private <T> ServiceLoader<T> getServiceLoader(Class<T> type, ClassLoader classLoader)

--- a/hartshorn-testsuite/src/main/java/org/dockbox/hartshorn/test/junit/HartshornJUnitCleanupCallback.java
+++ b/hartshorn-testsuite/src/main/java/org/dockbox/hartshorn/test/junit/HartshornJUnitCleanupCallback.java
@@ -19,7 +19,6 @@ package org.dockbox.hartshorn.test.junit;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.cleanup.ClearMockitoCachesCallback;
 import org.dockbox.hartshorn.test.junit.cleanup.HartshornCleanupCallback;
-import org.dockbox.hartshorn.util.option.Option;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
@@ -65,21 +64,6 @@ public class HartshornJUnitCleanupCallback
         for (HartshornCleanupCallback callback : HartshornJUnitNamespace.collectCleanupCallbacks(
             context)) {
             callback.closeAfterLifecycle(context);
-        }
-        // Always last, in case the application is used by the callbacks
-        this.tryCloseApplication(context);
-    }
-
-    private void tryCloseApplication(ExtensionContext context) throws Exception {
-        Option<ApplicationContext> closeableApplication = HartshornJUnitNamespace
-                .applicationIfPresent(context)
-                .ofType(ApplicationContext.class);
-
-        if (closeableApplication.present()) {
-            ApplicationContext closeable = closeableApplication.get();
-            if (!closeable.isClosed()) {
-                closeable.close();
-            }
         }
     }
 }

--- a/hartshorn-testsuite/src/main/java/org/dockbox/hartshorn/test/junit/HartshornJUnitCleanupCallback.java
+++ b/hartshorn-testsuite/src/main/java/org/dockbox/hartshorn/test/junit/HartshornJUnitCleanupCallback.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.test.junit;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.cleanup.ClearMockitoCachesCallback;
 import org.dockbox.hartshorn.test.junit.cleanup.HartshornCleanupCallback;
+import org.dockbox.hartshorn.util.option.Option;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
@@ -64,6 +65,28 @@ public class HartshornJUnitCleanupCallback
         for (HartshornCleanupCallback callback : HartshornJUnitNamespace.collectCleanupCallbacks(
             context)) {
             callback.closeAfterLifecycle(context);
+        }
+        // Always last, in case the application is used by the callbacks
+        this.tryCloseApplication(context);
+    }
+
+    private void tryCloseApplication(ExtensionContext context) throws Exception {
+        Option<ApplicationContext> closeableApplication = HartshornJUnitNamespace
+                .applicationIfPresent(context)
+                .ofType(ApplicationContext.class);
+
+        if (closeableApplication.present()) {
+            ApplicationContext closeable = closeableApplication.get();
+
+            // Don't auto-close if Jupiter is already enabled to do so for us.
+            // If not explicitly set, defaults to true.
+            boolean autoClosingEnabled = context.getConfigurationParameter(
+                    "junit.jupiter.extensions.store.close.autocloseable.enabled"
+            ).map(Boolean::parseBoolean).orElse(true);
+
+            if (!autoClosingEnabled && !closeable.isClosed()) {
+                closeable.close();
+            }
         }
     }
 }


### PR DESCRIPTION
### Type of Change
- [x] Chore (changes to the build process or auxiliary tools)

### Description
With the release of Java 25, which is the latest LTS release at the time of writing, Hartshorn will drop Java 21 as its main JDK target. As such, this PR migrates our tooling to Java 25, and fixes minor issues with compact source files (related to constructorless classes in unnamed packages).

A known limitation of compact source files is the fact that they do not reside within a named package. As such, we cannot perform automatic package scanning unless explicitly declared. The main class itself will always be included, including any bindings it declares.

A valid compact source file may look like the sample below, which is adapted from the Java Launchpad  sample starter:
```java
import ...;

void main(String[] args) {
    HartshornApplication.createApplication(args).initialize(configuration -> {
        configuration.scanPackages(packages -> {
            packages.add("org.dockbox.sample.java");
        });
    });
}

@Singleton
public ApplicationStarter applicationStarter() {
    return applicationContext -> {
        GreetingAction greetingAction = applicationContext.get(GreetingAction.class);
        greetingAction.greet();
    };
}
```

### Checklist

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch