### PR TITLE
Set up OpenRewrite, migrate to AssertJ

### DIFF
--- a/hartshorn-assembly/checkstyle/checkstyle.xml
+++ b/hartshorn-assembly/checkstyle/checkstyle.xml
@@ -27,10 +27,9 @@
     </module>
     <module name="UnusedImports"/>
     <module name="IllegalImport">
-      <!-- Should use Checker framework annotations -->
+      <!-- Should use Checker framework annotations, and AssertJ for test assertions -->
       <property name="illegalPkgs" value="org.jetbrains.annotations"/>
-      <property name="illegalClasses"
-          value="jakarta.annotation.Nonnull,jakarta.annotation.Nullable"/>
+      <property name="illegalClasses" value="jakarta.annotation.Nonnull,jakarta.annotation.Nullable,org.junit.jupiter.api.Assertions"/>
     </module>
 
     <!-- General Javadoc rules -->

--- a/hartshorn-assembly/pom.platform.build.xml
+++ b/hartshorn-assembly/pom.platform.build.xml
@@ -37,74 +37,6 @@
     <plugin.openrewrite.version>6.26.0</plugin.openrewrite.version>
   </properties>
 
-  <profiles>
-    <profile>
-      <id>openrewrite</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.openrewrite.maven</groupId>
-            <artifactId>rewrite-maven-plugin</artifactId>
-            <configuration>
-              <activeRecipes>
-                <recipe>org.openrewrite.java.testing.assertj.JUnitToAssertj</recipe>
-              </activeRecipes>
-              <exclusions>
-                <!--
-                Groovy sources are passed to Rewrite by GMaven, even though Groovy isn't Java. Kotlin
-                and Scala sources are correctly ignored.
-                -->
-                <exclusion>*/**.groovy</exclusion>
-                <!--
-                Source files using switch expressions/pattern matching. This is currently not supported
-                by Rewrite, see https://github.com/openrewrite/rewrite/issues/4153 for more information.
-                -->
-                <exclusion>
-                  hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionIntrospector.java
-                </exclusion>
-                <exclusion>
-                  hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionTypeParameterView.java
-                </exclusion>
-                <exclusion>
-                  hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/introspect/InjectorApplicationViewAdapter.java
-                </exclusion>
-                <exclusion>
-                  hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/provider/strategy/InstantiationStrategyComponentProviderStrategy.java
-                </exclusion>
-                <exclusion>
-                  hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/processing/MultiMapComponentProcessorRegistry.java
-                </exclusion>
-                <exclusion>
-                  hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/configuration/LaunchpadSharedComponentConfiguration.java
-                </exclusion>
-                <exclusion>
-                  hartshorn-reporting/src/main/java/org/dockbox/hartshorn/reporting/serialize/NodeToJacksonVisitor.java
-                </exclusion>
-                <exclusion>
-                  hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/parser/statement/ClassStatementParser.java
-                </exclusion>
-                <exclusion>
-                  hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConverterIntrospectionHelper.java
-                </exclusion>
-                <exclusion>
-                  hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionDefaultValueProviderFactoryTests.java
-                </exclusion>
-              </exclusions>
-              <failOnDryRunResults>true</failOnDryRunResults>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.openrewrite.recipe</groupId>
-                <artifactId>rewrite-testing-frameworks</artifactId>
-                <version>2.20.0</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <testResources>
       <testResource>
@@ -260,6 +192,25 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.openrewrite.maven</groupId>
+        <artifactId>rewrite-maven-plugin</artifactId>
+        <version>6.23.0</version>
+        <configuration>
+          <exportDatatables>true</exportDatatables>
+          <activeRecipes>
+            <recipe>org.openrewrite.java.testing.assertj.Assertj</recipe>
+          </activeRecipes>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-testing-frameworks</artifactId>
+            <version>3.21.3</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/hartshorn-assembly/pom.platform.support.xml
+++ b/hartshorn-assembly/pom.platform.support.xml
@@ -268,6 +268,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Language support -->
     <dependency>

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ExecutableScriptTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ExecutableScriptTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,38 +16,38 @@
 
 package test.org.dockbox.hartshorn.hsl;
 
-import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.hsl.ExecutableScript;
 import org.dockbox.hartshorn.hsl.UseExpressionValidation;
 import org.dockbox.hartshorn.hsl.customizer.ScriptContext;
+import org.dockbox.hartshorn.inject.annotations.Inject;
+import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import org.dockbox.hartshorn.inject.annotations.Inject;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 @UseExpressionValidation
-public class ExecutableScriptTests {
+class ExecutableScriptTests {
 
     @Inject
     private ApplicationContext context;
 
     @Test
-    void testHslScriptCanEvaluate() {
+    void hslScriptCanEvaluate() {
         String expression = "var a = 1";
         ExecutableScript script = ExecutableScript.of(this.context, expression);
-        ScriptContext scriptContext = Assertions.assertDoesNotThrow(script::evaluate);
+        ScriptContext scriptContext = script.evaluate();
         Object result = scriptContext.interpreter().global().values().get("a");
-        Assertions.assertNotNull(result);
+        assertThat(result).isNotNull();
     }
 
     @Test
-    void testHslScriptCanResolveWithoutEvaluate() {
+    void hslScriptCanResolveWithoutEvaluate() {
         String expression = "var a = 1";
         ExecutableScript script = ExecutableScript.of(this.context, expression);
-        ScriptContext scriptContext = Assertions.assertDoesNotThrow(script::resolve);
+        ScriptContext scriptContext = script.resolve();
         Object result = scriptContext.interpreter().global().values().get("a");
-        Assertions.assertNull(result);
+        assertThat(result).isNull();
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ExpressionConditionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ExpressionConditionTests.java
@@ -30,7 +30,6 @@ import org.dockbox.hartshorn.util.introspect.ElementAnnotationsIntrospector;
 import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 import org.dockbox.hartshorn.util.option.Option;
 import org.dockbox.hartshorn.util.types.TypeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -38,6 +37,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 @UseExpressionValidation
@@ -58,27 +59,27 @@ public class ExpressionConditionTests {
 
     @ParameterizedTest
     @MethodSource("scripts")
-    void testBulkValidations(String expression, boolean matches) {
+    void bulkValidations(String expression, boolean matches) {
         ConditionResult result = this.match(expression);
-        Assertions.assertEquals(matches, result.matches());
+        assertThat(result.matches()).isEqualTo(matches);
     }
 
     @Test
-    void testApplicationContextIsOptInAvailable() {
+    void applicationContextIsOptInAvailable() {
         ExpressionConditionContext context =
             new ExpressionConditionContext(this.applicationContext).includeApplicationContext(true);
         String expression =
             "applicationContext.getClass().getName() == \"%s\"".formatted(this.applicationContext.getClass()
                 .getName());
         ConditionResult result = this.match(expression, context);
-        Assertions.assertTrue(result.matches());
+        assertThat(result.matches()).isTrue();
     }
 
     @Test
-    void testApplicationContextIsAvailableDefault() {
+    void applicationContextIsAvailableDefault() {
         String expression = "null != applicationContext";
         ConditionResult result = this.match(expression);
-        Assertions.assertTrue(result.matches());
+        assertThat(result.matches()).isTrue();
     }
 
     ConditionResult match(String expression, ContextView... contexts) {

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/FinalizedTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/FinalizedTests.java
@@ -24,13 +24,14 @@ import org.dockbox.hartshorn.hsl.runtime.FormattedDiagnostic;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
 @UseExpressionValidation
-public class FinalizedTests {
+class FinalizedTests {
 
     @Inject
     private ApplicationContext applicationContext;
@@ -53,7 +54,7 @@ public class FinalizedTests {
             class Admin extends User { }
             """);
         script.runtime().imports(User.class);
-        Assertions.assertDoesNotThrow(script::evaluate);
+        script.evaluate();
     }
 
     @Test
@@ -69,7 +70,7 @@ public class FinalizedTests {
     }
 
     @Test
-    void testCannotReassignFinalVariables() {
+    void cannotReassignFinalVariables() {
         ExecutableScript script = ExecutableScript.of(this.applicationContext, """
             final var x = 1;
             x = 2;
@@ -82,7 +83,7 @@ public class FinalizedTests {
     }
 
     @Test
-    void testCannotReassignFinalFunctions() {
+    void cannotReassignFinalFunctions() {
         ExecutableScript script = ExecutableScript.of(this.applicationContext, """
             final function x() { }
             function x() { }
@@ -95,7 +96,7 @@ public class FinalizedTests {
     }
 
     @Test
-    void testCannotReassignFinalClasses() {
+    void cannotReassignFinalClasses() {
         ExecutableScript script = ExecutableScript.of(this.applicationContext, """
             final class User { }
             class User { }
@@ -108,14 +109,14 @@ public class FinalizedTests {
     }
 
     @Test
-    void testCannotReassignFinalNativeFunctions() {
+    void cannotReassignFinalNativeFunctions() {
         ExecutableScript script = ExecutableScript.of(this.applicationContext, """
             final native function a:x();
             function x() { }
             """);
         // Do not evaluate, as the native function does not exist in the current environment.
         ScriptEvaluationError error =
-            Assertions.assertThrows(ScriptEvaluationError.class, script::resolve);
+            assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(script::resolve).actual();
         ScriptAssertions.assertEvaluationError(error, FormattedDiagnostic.builder()
             .message(DiagnosticMessage.ILLEGAL_FINAL_X_REASSIGNMENT)
             .argument("native function")

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/InterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/InterpreterTests.java
@@ -16,51 +16,51 @@
 
 package test.org.dockbox.hartshorn.hsl;
 
-import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.hsl.ExecutableScript;
 import org.dockbox.hartshorn.hsl.ScriptEvaluationError;
 import org.dockbox.hartshorn.hsl.UseExpressionValidation;
 import org.dockbox.hartshorn.hsl.modules.InstanceNativeModule;
+import org.dockbox.hartshorn.inject.annotations.Inject;
+import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import org.dockbox.hartshorn.inject.annotations.Inject;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 @UseExpressionValidation
-public class InterpreterTests {
+class InterpreterTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
-    void testAmbiguousExternalFunctionsAreAllowedByDefault() {
+    void ambiguousExternalFunctionsAreAllowedByDefault() {
         ExecutableScript script = ExecutableScript.of(this.applicationContext, "ambiguousCall()");
         script.runtime()
             .module("ambiguous",
                 new InstanceNativeModule(this.applicationContext, new AmbiguousExternalModule()));
-        Assertions.assertDoesNotThrow(script::evaluate);
+        script.evaluate();
     }
 
     @Test
-    void testAmbiguousExternalFunctionsAreAllowedWhenEnabled() {
+    void ambiguousExternalFunctionsAreAllowedWhenEnabled() {
         ExecutableScript script = ExecutableScript.of(this.applicationContext, "ambiguousCall()");
         script.runtime()
             .module("ambiguous",
                 new InstanceNativeModule(this.applicationContext, new AmbiguousExternalModule()));
         script.runtime().interpreterOptions().permitAmbiguousExternalFunctions(true);
-        Assertions.assertDoesNotThrow(script::evaluate);
+        script.evaluate();
     }
 
     @Test
-    void testAmbiguousExternalFunctionsAreNotAllowedWhenDisabled() {
+    void ambiguousExternalFunctionsAreNotAllowedWhenDisabled() {
         ExecutableScript script = ExecutableScript.of(this.applicationContext, "ambiguousCall()");
         script.runtime()
             .module("ambiguous",
                 new InstanceNativeModule(this.applicationContext, new AmbiguousExternalModule()));
         script.runtime().interpreterOptions().permitAmbiguousExternalFunctions(false);
-        Assertions.assertThrows(ScriptEvaluationError.class, script::evaluate);
+        assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(script::evaluate);
     }
 
     public static class AmbiguousExternalModule {

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/LexerTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/LexerTests.java
@@ -32,7 +32,6 @@ import org.dockbox.hartshorn.hsl.token.type.ConditionTokenType;
 import org.dockbox.hartshorn.hsl.token.type.EnumTokenType;
 import org.dockbox.hartshorn.hsl.token.type.LiteralTokenType;
 import org.dockbox.hartshorn.hsl.token.type.TokenType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -43,16 +42,17 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 public class LexerTests {
 
     public static Stream<Arguments> tokens() {
         final List<Arguments> arguments = new ArrayList<>();
         DefaultTokenRegistry tokenRegistry = DefaultTokenRegistry.createDefault();
-        Set<TokenType> nonLiteralTokens = tokenRegistry.tokenTypes(type -> {
-            return !(type instanceof LiteralTokenType || tokenRegistry.comments()
+        Set<TokenType> nonLiteralTokens = tokenRegistry.tokenTypes(type -> !(type instanceof LiteralTokenType || tokenRegistry.comments()
                 .resolveFromOpenToken(type)
-                .present());
-        });
+                .present()));
         for (TokenType type : nonLiteralTokens) {
             arguments.add(Arguments.of(type.representation(), type));
         }
@@ -65,60 +65,60 @@ public class LexerTests {
 
     @ParameterizedTest
     @MethodSource("tokens")
-    void testCorrectToken(String text, TokenType expected) {
+    void correctToken(String text, TokenType expected) {
         Lexer lexer =
             new SimpleTokenRegistryLexer(text, DefaultTokenRegistry.createDefault());
         List<Token> tokens = lexer.scanTokens();
 
-        Assertions.assertNotNull(tokens);
-        Assertions.assertEquals(2, tokens.size());
+        assertThat(tokens)
+                .hasSize(2);
 
         Token token = tokens.getFirst();
-        Assertions.assertEquals(expected, token.type());
-        Assertions.assertEquals(1, token.line());
+        assertThat(token.type()).isEqualTo(expected);
+        assertThat(token.line()).isOne();
 
         Token eof = tokens.get(1);
-        Assertions.assertEquals(LiteralTokenType.EOF, eof.type());
+        assertThat(eof.type()).isEqualTo(LiteralTokenType.EOF);
     }
 
     @Test
-    void testSingleLineComment() {
+    void singleLineComment() {
         Lexer lexer =
             new SimpleTokenRegistryLexer("# Comment", DefaultTokenRegistry.createDefault());
         List<Token> tokens = lexer.scanTokens();
 
-        Assertions.assertNotNull(tokens);
-        Assertions.assertEquals(1, tokens.size());
+        assertThat(tokens)
+                .hasSize(1);
 
         Token token = tokens.getFirst();
-        Assertions.assertEquals(LiteralTokenType.EOF, token.type());
+        assertThat(token.type()).isEqualTo(LiteralTokenType.EOF);
 
         List<Comment> comments = lexer.comments();
-        Assertions.assertNotNull(comments);
-        Assertions.assertEquals(1, comments.size());
+        assertThat(comments)
+                .hasSize(1);
 
         Comment comment = comments.getFirst();
         // Comments are not trimmed, include whitespace
-        Assertions.assertEquals(" Comment", comment.text());
+        assertThat(comment.text()).isEqualTo(" Comment");
     }
 
     @Test
-    void testCombinedOperatorsAreParsedCorrectly() {
+    void combinedOperatorsAreParsedCorrectly() {
         // No such operator (logical shift left), so should be parsed as '1 << < 2' (1 shift left, less than 2).
         // While this isn't valid code for HSL, it's a good test to see if the lexer is working as expected.
         final Lexer lexer =
             new SimpleTokenRegistryLexer("1 <<< 2", DefaultTokenRegistry.createDefault());
         List<Token> tokens = lexer.scanTokens();
-        Assertions.assertSame(5, tokens.size());
-        Assertions.assertEquals(LiteralTokenType.NUMBER, tokens.get(0).type());
-        Assertions.assertEquals(BitwiseTokenType.SHIFT_LEFT, tokens.get(1).type());
-        Assertions.assertEquals(ConditionTokenType.LESS, tokens.get(2).type());
-        Assertions.assertEquals(LiteralTokenType.NUMBER, tokens.get(3).type());
-        Assertions.assertEquals(LiteralTokenType.EOF, tokens.get(4).type());
+        assertThat(tokens).size().isSameAs(5);
+        assertThat(tokens.get(0).type()).isEqualTo(LiteralTokenType.NUMBER);
+        assertThat(tokens.get(1).type()).isEqualTo(BitwiseTokenType.SHIFT_LEFT);
+        assertThat(tokens.get(2).type()).isEqualTo(ConditionTokenType.LESS);
+        assertThat(tokens.get(3).type()).isEqualTo(LiteralTokenType.NUMBER);
+        assertThat(tokens.get(4).type()).isEqualTo(LiteralTokenType.EOF);
     }
 
     @Test
-    void testIncompleteTokenStepsBackToParent() {
+    void incompleteTokenStepsBackToParent() {
         DefaultTokenRegistry registry = DefaultTokenRegistry.createDefault();
         registry.addTokens(QuadrupleToken.QUADRUPLE_DASH);
 
@@ -128,19 +128,19 @@ public class LexerTests {
         final Lexer lexer = new SimpleTokenRegistryLexer("---", registry);
         List<Token> tokens = lexer.scanTokens();
 
-        Assertions.assertSame(3, tokens.size());
-        Assertions.assertEquals(ArithmeticTokenType.MINUS_MINUS, tokens.get(0).type());
-        Assertions.assertEquals(ArithmeticTokenType.MINUS, tokens.get(1).type());
-        Assertions.assertEquals(LiteralTokenType.EOF, tokens.get(2).type());
+        assertThat(tokens).size().isSameAs(3);
+        assertThat(tokens.get(0).type()).isEqualTo(ArithmeticTokenType.MINUS_MINUS);
+        assertThat(tokens.get(1).type()).isEqualTo(ArithmeticTokenType.MINUS);
+        assertThat(tokens.get(2).type()).isEqualTo(LiteralTokenType.EOF);
     }
 
     @Test
-    void testIncompleteInvalidTokenFails() {
+    void incompleteInvalidTokenFails() {
         DefaultTokenRegistry registry = DefaultTokenRegistry.createDefault();
         registry.addTokens(QuadrupleToken.QUADRUPLE_AT);
 
         final Lexer lexer = new SimpleTokenRegistryLexer("@@@", registry);
-        Assertions.assertThrows(ScriptEvaluationError.class, lexer::scanTokens);
+        assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(lexer::scanTokens);
     }
 
     enum QuadrupleToken implements EnumTokenType {

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ScriptRuntimeTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ScriptRuntimeTests.java
@@ -29,7 +29,6 @@ import org.dockbox.hartshorn.hsl.token.type.TokenType;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -46,6 +45,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiPredicate;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 @UseExpressionValidation
@@ -81,37 +82,37 @@ public class ScriptRuntimeTests {
 
     @ParameterizedTest
     @MethodSource("scripts")
-    void testPredefinedScript(Path path) throws IOException {
+    void predefinedScript(Path path) throws Exception {
         this.assertNoErrorsReported(ExecutableScript.of(this.applicationContext, path));
     }
 
     @ParameterizedTest
     @MethodSource("scripts")
-    void testPredefinedScriptWithOptionalSemicolons(Path path) throws IOException {
+    void predefinedScriptWithOptionalSemicolons(Path path) throws Exception {
         String source = ExecutableScript.sourceFromPath(path).replaceAll(";", "");
         this.assertNoErrorsReported(source);
     }
 
     @Test
-    void testExpression() {
+    void expression() {
         this.assertValid("1 == 1");
     }
 
     @Test
-    void testComplexExpression() {
+    void complexExpression() {
         String expression = "1 + 3 == 4 && 2 + 2 == 4 && 2 - 2 == 0";
         this.assertValid(expression);
     }
 
     @Test
-    void testExpressionWithGlobal() {
+    void expressionWithGlobal() {
         ExpressionScript expression = ExpressionScript.of(this.applicationContext, "a == 12");
         expression.runtime().global("a", 12);
         this.assertValid(expression);
     }
 
     @Test
-    void testExpressionWithGlobalFunctionAccess() {
+    void expressionWithGlobalFunctionAccess() {
         String expression = "context != null && context.environment() != null";
         ExpressionScript script = ExpressionScript.of(this.applicationContext, expression);
         script.runtime().global("context", this.applicationContext);
@@ -119,7 +120,7 @@ public class ScriptRuntimeTests {
     }
 
     @Test
-    void testScriptWithGlobalFunctionAccess() {
+    void scriptWithGlobalFunctionAccess() {
         String expression = "context.environment().isBatchMode()";
         ExecutableScript script = ExecutableScript.of(this.applicationContext, expression);
         script.runtime().global("context", this.applicationContext);
@@ -127,7 +128,7 @@ public class ScriptRuntimeTests {
     }
 
     @Test
-    void testExpressionWithNativeAccess() {
+    void expressionWithNativeAccess() {
         ExpressionScript expression =
             ExpressionScript.of(this.applicationContext, "isClosed() == false");
         expression.runtime()
@@ -137,7 +138,7 @@ public class ScriptRuntimeTests {
     }
 
     @Test
-    void testMultilineWithComments() {
+    void multilineWithComments() {
         String expression = """
             print("Hello world!");
             
@@ -155,25 +156,24 @@ public class ScriptRuntimeTests {
         ScriptContext context = this.assertNoErrorsReported(expression);
 
         List<Comment> comments = context.comments();
-        Assertions.assertEquals(3, comments.size());
+        assertThat(comments).hasSize(3);
 
         // Comments are not trimmed, so we need to include spaces in the expected result
         Comment commentOne = comments.getFirst();
-        Assertions.assertEquals(" This is a comment", commentOne.text());
-        Assertions.assertEquals(3, commentOne.line());
+        assertThat(commentOne.text()).isEqualTo(" This is a comment");
+        assertThat(commentOne.line()).isEqualTo(3);
 
         Comment commentTwo = comments.get(1);
-        Assertions.assertEquals(" This is also a comment, print(\"Hello world 3!\");",
-            commentTwo.text());
-        Assertions.assertEquals(6, commentTwo.line());
+        assertThat(commentTwo.text()).isEqualTo(" This is also a comment, print(\"Hello world 3!\");");
+        assertThat(commentTwo.line()).isEqualTo(6);
 
         Comment commentThree = comments.get(2);
-        Assertions.assertEquals(" This is a multi-line comment\nsee?!\n", commentThree.text());
-        Assertions.assertEquals(9, commentThree.line());
+        assertThat(commentThree.text()).isEqualTo(" This is a multi-line comment\nsee?!\n");
+        assertThat(commentThree.line()).isEqualTo(9);
     }
 
     @Test
-    void testGlobalResultTracking() {
+    void globalResultTracking() {
         String expression = """
             var a = 12;
             var b = 13;
@@ -182,48 +182,49 @@ public class ScriptRuntimeTests {
         ScriptContext context = this.assertNoErrorsReported(expression);
 
         Map<String, Object> results = context.interpreter().global().values();
-        Assertions.assertFalse(results.isEmpty());
-        Assertions.assertEquals(12.0d, results.get("a"));
-        Assertions.assertEquals(13.0d, results.get("b"));
-        Assertions.assertEquals(25.0d, results.get("c"));
+        assertThat(results)
+                .containsEntry("a", 12.0d)
+                .containsEntry("b", 13.0d)
+                .containsEntry("c", 25.0d);
     }
 
     @ParameterizedTest
     @MethodSource("phases")
-    void testPhaseCustomizers(Phase phase) {
+    void phaseCustomizers(Phase phase) {
         ExecutableScript script = ExecutableScript.of(this.applicationContext, "1 == 1");
 
         AtomicBoolean called = new AtomicBoolean(false);
         CodeCustomizer customizer = CodeCustomizer.of(phase, context -> called.set(true));
         script.runtime().customizer(customizer);
         script.evaluate();
-        Assertions.assertTrue(called.get());
+        assertThat(called.get()).isTrue();
     }
 
     @ParameterizedTest
     @MethodSource("bitwise")
-    void testBitwiseOperator(TokenType token, int left, int right, int expected) {
+    void bitwiseOperator(TokenType token, int left, int right, int expected) {
         String expression = "var result = %s %s %s".formatted(left, token.representation(), right);
         ScriptContext context = this.assertNoErrorsReported(expression);
         Object result = context.interpreter().global().values().get("result");
-        Assertions.assertNotNull(result);
-        Assertions.assertEquals(expected, result);
+        assertThat(result)
+                .isNotNull()
+                .isEqualTo(expected);
     }
 
     @Test
-    void testNegativeNumbers() {
+    void negativeNumbers() {
         this.assertValid("-1 == -1");
     }
 
     @Test
-    void testComplement() {
+    void complement() {
         int expected = ~35; // -36
         String expression = "~35 == %s".formatted(expected);
         this.assertValid(expression);
     }
 
     @Test
-    void testInterpreterCanBeReused() {
+    void interpreterCanBeReused() {
         ExecutableScript script = ExecutableScript.of(this.applicationContext, """
             var x = 1;
             test ("Variable has not been modified") {
@@ -241,8 +242,8 @@ public class ScriptRuntimeTests {
     }
 
     ScriptContext assertValid(ExpressionScript expression) {
-        ScriptContext context = Assertions.assertDoesNotThrow(expression::evaluate);
-        Assertions.assertTrue(ExpressionScript.valid(context));
+        ScriptContext context = expression.evaluate();
+        assertThat(ExpressionScript.valid(context)).isTrue();
         return context;
     }
 
@@ -252,6 +253,6 @@ public class ScriptRuntimeTests {
     }
 
     ScriptContext assertNoErrorsReported(ExecutableScript script) {
-        return Assertions.assertDoesNotThrow(script::evaluate);
+        return script.evaluate();
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/VirtualClassTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/VirtualClassTests.java
@@ -16,7 +16,6 @@
 
 package test.org.dockbox.hartshorn.hsl;
 
-import java.util.stream.Stream;
 import org.dockbox.hartshorn.hsl.ExecutableScript;
 import org.dockbox.hartshorn.hsl.ScriptEvaluationError;
 import org.dockbox.hartshorn.hsl.UseExpressionValidation;
@@ -25,11 +24,14 @@ import org.dockbox.hartshorn.hsl.runtime.FormattedDiagnostic;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 @UseExpressionValidation
@@ -112,11 +114,11 @@ public class VirtualClassTests {
         // If an error message is expected, assert that the script evaluation fails with the expected message
         if (message != null) {
             ScriptEvaluationError error =
-                Assertions.assertThrows(ScriptEvaluationError.class, script::evaluate);
+                assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(script::evaluate).actual();
             ScriptAssertions.assertEvaluationError(error, message);
         }
         else {
-            Assertions.assertDoesNotThrow(script::evaluate);
+            script.evaluate();
         }
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/ArrayComprehensionExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/ArrayComprehensionExpressionTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.ast.expression;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.ast.expression.ArrayComprehensionExpression;
 import org.dockbox.hartshorn.hsl.interpreter.Array;
 import org.dockbox.hartshorn.hsl.interpreter.expression.ArrayComprehensionExpressionInterpreter;
@@ -26,7 +27,6 @@ import org.dockbox.hartshorn.hsl.parser.expression.LiteralExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,6 +34,8 @@ import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
 import java.util.List;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class ArrayComprehensionExpressionTests {
@@ -66,9 +68,11 @@ public class ArrayComprehensionExpressionTests {
             ArrayComprehensionExpression.class,
             new ArrayComprehensionExpressionInterpreter()
         ).interpretValue();
-        Array array = Assertions.assertInstanceOf(Array.class, interpreted);
-        Assertions.assertEquals(1, array.length());
-        Assertions.assertEquals("test", array.value(0));
+        Array array = assertThat(interpreted)
+                .asInstanceOf(InstanceOfAssertFactories.type(Array.class))
+                .actual();
+        assertThat(array.length()).isOne();
+        assertThat(array.value(0)).isEqualTo("test");
     }
 
     @ParameterizedTest
@@ -88,9 +92,11 @@ public class ArrayComprehensionExpressionTests {
             ArrayComprehensionExpression.class,
             new ArrayComprehensionExpressionInterpreter()
         ).interpretValue();
-        Array array = Assertions.assertInstanceOf(Array.class, interpreted);
-        Assertions.assertEquals(1, array.length());
-        Assertions.assertEquals("test2", array.value(0));
+        Array array = assertThat(interpreted)
+                .asInstanceOf(InstanceOfAssertFactories.type(Array.class))
+                .actual();
+        assertThat(array.length()).isOne();
+        assertThat(array.value(0)).isEqualTo("test2");
     }
 
     @ParameterizedTest
@@ -109,8 +115,10 @@ public class ArrayComprehensionExpressionTests {
             ArrayComprehensionExpression.class,
             new ArrayComprehensionExpressionInterpreter()
         ).interpretValue();
-        Array array = Assertions.assertInstanceOf(Array.class, interpreted);
-        Assertions.assertEquals(0, array.length());
+        Array array = assertThat(interpreted)
+                .asInstanceOf(InstanceOfAssertFactories.type(Array.class))
+                .actual();
+        assertThat(array.length()).isZero();
     }
 
     @ParameterizedTest
@@ -129,8 +137,10 @@ public class ArrayComprehensionExpressionTests {
             ArrayComprehensionExpression.class,
             new ArrayComprehensionExpressionInterpreter()
         ).interpretValue();
-        Array array = Assertions.assertInstanceOf(Array.class, interpreted);
-        Assertions.assertEquals(1, array.length());
-        Assertions.assertEquals("other", array.value(0));
+        Array array = assertThat(interpreted)
+                .asInstanceOf(InstanceOfAssertFactories.type(Array.class))
+                .actual();
+        assertThat(array.length()).isOne();
+        assertThat(array.value(0)).isEqualTo("other");
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/ArrayGetExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/ArrayGetExpressionTests.java
@@ -24,15 +24,17 @@ import org.dockbox.hartshorn.hsl.parser.expression.LiteralExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ArrayGetExpressionTests {
+class ArrayGetExpressionTests {
 
     @Test
-    void testArrayGetExpressionCanGetIfInRange(@Inject ApplicationContext applicationContext) {
+    void arrayGetExpressionCanGetIfInRange(@Inject ApplicationContext applicationContext) {
         Object[] realArray = {"test"};
         HSLTestHelper helper = HSLTestHelper.ofExpression(applicationContext, "array[0]")
             .expressionParser(new LiteralExpressionParser())
@@ -44,11 +46,11 @@ public class ArrayGetExpressionTests {
             ArrayGetExpression.class,
             new ArrayGetExpressionInterpreter()
         ).interpretValue();
-        Assertions.assertSame(realArray[0], interpretedValue);
+        assertThat(interpretedValue).isSameAs(realArray[0]);
     }
 
     @Test
-    void testArrayGetExpressionThrowsIfOutOfRange(@Inject ApplicationContext applicationContext) {
+    void arrayGetExpressionThrowsIfOutOfRange(@Inject ApplicationContext applicationContext) {
         Object[] realArray = {"test"};
         HSLTestHelper helper = HSLTestHelper.ofExpression(applicationContext, "array[1]")
             .expressionParser(new LiteralExpressionParser())
@@ -56,11 +58,10 @@ public class ArrayGetExpressionTests {
             .defineLocal("array", new Array(realArray))
             .build();
 
-        Assertions.assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+        assertThatExceptionOfType(ArrayIndexOutOfBoundsException.class).isThrownBy(() ->
             helper.evaluateWith(
                 ArrayGetExpression.class,
                 new ArrayGetExpressionInterpreter()
-            ).interpretValue();
-        });
+            ).interpretValue());
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/ArrayLiteralExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/ArrayLiteralExpressionTests.java
@@ -16,21 +16,23 @@
 
 package test.org.dockbox.hartshorn.hsl.ast.expression;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.interpreter.Array;
 import org.dockbox.hartshorn.hsl.parser.expression.ComplexArrayExpressionParser;
 import org.dockbox.hartshorn.hsl.parser.expression.LiteralExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ArrayLiteralExpressionTests {
+class ArrayLiteralExpressionTests {
 
     @Test
-    void testEmptyArrayLiteralYieldsEmptyArrayObject(
+    void emptyArrayLiteralYieldsEmptyArrayObject(
         @Inject ApplicationContext applicationContext
     ) {
         HSLTestHelper helper = HSLTestHelper.ofExpression(applicationContext, "[]")
@@ -38,12 +40,14 @@ public class ArrayLiteralExpressionTests {
             .build();
         Object value = helper.interpretValue();
 
-        Array array = Assertions.assertInstanceOf(Array.class, value);
-        Assertions.assertEquals(0, array.length());
+        Array array = assertThat(value)
+                .asInstanceOf(InstanceOfAssertFactories.type(Array.class))
+                .actual();
+        assertThat(array.length()).isZero();
     }
 
     @Test
-    void testSingleValueArrayLiteralYieldsArrayObject(
+    void singleValueArrayLiteralYieldsArrayObject(
         @Inject ApplicationContext applicationContext
     ) {
         HSLTestHelper helper = HSLTestHelper.ofExpression(applicationContext, "[\"test\"]")
@@ -52,13 +56,15 @@ public class ArrayLiteralExpressionTests {
             .build();
         Object value = helper.interpretValue();
 
-        Array array = Assertions.assertInstanceOf(Array.class, value);
-        Assertions.assertEquals(1, array.length());
-        Assertions.assertEquals("test", array.value(0));
+        Array array = assertThat(value)
+                .asInstanceOf(InstanceOfAssertFactories.type(Array.class))
+                .actual();
+        assertThat(array.length()).isOne();
+        assertThat(array.value(0)).isEqualTo("test");
     }
 
     @Test
-    void testMultipleValueArrayLiteralYieldsArrayObject(
+    void multipleValueArrayLiteralYieldsArrayObject(
         @Inject ApplicationContext applicationContext
     ) {
         HSLTestHelper helper = HSLTestHelper.ofExpression(applicationContext, """
@@ -69,9 +75,11 @@ public class ArrayLiteralExpressionTests {
             .build();
         Object value = helper.interpretValue();
 
-        Array array = Assertions.assertInstanceOf(Array.class, value);
-        Assertions.assertEquals(2, array.length());
-        Assertions.assertEquals("test", array.value(0));
-        Assertions.assertEquals("test2", array.value(1));
+        Array array = assertThat(value)
+                .asInstanceOf(InstanceOfAssertFactories.type(Array.class))
+                .actual();
+        assertThat(array.length()).isEqualTo(2);
+        assertThat(array.value(0)).isEqualTo("test");
+        assertThat(array.value(1)).isEqualTo("test2");
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/ArraySetExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/ArraySetExpressionTests.java
@@ -25,15 +25,17 @@ import org.dockbox.hartshorn.hsl.parser.expression.LiteralExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ArraySetExpressionTests {
+class ArraySetExpressionTests {
 
     @Test
-    void testSetWithinArrayRange(@Inject ApplicationContext applicationContext) {
+    void setWithinArrayRange(@Inject ApplicationContext applicationContext) {
         Object[] realArray = {"test"};
         Array hslArray = new Array(realArray);
         HSLTestHelper helper = HSLTestHelper.ofExpression(applicationContext, """
@@ -48,13 +50,13 @@ public class ArraySetExpressionTests {
         Object interpreted = helper
             .evaluateWith(ArraySetExpression.class, new ArraySetExpressionInterpreter())
             .interpretValue();
-        Assertions.assertEquals("value", interpreted);
-        Assertions.assertEquals("value", hslArray.value(0));
-        Assertions.assertEquals("value", realArray[0]);
+        assertThat(interpreted).isEqualTo("value");
+        assertThat(hslArray.value(0)).isEqualTo("value");
+        assertThat(realArray[0]).isEqualTo("value");
     }
 
     @Test
-    void testSetOutsideRangeThrowsOutOfBounds(@Inject ApplicationContext applicationContext) {
+    void setOutsideRangeThrowsOutOfBounds(@Inject ApplicationContext applicationContext) {
         Object[] realArray = {"test"};
         Array hslArray = new Array(realArray);
         HSLTestHelper helper = HSLTestHelper.ofExpression(applicationContext, """
@@ -66,11 +68,10 @@ public class ArraySetExpressionTests {
             .defineLocal("array", hslArray)
             .build();
 
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
+        assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() ->
             helper.evaluateWith(
                 ArraySetExpression.class,
                 new ArraySetExpressionInterpreter()
-            ).interpretValue();
-        });
+            ).interpretValue());
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/AssignExpressionInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/AssignExpressionInterpreterTests.java
@@ -29,7 +29,6 @@ import org.dockbox.hartshorn.hsl.token.type.LiteralTokenType;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -38,6 +37,9 @@ import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class AssignExpressionInterpreterTests {
@@ -54,7 +56,7 @@ public class AssignExpressionInterpreterTests {
 
     @ParameterizedTest
     @MethodSource("variableDefinitionScopes")
-    void testAssignmentToDefinedVariable(
+    void assignmentToDefinedVariable(
         Function<Interpreter, VariableScope> variableScopeFunction
     ) {
         HSLTestHelper helper = HSLTestHelper.ofExpression(this.applicationContext, """
@@ -69,15 +71,15 @@ public class AssignExpressionInterpreterTests {
         Object interpreted = helper
             .evaluateWith(AssignExpression.class, new AssignExpressionInterpreter())
             .interpretValue();
-        Assertions.assertEquals("newValue", interpreted);
+        assertThat(interpreted).isEqualTo("newValue");
 
         VariableScope scope = variableScopeFunction.apply(helper.interpreter());
         Object variableValue = scope.get(Token.of(LiteralTokenType.IDENTIFIER, "variable").build());
-        Assertions.assertEquals("newValue", variableValue);
+        assertThat(variableValue).isEqualTo("newValue");
     }
 
     @Test
-    void testAssignmentToUndefinedVariable() {
+    void assignmentToUndefinedVariable() {
         HSLTestHelper helper = HSLTestHelper.ofExpression(this.applicationContext, """
                 variable = "newValue"
                 """)
@@ -86,9 +88,8 @@ public class AssignExpressionInterpreterTests {
             .expressionParser(new IdentifierExpressionParser())
             .build();
 
-        Assertions.assertThrows(ScriptEvaluationError.class, () -> helper
+        assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(() -> helper
             .evaluateWith(AssignExpression.class, new AssignExpressionInterpreter())
-            .interpretValue()
-        );
+            .interpretValue());
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/AssignExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/AssignExpressionTests.java
@@ -31,7 +31,6 @@ import org.dockbox.hartshorn.hsl.token.type.LiteralTokenType;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -41,6 +40,9 @@ import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class AssignExpressionTests {
@@ -57,7 +59,7 @@ public class AssignExpressionTests {
 
     @ParameterizedTest
     @MethodSource("variableDefinitionScopes")
-    void testAssignmentToDefinedVariable(
+    void assignmentToDefinedVariable(
         Function<Interpreter, VariableScope> variableScopeFunction
     ) {
         HSLTestHelper helper = HSLTestHelper.ofExpression(this.applicationContext, """
@@ -72,11 +74,11 @@ public class AssignExpressionTests {
         Object interpreted = helper
             .evaluateWith(AssignExpression.class, new AssignExpressionInterpreter())
             .interpretValue();
-        Assertions.assertEquals("newValue", interpreted);
+        assertThat(interpreted).isEqualTo("newValue");
 
         VariableScope scope = variableScopeFunction.apply(helper.interpreter());
         Object variableValue = scope.get(Token.of(LiteralTokenType.IDENTIFIER, "variable").build());
-        Assertions.assertEquals("newValue", variableValue);
+        assertThat(variableValue).isEqualTo("newValue");
     }
 
     @Test
@@ -84,7 +86,7 @@ public class AssignExpressionTests {
         PropertyContainer container = Mockito.mock(PropertyContainer.class);
         Mockito.doAnswer(invocation -> {
             Object value = invocation.getArgument(2);
-            Assertions.assertEquals(42d, value);
+            assertThat(value).isEqualTo(42d);
             return null;
         }).when(container).set(
             Mockito.any(Interpreter.class),
@@ -103,7 +105,7 @@ public class AssignExpressionTests {
                 .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals(42d, value);
+        assertThat(value).isEqualTo(42d);
 
         Mockito.verify(container).set(
             Mockito.eq(helper.interpreter()),
@@ -114,7 +116,7 @@ public class AssignExpressionTests {
     }
 
     @Test
-    void testAssignmentToUndefinedVariable() {
+    void assignmentToUndefinedVariable() {
         HSLTestHelper helper = HSLTestHelper.ofExpression(this.applicationContext, """
                 variable = "newValue"
                 """)
@@ -123,7 +125,7 @@ public class AssignExpressionTests {
             .expressionParser(new IdentifierExpressionParser())
             .build();
 
-        Assertions.assertThrows(ScriptEvaluationError.class, () -> helper
+        assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(() -> helper
             .evaluateWith(AssignExpression.class, new AssignExpressionInterpreter())
             .interpretValue());
     }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/BinaryExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/BinaryExpressionTests.java
@@ -25,13 +25,14 @@ import org.dockbox.hartshorn.hsl.parser.expression.IdentifierExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class BinaryExpressionTests {
@@ -59,7 +60,7 @@ public class BinaryExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals(expected, value);
+        assertThat(value).isEqualTo(expected);
     }
 
     public static Stream<Arguments> binaryCases() {

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/BitwiseExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/BitwiseExpressionTests.java
@@ -21,13 +21,14 @@ import org.dockbox.hartshorn.hsl.parser.expression.IdentifierExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class BitwiseExpressionTests {
@@ -54,7 +55,7 @@ public class BitwiseExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals(expected, value);
+        assertThat(value).isEqualTo(expected);
     }
 
     public static Stream<Arguments> bitwiseCases() {

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/ElvisExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/ElvisExpressionTests.java
@@ -21,12 +21,13 @@ import org.dockbox.hartshorn.hsl.parser.expression.LiteralExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ElvisExpressionTests {
+class ElvisExpressionTests {
 
     @Test
     void elvisWithTruthyValueReturnsLeft(@Inject ApplicationContext applicationContext) {
@@ -36,7 +37,7 @@ public class ElvisExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals(42d, value);
+        assertThat(value).isEqualTo(42d);
     }
 
     @Test
@@ -47,6 +48,6 @@ public class ElvisExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals(24d, value);
+        assertThat(value).isEqualTo(24d);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/FunctionCallExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/FunctionCallExpressionTests.java
@@ -24,19 +24,20 @@ import org.dockbox.hartshorn.hsl.parser.expression.LiteralExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class FunctionCallExpressionTests {
+class FunctionCallExpressionTests {
 
     @Test
     void functionWithoutArgumentsCanBeCalled(@Inject ApplicationContext applicationContext) {
         CallableNode node = (at, interpreter, instance, args) -> {
-            Assertions.assertNull(instance);
-            Assertions.assertTrue(args.isEmpty());
+            assertThat(instance).isNull();
+            assertThat(args).isEmpty();
             return "Hello world!";
         };
 
@@ -47,15 +48,15 @@ public class FunctionCallExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals("Hello world!", value);
+        assertThat(value).isEqualTo("Hello world!");
     }
 
     @Test
     void functionWithArgumentsCanBeCalled(@Inject ApplicationContext applicationContext) {
         CallableNode node = (at, interpreter, instance, args) -> {
-            Assertions.assertNull(instance);
-            Assertions.assertEquals(1, args.size());
-            Assertions.assertEquals("Guus", args.getFirst());
+            assertThat(instance).isNull();
+            assertThat(args).hasSize(1);
+            assertThat(args).first().isEqualTo("Guus");
 
             return "Hello " + args.getFirst() + "!";
         };
@@ -70,7 +71,7 @@ public class FunctionCallExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals("Hello Guus!", value);
+        assertThat(value).isEqualTo("Hello Guus!");
     }
 
     @Test
@@ -79,10 +80,10 @@ public class FunctionCallExpressionTests {
         Mockito.when(objectReference.externalObject()).thenReturn("Guus");
 
         CallableNode node = (at, interpreter, instance, args) -> {
-            Assertions.assertNull(instance);
-            Assertions.assertEquals(1, args.size());
+            assertThat(instance).isNull();
+            assertThat(args).hasSize(1);
             // Thus, not an ExternalObjectReference anymore
-            Assertions.assertEquals("Guus", args.getFirst());
+            assertThat(args).first().isEqualTo("Guus");
 
             return "Hello world!";
         };
@@ -95,6 +96,6 @@ public class FunctionCallExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals("Hello world!", value);
+        assertThat(value).isEqualTo("Hello world!");
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/GetExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/GetExpressionTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.ast.expression;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.interpreter.Interpreter;
 import org.dockbox.hartshorn.hsl.interpreter.VariableScope;
 import org.dockbox.hartshorn.hsl.objects.ExternalObjectReference;
@@ -28,13 +29,14 @@ import org.dockbox.hartshorn.hsl.token.Token;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class GetExpressionTests {
+class GetExpressionTests {
 
     @Test
     void getExpressionReturnsPropertyContainerValue(@Inject ApplicationContext applicationContext) {
@@ -52,7 +54,7 @@ public class GetExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals("Hello, World!", value);
+        assertThat(value).isEqualTo("Hello, World!");
     }
 
     @Test
@@ -77,9 +79,10 @@ public class GetExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        // String, not ExternalObjectReference. Should unwrap automatically.
-        Assertions.assertInstanceOf(String.class, value);
-        Assertions.assertEquals("Hello, World!", value);
+        assertThat(value)
+                // String, not ExternalObjectReference. Should unwrap automatically.
+                .isInstanceOf(String.class)
+                .isEqualTo("Hello, World!");
     }
 
     @Test
@@ -110,9 +113,10 @@ public class GetExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        ExternalFunction externalFunction =
-            Assertions.assertInstanceOf(ExternalFunction.class, value);
+        ExternalFunction externalFunction = assertThat(value)
+                .asInstanceOf(InstanceOfAssertFactories.type(ExternalFunction.class))
+                .actual();
         InstanceReference bound = externalFunction.bound();
-        Assertions.assertSame(instanceReference, bound);
+        assertThat(bound).isSameAs(instanceReference);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/InfixExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/InfixExpressionTests.java
@@ -28,13 +28,15 @@ import org.dockbox.hartshorn.hsl.runtime.Phase;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class InfixExpressionTests {
+class InfixExpressionTests {
 
     @Test
     void infixExpressionWithDefinitionAndImplementationPasses(
@@ -52,7 +54,7 @@ public class InfixExpressionTests {
                 parser.addContext(functionParserContext);
             })
             // Infix function implementation
-            .defineLocal("or", (CallableNode) (at, interpreter, instance, arguments) -> {
+            .defineLocal("or", (CallableNode) (_, _, _, arguments) -> {
                 Object left = arguments.getFirst();
                 Object right = arguments.getLast();
                 return InterpreterUtilities.isTruthy(left) ? left : right;
@@ -60,8 +62,7 @@ public class InfixExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        String result = Assertions.assertInstanceOf(String.class, value);
-        Assertions.assertEquals("pizza", result);
+        assertThat(value).isEqualTo("pizza");
     }
 
     @Test
@@ -81,11 +82,8 @@ public class InfixExpressionTests {
             })
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::expression
-        );
-        Assertions.assertEquals(Phase.PARSING, error.phase());
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::expression).actual();
+        assertThat(error.phase()).isEqualTo(Phase.PARSING);
     }
 
     @Test
@@ -104,13 +102,10 @@ public class InfixExpressionTests {
             })
             .build();
 
-        Assertions.assertDoesNotThrow(helper::parse);
+        helper.parse();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpretValue
-        );
-        Assertions.assertEquals(Phase.INTERPRETING, error.phase());
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpretValue).actual();
+        assertThat(error.phase()).isEqualTo(Phase.INTERPRETING);
         ScriptAssertions.assertEvaluationError(
             error,
             FormattedDiagnostic.of(DiagnosticMessage.UNDEFINED_VARIABLE, "or")
@@ -131,11 +126,8 @@ public class InfixExpressionTests {
             })
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::expression
-        );
-        Assertions.assertEquals(Phase.PARSING, error.phase());
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::expression).actual();
+        assertThat(error.phase()).isEqualTo(Phase.PARSING);
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.EXPECTED_EXPRESSION);
     }
 
@@ -153,11 +145,8 @@ public class InfixExpressionTests {
             })
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::expression
-        );
-        Assertions.assertEquals(Phase.PARSING, error.phase());
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::expression).actual();
+        assertThat(error.phase()).isEqualTo(Phase.PARSING);
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.EXPECTED_EXPRESSION);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/LogicalAssignExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/LogicalAssignExpressionTests.java
@@ -27,7 +27,6 @@ import org.dockbox.hartshorn.hsl.token.type.TokenType;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -37,6 +36,9 @@ import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
 import java.util.List;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class LogicalAssignExpressionTests {
@@ -64,12 +66,10 @@ public class LogicalAssignExpressionTests {
             .toList();
         DefaultTokenRegistry.createDefault()
             .tokenTypes(token -> token.assignsWith() != null)
-            .forEach(tokenType -> {
-                Assertions.assertTrue(coveredTokenTypes.contains(tokenType),
-                    "Token type %s is not covered by tests".formatted(
-                        tokenType.representation()
-                    ));
-            });
+            .forEach(tokenType ->
+            assertThat(coveredTokenTypes.contains(tokenType)).as("Token type %s is not covered by tests".formatted(
+                tokenType.representation()
+            )).isTrue());
     }
 
     @ParameterizedTest
@@ -79,17 +79,16 @@ public class LogicalAssignExpressionTests {
                 this.applicationContext,
                 "a %s 1".formatted(tokenType.representation())
             )
-            .parser(parser -> {
-                parser.expressionParser(new LogicalAssignExpressionParser(parser.tokenRegistry()));
-            })
+            .parser(parser ->
+                parser.expressionParser(new LogicalAssignExpressionParser(parser.tokenRegistry())))
             .expressionParser(new IdentifierExpressionParser())
             .expressionParser(new LiteralExpressionParser())
             .defineLocal("a", 0b101)
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals(result, value);
-        Assertions.assertEquals(result, helper.findVariable("a"));
+        assertThat(value).isEqualTo(result);
+        assertThat(helper.findVariable("a")).isEqualTo(result);
     }
 
     @ParameterizedTest
@@ -99,16 +98,12 @@ public class LogicalAssignExpressionTests {
                 this.applicationContext,
                 "1 %s 1".formatted(tokenType.representation())
             )
-            .parser(parser -> {
-                parser.expressionParser(new LogicalAssignExpressionParser(parser.tokenRegistry()));
-            })
+            .parser(parser ->
+                parser.expressionParser(new LogicalAssignExpressionParser(parser.tokenRegistry())))
             .expressionParser(new LiteralExpressionParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::expression
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::expression).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.INVALID_ASSIGNMENT_TARGET);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/LogicalExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/LogicalExpressionTests.java
@@ -21,13 +21,14 @@ import org.dockbox.hartshorn.hsl.parser.expression.LogicalExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class LogicalExpressionTests {
@@ -54,7 +55,7 @@ public class LogicalExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals(expected, value);
+        assertThat(value).isEqualTo(expected);
     }
 
     public static Stream<Arguments> logicalCases() {

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/PostfixExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/PostfixExpressionTests.java
@@ -24,13 +24,15 @@ import org.dockbox.hartshorn.hsl.runtime.FormattedDiagnostic;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class PostfixExpressionTests {
+class PostfixExpressionTests {
 
     @Test
     void postFixIncrementYieldsOriginalValueAndIncrementsVariable(
@@ -44,10 +46,10 @@ public class PostfixExpressionTests {
 
         Object expressionResult = helper.interpretValue();
         // Note that the result is expected to be int 5, rather than double 5.0
-        Assertions.assertEquals(5, expressionResult);
+        assertThat(expressionResult).isEqualTo(5);
 
         Object variableValue = helper.findVariable("a");
-        Assertions.assertEquals(6d, variableValue);
+        assertThat(variableValue).isEqualTo(6d);
     }
 
     @Test
@@ -59,10 +61,7 @@ public class PostfixExpressionTests {
             .defineLocal("a", actual)
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpretValue
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpretValue).actual();
         ScriptAssertions.assertEvaluationError(
             error,
             FormattedDiagnostic.of(DiagnosticMessage.NON_NUMBER_OPERAND, actual)
@@ -81,10 +80,10 @@ public class PostfixExpressionTests {
 
         Object expressionResult = helper.interpretValue();
         // Note that the result is expected to be int 5, rather than double 5.0
-        Assertions.assertEquals(5, expressionResult);
+        assertThat(expressionResult).isEqualTo(5);
 
         Object variableValue = helper.findVariable("a");
-        Assertions.assertEquals(4d, variableValue);
+        assertThat(variableValue).isEqualTo(4d);
     }
 
     @Test
@@ -96,10 +95,7 @@ public class PostfixExpressionTests {
             .defineLocal("a", actual)
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpretValue
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpretValue).actual();
         ScriptAssertions.assertEvaluationError(
             error,
             FormattedDiagnostic.of(DiagnosticMessage.NON_NUMBER_OPERAND, actual)

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/PrefixExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/PrefixExpressionTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.ast.expression;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.ScriptEvaluationError;
 import org.dockbox.hartshorn.hsl.objects.CallableNode;
 import org.dockbox.hartshorn.hsl.parser.expression.FunctionParserContext;
@@ -27,13 +28,15 @@ import org.dockbox.hartshorn.hsl.runtime.Phase;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
+import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 @HartshornIntegrationTest(includeBasePackages = false)
-public class PrefixExpressionTests {
+class PrefixExpressionTests {
 
     @Test
     void prefixExpressionWithDefinitionAndImplementationPasses(
@@ -49,14 +52,13 @@ public class PrefixExpressionTests {
                 parser.addContext(functionParserContext);
             })
             // Prefix function implementation
-            .defineLocal("not", (CallableNode) (at, interpreter, instance, arguments) -> {
-                return !((Boolean) arguments.getFirst());
-            })
+            .defineLocal("not", (CallableNode) (at, interpreter, instance, arguments) -> !((Boolean) arguments.getFirst()))
             .build();
 
         Object value = helper.interpretValue();
-        boolean result = Assertions.assertInstanceOf(Boolean.class, value);
-        Assertions.assertFalse(result);
+        assertThat(value)
+                .asInstanceOf(InstanceOfAssertFactories.BOOLEAN)
+                .isFalse();
     }
 
     @Test
@@ -72,11 +74,8 @@ public class PrefixExpressionTests {
             })
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::expression
-        );
-        Assertions.assertEquals(Phase.PARSING, error.phase());
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::expression).actual();
+        assertThat(error.phase()).isEqualTo(Phase.PARSING);
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.EXPECTED_EXPRESSION);
     }
 
@@ -94,13 +93,10 @@ public class PrefixExpressionTests {
             })
             .build();
 
-        Assertions.assertDoesNotThrow(helper::parse);
+        helper.parse();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpretValue
-        );
-        Assertions.assertEquals(Phase.INTERPRETING, error.phase());
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpretValue).actual();
+        assertThat(error.phase()).isEqualTo(Phase.INTERPRETING);
         ScriptAssertions.assertEvaluationError(
             error,
             FormattedDiagnostic.of(DiagnosticMessage.UNDEFINED_VARIABLE, "not")
@@ -121,11 +117,8 @@ public class PrefixExpressionTests {
             })
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::expression
-        );
-        Assertions.assertEquals(Phase.PARSING, error.phase());
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::expression).actual();
+        assertThat(error.phase()).isEqualTo(Phase.PARSING);
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.EXPECTED_EXPRESSION);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/RangeExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/RangeExpressionTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.ast.expression;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.interpreter.Array;
 import org.dockbox.hartshorn.hsl.parser.expression.IdentifierExpressionParser;
 import org.dockbox.hartshorn.hsl.parser.expression.LiteralExpressionParser;
@@ -23,12 +24,13 @@ import org.dockbox.hartshorn.hsl.parser.expression.RangeExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class RangeExpressionTests {
+class RangeExpressionTests {
 
     @Test
     void rangeYieldsLeftRightInclusiveArray(@Inject ApplicationContext applicationContext) {
@@ -38,11 +40,10 @@ public class RangeExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Array array = Assertions.assertInstanceOf(Array.class, value);
-        Assertions.assertArrayEquals(
-            new Double[] {1d, 2d, 3d, 4d, 5d},
-            array.values()
-        );
+        Array array = assertThat(value)
+                .asInstanceOf(InstanceOfAssertFactories.type(Array.class))
+                .actual();
+        assertThat(array.values()).containsExactly(new Double[]{1d, 2d, 3d, 4d, 5d});
     }
 
     @Test
@@ -53,11 +54,10 @@ public class RangeExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Array array = Assertions.assertInstanceOf(Array.class, value);
-        Assertions.assertArrayEquals(
-            new Double[] {2d},
-            array.values()
-        );
+        Array array = assertThat(value)
+                .asInstanceOf(InstanceOfAssertFactories.type(Array.class))
+                .actual();
+        assertThat(array.values()).containsExactly(new Double[]{2d});
     }
 
     @Test
@@ -71,10 +71,9 @@ public class RangeExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Array array = Assertions.assertInstanceOf(Array.class, value);
-        Assertions.assertArrayEquals(
-            new Double[] {1d, 2d, 3d, 4d, 5d},
-            array.values()
-        );
+        Array array = assertThat(value)
+                .asInstanceOf(InstanceOfAssertFactories.type(Array.class))
+                .actual();
+        assertThat(array.values()).containsExactly(new Double[]{1d, 2d, 3d, 4d, 5d});
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/SuperExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/SuperExpressionTests.java
@@ -28,13 +28,14 @@ import org.dockbox.hartshorn.hsl.semantic.ClassType;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class SuperExpressionTests {
+class SuperExpressionTests {
 
     @Test
     void superMethodCanBeAccessedWithCurrentInstance(
@@ -78,7 +79,7 @@ public class SuperExpressionTests {
         Object value = helper.interpretOnly()
             .captures()
             .capturedValue();
-        Assertions.assertSame(methodReference, value);
-        Assertions.assertSame(instanceReference, methodReference.bound());
+        assertThat(value).isSameAs(methodReference);
+        assertThat(methodReference.bound()).isSameAs(instanceReference);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/TernaryExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/TernaryExpressionTests.java
@@ -21,12 +21,13 @@ import org.dockbox.hartshorn.hsl.parser.expression.TernaryExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class TernaryExpressionTests {
+class TernaryExpressionTests {
 
     @Test
     void ternaryWithTruthyValueReturnsLeft(@Inject ApplicationContext applicationContext) {
@@ -36,7 +37,7 @@ public class TernaryExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals(42d, value);
+        assertThat(value).isEqualTo(42d);
     }
 
     @Test
@@ -47,6 +48,6 @@ public class TernaryExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals(24d, value);
+        assertThat(value).isEqualTo(24d);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/UnaryExpressionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/expression/UnaryExpressionTests.java
@@ -21,13 +21,14 @@ import org.dockbox.hartshorn.hsl.parser.expression.UnaryExpressionParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class UnaryExpressionTests {
@@ -54,7 +55,7 @@ public class UnaryExpressionTests {
             .build();
 
         Object value = helper.interpretValue();
-        Assertions.assertEquals(expected, value);
+        assertThat(value).isEqualTo(expected);
     }
 
     public static Stream<Arguments> logicalCases() {

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ClassStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ClassStatementInterpreterTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.ast.statement;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.customizer.CodeCustomizer;
 import org.dockbox.hartshorn.hsl.objects.ClassReference;
 import org.dockbox.hartshorn.hsl.objects.external.CompositeInstance;
@@ -31,12 +32,13 @@ import org.dockbox.hartshorn.hsl.runtime.Phase;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ClassStatementInterpreterTests {
+class ClassStatementInterpreterTests {
 
     @Inject
     private ApplicationContext applicationContext;
@@ -58,19 +60,20 @@ public class ClassStatementInterpreterTests {
         helper.interpret();
 
         Object classVariable = helper.findVariable("Person");
-        VirtualClass virtualClass = Assertions.assertInstanceOf(VirtualClass.class, classVariable);
-        Assertions.assertNull(virtualClass.superClass());
-        Assertions.assertFalse(virtualClass.isDynamic());
+        VirtualClass virtualClass = assertThat(classVariable)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualClass.class))
+                .actual();
+        assertThat(virtualClass.superClass()).isNull();
+        assertThat(virtualClass.isDynamic()).isFalse();
 
         VirtualProperty name = virtualClass.property("name");
-        Assertions.assertNotNull(name);
+        assertThat(name).isNotNull();
 
         Object instance = helper.captures().capturedValue();
-        VirtualInstance virtualInstance = Assertions.assertInstanceOf(
-            VirtualInstance.class,
-            instance
-        );
-        Assertions.assertEquals(virtualClass, virtualInstance.virtualClass());
+        VirtualInstance virtualInstance = assertThat(instance)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualInstance.class))
+                .actual();
+        assertThat(virtualInstance.virtualClass()).isEqualTo(virtualClass);
     }
 
     @Test
@@ -90,19 +93,20 @@ public class ClassStatementInterpreterTests {
         helper.interpret();
 
         Object classVariable = helper.findVariable("Person");
-        VirtualClass virtualClass = Assertions.assertInstanceOf(VirtualClass.class, classVariable);
-        Assertions.assertNull(virtualClass.superClass());
-        Assertions.assertTrue(virtualClass.isDynamic());
+        VirtualClass virtualClass = assertThat(classVariable)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualClass.class))
+                .actual();
+        assertThat(virtualClass.superClass()).isNull();
+        assertThat(virtualClass.isDynamic()).isTrue();
 
         VirtualProperty name = virtualClass.property("name");
-        Assertions.assertNotNull(name);
+        assertThat(name).isNotNull();
 
         Object instance = helper.captures().capturedValue();
-        VirtualInstance virtualInstance = Assertions.assertInstanceOf(
-            VirtualInstance.class,
-            instance
-        );
-        Assertions.assertEquals(virtualClass, virtualInstance.virtualClass());
+        VirtualInstance virtualInstance = assertThat(instance)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualInstance.class))
+                .actual();
+        assertThat(virtualInstance.virtualClass()).isEqualTo(virtualClass);
     }
 
     @Test
@@ -125,31 +129,33 @@ public class ClassStatementInterpreterTests {
         helper.interpret();
 
         Object classVariable = helper.findVariable("Person");
-        VirtualClass virtualClass = Assertions.assertInstanceOf(VirtualClass.class, classVariable);
-        Assertions.assertFalse(virtualClass.isDynamic());
+        VirtualClass virtualClass = assertThat(classVariable)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualClass.class))
+                .actual();
+        assertThat(virtualClass.isDynamic()).isFalse();
 
         VirtualProperty name = virtualClass.property("name");
-        Assertions.assertNotNull(name);
+        assertThat(name).isNotNull();
 
         ClassReference superClass = virtualClass.superClass();
-        Assertions.assertNotNull(superClass);
-        Assertions.assertEquals("LivingThing", superClass.name());
+        assertThat(superClass).isNotNull();
+        assertThat(superClass.name()).isEqualTo("LivingThing");
 
-        VirtualClass virtualSuperClass =
-            Assertions.assertInstanceOf(VirtualClass.class, superClass);
+        VirtualClass virtualSuperClass = assertThat(superClass)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualClass.class))
+                .actual();
         VirtualProperty age = virtualSuperClass.property("age");
-        Assertions.assertNotNull(age);
+        assertThat(age).isNotNull();
 
         VirtualProperty childAge = virtualClass.property("age");
         // No override, so definition remains in super class
-        Assertions.assertNull(childAge);
+        assertThat(childAge).isNull();
 
         Object instance = helper.captures().capturedValue();
-        VirtualInstance virtualInstance = Assertions.assertInstanceOf(
-            VirtualInstance.class,
-            instance
-        );
-        Assertions.assertEquals(virtualClass, virtualInstance.virtualClass());
+        VirtualInstance virtualInstance = assertThat(instance)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualInstance.class))
+                .actual();
+        assertThat(virtualInstance.virtualClass()).isEqualTo(virtualClass);
     }
 
     static class ExternalThing {
@@ -176,26 +182,28 @@ public class ClassStatementInterpreterTests {
         helper.interpret();
 
         Object classVariable = helper.findVariable("Person");
-        VirtualClass virtualClass = Assertions.assertInstanceOf(VirtualClass.class, classVariable);
-        Assertions.assertFalse(virtualClass.isDynamic());
+        VirtualClass virtualClass = assertThat(classVariable)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualClass.class))
+                .actual();
+        assertThat(virtualClass.isDynamic()).isFalse();
 
         VirtualProperty name = virtualClass.property("name");
-        Assertions.assertNotNull(name);
+        assertThat(name).isNotNull();
 
         ClassReference superClass = virtualClass.superClass();
-        ExternalClass<?> externalClass =
-            Assertions.assertInstanceOf(ExternalClass.class, superClass);
-        Assertions.assertEquals("ExternalThing", externalClass.name());
-        Assertions.assertTrue(externalClass.type().is(ExternalThing.class));
+        ExternalClass<?> externalClass = assertThat(superClass)
+                .asInstanceOf(InstanceOfAssertFactories.type(ExternalClass.class))
+                .actual();
+        assertThat(externalClass.name()).isEqualTo("ExternalThing");
+        assertThat(externalClass.type().is(ExternalThing.class)).isTrue();
 
         Object instance = helper.captures().capturedValue();
-        CompositeInstance<?> compositeInstance = Assertions.assertInstanceOf(
-            CompositeInstance.class,
-            instance
-        );
-        Assertions.assertEquals(virtualClass, compositeInstance.virtualClass());
+        CompositeInstance<?> compositeInstance = assertThat(instance)
+                .asInstanceOf(InstanceOfAssertFactories.type(CompositeInstance.class))
+                .actual();
+        assertThat(compositeInstance.virtualClass()).isEqualTo(virtualClass);
 
         Object externalObject = compositeInstance.externalObject();
-        Assertions.assertInstanceOf(ExternalThing.class, externalObject);
+        assertThat(externalObject).isInstanceOf(ExternalThing.class);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ConstructorStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ConstructorStatementInterpreterTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.ast.statement;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.ScriptEvaluationError;
 import org.dockbox.hartshorn.hsl.customizer.CodeCustomizer;
 import org.dockbox.hartshorn.hsl.objects.virtual.VirtualFunction;
@@ -28,13 +29,15 @@ import org.dockbox.hartshorn.hsl.token.type.FunctionTokenType;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ConstructorStatementInterpreterTests {
+class ConstructorStatementInterpreterTests {
 
     @Test
     void constructorDefinesInitializer(@Inject ApplicationContext applicationContext) {
@@ -43,19 +46,17 @@ public class ConstructorStatementInterpreterTests {
                 """)
             .statementParser(new ConstructorStatementParser())
             .statementParser(new BlockStatementParser())
-            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context -> {
-                context.resolver().currentClassType(ClassType.CLASS);
-            }))
+            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context ->
+                context.resolver().currentClassType(ClassType.CLASS)))
             .build();
 
         helper.interpret();
 
         Object constructor = helper.findVariable(FunctionTokenType.CONSTRUCTOR.defaultLexeme());
-        VirtualFunction virtualFunction = Assertions.assertInstanceOf(
-            VirtualFunction.class,
-            constructor
-        );
-        Assertions.assertTrue(virtualFunction.isInitializer());
+        VirtualFunction virtualFunction = assertThat(constructor)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualFunction.class))
+                .actual();
+        assertThat(virtualFunction.isInitializer()).isTrue();
     }
 
     @Test
@@ -67,10 +68,7 @@ public class ConstructorStatementInterpreterTests {
             .statementParser(new BlockStatementParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.CONSTRUCTOR_OUTSIDE_CLASS);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/DoWhileStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/DoWhileStatementInterpreterTests.java
@@ -25,12 +25,13 @@ import org.dockbox.hartshorn.hsl.parser.statement.DoWhileStatementParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class DoWhileStatementInterpreterTests {
+class DoWhileStatementInterpreterTests {
 
     @Test
     void doWhileWithFalseExpressionExecutesOnce(@Inject ApplicationContext applicationContext) {
@@ -45,8 +46,8 @@ public class DoWhileStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertTrue(helper.checkpoints().checkpointAccessed("inside-do-while"));
-        Assertions.assertEquals(1, helper.checkpoints().checkpointAccessCount("inside-do-while"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-do-while")).isTrue();
+        assertThat(helper.checkpoints().checkpointAccessCount("inside-do-while")).isOne();
     }
 
     @Test
@@ -68,6 +69,6 @@ public class DoWhileStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertEquals(3, helper.checkpoints().checkpointAccessCount("inside-do-while"));
+        assertThat(helper.checkpoints().checkpointAccessCount("inside-do-while")).isEqualTo(3);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/FieldStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/FieldStatementInterpreterTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.ast.statement;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.objects.virtual.VirtualInstance;
 import org.dockbox.hartshorn.hsl.parser.expression.CallExpressionParser;
 import org.dockbox.hartshorn.hsl.parser.expression.IdentifierExpressionParser;
@@ -28,7 +29,6 @@ import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.StringUtilities;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -36,6 +36,8 @@ import test.org.dockbox.hartshorn.hsl.support.CaptureModule;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class FieldStatementInterpreterTests {
@@ -94,7 +96,9 @@ public class FieldStatementInterpreterTests {
 
     private static void assertFieldInitialized(HSLTestHelper helper, Object expected) {
         Object value = helper.captures().capturedValue();
-        VirtualInstance instance = Assertions.assertInstanceOf(VirtualInstance.class, value);
+        VirtualInstance instance = assertThat(value)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualInstance.class))
+                .actual();
         Token ageToken = Token.of(LiteralTokenType.IDENTIFIER)
             .lexeme("age")
             .build();
@@ -104,6 +108,6 @@ public class FieldStatementInterpreterTests {
             // Class scope, to ensure private fields are accessible
             instance.virtualClass().variableScope()
         );
-        Assertions.assertEquals(expected, age);
+        assertThat(age).isEqualTo(expected);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ForEachStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ForEachStatementInterpreterTests.java
@@ -26,7 +26,6 @@ import org.dockbox.hartshorn.hsl.runtime.DiagnosticMessage;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -37,6 +36,9 @@ import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
 import java.util.List;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class ForEachStatementInterpreterTests {
@@ -72,10 +74,10 @@ public class ForEachStatementInterpreterTests {
         helper.interpret();
 
         CheckpointModule checkpoints = helper.checkpoints();
-        Assertions.assertEquals(3, checkpoints.checkpoints().size());
-        Assertions.assertTrue(checkpoints.checkpointAccessed("a"));
-        Assertions.assertTrue(checkpoints.checkpointAccessed("b"));
-        Assertions.assertTrue(checkpoints.checkpointAccessed("c"));
+        assertThat(checkpoints.checkpoints()).hasSize(3);
+        assertThat(checkpoints.checkpointAccessed("a")).isTrue();
+        assertThat(checkpoints.checkpointAccessed("b")).isTrue();
+        assertThat(checkpoints.checkpointAccessed("c")).isTrue();
     }
 
     @Test
@@ -92,10 +94,7 @@ public class ForEachStatementInterpreterTests {
             .defineGlobal("items", "not an iterable")
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.NON_ITERABLE_COLLECTION);
     }
 
@@ -116,6 +115,6 @@ public class ForEachStatementInterpreterTests {
         helper.interpret();
 
         CheckpointModule checkpoints = helper.checkpoints();
-        Assertions.assertEquals(0, checkpoints.checkpoints().size());
+        assertThat(checkpoints.checkpoints()).isEmpty();
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ForStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ForStatementInterpreterTests.java
@@ -26,12 +26,13 @@ import org.dockbox.hartshorn.hsl.parser.statement.VariableDeclarationParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ForStatementInterpreterTests {
+class ForStatementInterpreterTests {
 
     @Test
     void forLoopWithFalseConditionNeverExecutes(@Inject ApplicationContext applicationContext) {
@@ -49,7 +50,7 @@ public class ForStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertFalse(helper.checkpoints().checkpointAccessed("inside-for-loop"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-for-loop")).isFalse();
     }
 
     @Test
@@ -69,7 +70,7 @@ public class ForStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertTrue(helper.checkpoints().checkpointAccessed("inside-for-loop"));
-        Assertions.assertEquals(3, helper.checkpoints().checkpointAccessCount("inside-for-loop"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-for-loop")).isTrue();
+        assertThat(helper.checkpoints().checkpointAccessCount("inside-for-loop")).isEqualTo(3);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/FunctionStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/FunctionStatementInterpreterTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.ast.statement;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.ScriptEvaluationError;
 import org.dockbox.hartshorn.hsl.ast.statement.FunctionStatement;
 import org.dockbox.hartshorn.hsl.ast.statement.ReturnStatement;
@@ -30,13 +31,15 @@ import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class FunctionStatementInterpreterTests {
+class FunctionStatementInterpreterTests {
 
     @Test
     void regularFunctionWithoutExplicitReturnDeclarationIsDefined(
@@ -50,16 +53,17 @@ public class FunctionStatementInterpreterTests {
         helper.interpret();
 
         Object greet = helper.findVariable("greet");
-        VirtualFunction greetFunction = Assertions.assertInstanceOf(VirtualFunction.class, greet);
-        Assertions.assertEquals(ReturnStatement.ReturnType.RETURN, greetFunction.returnType());
+        VirtualFunction greetFunction = assertThat(greet)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualFunction.class))
+                .actual();
+        assertThat(greetFunction.returnType()).isEqualTo(ReturnStatement.ReturnType.RETURN);
 
-        FunctionStatement functionStatement = Assertions.assertInstanceOf(
-            FunctionStatement.class,
-            greetFunction.declaration()
-        );
-        Assertions.assertEquals("greet", functionStatement.name().lexeme());
-        Assertions.assertEquals(1, functionStatement.parameters().size());
-        Assertions.assertEquals("name", functionStatement.parameters().getFirst().name().lexeme());
+        FunctionStatement functionStatement = assertThat(greetFunction.declaration())
+                .asInstanceOf(InstanceOfAssertFactories.type(FunctionStatement.class))
+                .actual();
+        assertThat(functionStatement.name().lexeme()).isEqualTo("greet");
+        assertThat(functionStatement.parameters()).hasSize(1);
+        assertThat(functionStatement.parameters().getFirst().name().lexeme()).isEqualTo("name");
     }
 
     @Test
@@ -79,16 +83,17 @@ public class FunctionStatementInterpreterTests {
         helper.interpret();
 
         Object greet = helper.findVariable("greet");
-        VirtualFunction greetFunction = Assertions.assertInstanceOf(VirtualFunction.class, greet);
-        Assertions.assertEquals(ReturnStatement.ReturnType.RETURN, greetFunction.returnType());
+        VirtualFunction greetFunction = assertThat(greet)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualFunction.class))
+                .actual();
+        assertThat(greetFunction.returnType()).isEqualTo(ReturnStatement.ReturnType.RETURN);
 
-        FunctionStatement functionStatement = Assertions.assertInstanceOf(
-            FunctionStatement.class,
-            greetFunction.declaration()
-        );
-        Assertions.assertEquals("greet", functionStatement.name().lexeme());
-        Assertions.assertEquals(1, functionStatement.parameters().size());
-        Assertions.assertEquals("name", functionStatement.parameters().getFirst().name().lexeme());
+        FunctionStatement functionStatement = assertThat(greetFunction.declaration())
+                .asInstanceOf(InstanceOfAssertFactories.type(FunctionStatement.class))
+                .actual();
+        assertThat(functionStatement.name().lexeme()).isEqualTo("greet");
+        assertThat(functionStatement.parameters()).hasSize(1);
+        assertThat(functionStatement.parameters().getFirst().name().lexeme()).isEqualTo("name");
     }
 
     @Test
@@ -104,21 +109,22 @@ public class FunctionStatementInterpreterTests {
         helper.interpret();
 
         Object greet = helper.findVariable("greet");
-        VirtualFunction greetFunction = Assertions.assertInstanceOf(VirtualFunction.class, greet);
-        Assertions.assertEquals(ReturnStatement.ReturnType.RETURN, greetFunction.returnType());
-        FunctionStatement functionStatement = Assertions.assertInstanceOf(
-            FunctionStatement.class,
-            greetFunction.declaration()
-        );
-        Assertions.assertEquals("greet", functionStatement.name().lexeme());
-        Assertions.assertEquals(1, functionStatement.parameters().size());
-        Assertions.assertEquals("name", functionStatement.parameters().getFirst().name().lexeme());
+        VirtualFunction greetFunction = assertThat(greet)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualFunction.class))
+                .actual();
+        assertThat(greetFunction.returnType()).isEqualTo(ReturnStatement.ReturnType.RETURN);
+        FunctionStatement functionStatement = assertThat(greetFunction.declaration())
+                .asInstanceOf(InstanceOfAssertFactories.type(FunctionStatement.class))
+                .actual();
+        assertThat(functionStatement.name().lexeme()).isEqualTo("greet");
+        assertThat(functionStatement.parameters()).hasSize(1);
+        assertThat(functionStatement.parameters().getFirst().name().lexeme()).isEqualTo("name");
 
         Option<FunctionParserContext> functionParserContext = helper.context().parser()
             .firstContext(FunctionParserContext.class);
-        Assertions.assertTrue(functionParserContext.present());
+        assertThat(functionParserContext.present()).isTrue();
         FunctionParserContext context = functionParserContext.get();
-        Assertions.assertTrue(context.prefixFunctions().contains("greet"));
+        assertThat(context.prefixFunctions()).contains("greet");
     }
 
     @Test
@@ -133,10 +139,7 @@ public class FunctionStatementInterpreterTests {
             .statementParser(new BlockStatementParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.TOO_MANY_PARAMETERS_FOR_X);
     }
 
@@ -152,10 +155,7 @@ public class FunctionStatementInterpreterTests {
             .statementParser(new BlockStatementParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpret).actual();
         ScriptAssertions.assertEvaluationError(error,
             DiagnosticMessage.NOT_ENOUGH_PARAMETERS_FOR_X);
     }
@@ -172,23 +172,23 @@ public class FunctionStatementInterpreterTests {
         helper.interpret();
 
         Object combine = helper.findVariable("combine");
-        VirtualFunction combineFunction =
-            Assertions.assertInstanceOf(VirtualFunction.class, combine);
-        Assertions.assertEquals(ReturnStatement.ReturnType.RETURN, combineFunction.returnType());
-        FunctionStatement functionStatement = Assertions.assertInstanceOf(
-            FunctionStatement.class,
-            combineFunction.declaration()
-        );
-        Assertions.assertEquals("combine", functionStatement.name().lexeme());
-        Assertions.assertEquals(2, functionStatement.parameters().size());
-        Assertions.assertEquals("a", functionStatement.parameters().getFirst().name().lexeme());
-        Assertions.assertEquals("b", functionStatement.parameters().getLast().name().lexeme());
+        VirtualFunction combineFunction = assertThat(combine)
+                .asInstanceOf(InstanceOfAssertFactories.type(VirtualFunction.class))
+                .actual();
+        assertThat(combineFunction.returnType()).isEqualTo(ReturnStatement.ReturnType.RETURN);
+        FunctionStatement functionStatement = assertThat(combineFunction.declaration())
+                .asInstanceOf(InstanceOfAssertFactories.type(FunctionStatement.class))
+                .actual();
+        assertThat(functionStatement.name().lexeme()).isEqualTo("combine");
+        assertThat(functionStatement.parameters()).hasSize(2);
+        assertThat(functionStatement.parameters().getFirst().name().lexeme()).isEqualTo("a");
+        assertThat(functionStatement.parameters().getLast().name().lexeme()).isEqualTo("b");
 
         Option<FunctionParserContext> functionParserContext = helper.context().parser()
             .firstContext(FunctionParserContext.class);
-        Assertions.assertTrue(functionParserContext.present());
+        assertThat(functionParserContext.present()).isTrue();
         FunctionParserContext context = functionParserContext.get();
-        Assertions.assertTrue(context.infixFunctions().contains("combine"));
+        assertThat(context.infixFunctions()).contains("combine");
     }
 
     @Test
@@ -203,10 +203,7 @@ public class FunctionStatementInterpreterTests {
             .statementParser(new BlockStatementParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.TOO_MANY_PARAMETERS_FOR_X);
     }
 
@@ -222,10 +219,7 @@ public class FunctionStatementInterpreterTests {
             .statementParser(new BlockStatementParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpret).actual();
         ScriptAssertions.assertEvaluationError(error,
             DiagnosticMessage.NOT_ENOUGH_PARAMETERS_FOR_X);
     }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/IfStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/IfStatementInterpreterTests.java
@@ -22,18 +22,19 @@ import org.dockbox.hartshorn.hsl.parser.statement.IfStatementParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class IfStatementInterpreterTests {
+class IfStatementInterpreterTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
-    void testIfStatementEvaluatesIfConditionIsTrue() {
+    void ifStatementEvaluatesIfConditionIsTrue() {
         HSLTestHelper helper = HSLTestHelper.of(this.applicationContext, """
                 if (true) {
                     checkpoint("inside-true");
@@ -45,11 +46,11 @@ public class IfStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertTrue(helper.checkpoints().checkpointAccessed("inside-true"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-true")).isTrue();
     }
 
     @Test
-    void testIfStatementEvaluatesIfConditionIsTruthy() {
+    void ifStatementEvaluatesIfConditionIsTruthy() {
         HSLTestHelper helper = HSLTestHelper.of(this.applicationContext, """
                 if ("truthy-value") {
                     checkpoint("inside-true");
@@ -61,11 +62,11 @@ public class IfStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertTrue(helper.checkpoints().checkpointAccessed("inside-true"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-true")).isTrue();
     }
 
     @Test
-    void testIfStatementDoesNotEvaluateIfConditionIsFalse() {
+    void ifStatementDoesNotEvaluateIfConditionIsFalse() {
         HSLTestHelper helper = HSLTestHelper.of(this.applicationContext, """
                 if (false) {
                     checkpoint("inside-true");
@@ -77,11 +78,11 @@ public class IfStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertFalse(helper.checkpoints().checkpointAccessed("inside-true"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-true")).isFalse();
     }
 
     @Test
-    void testIfStatementDoesNotEvaluateIfConditionIsFalsy() {
+    void ifStatementDoesNotEvaluateIfConditionIsFalsy() {
         HSLTestHelper helper = HSLTestHelper.of(this.applicationContext, """
                 if (null) {
                     checkpoint("inside-true");
@@ -93,7 +94,7 @@ public class IfStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertFalse(helper.checkpoints().checkpointAccessed("inside-true"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-true")).isFalse();
     }
 
     @Test
@@ -112,8 +113,8 @@ public class IfStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertTrue(helper.checkpoints().checkpointAccessed("inside-true"));
-        Assertions.assertFalse(helper.checkpoints().checkpointAccessed("inside-false"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-true")).isTrue();
+        assertThat(helper.checkpoints().checkpointAccessed("inside-false")).isFalse();
     }
 
     @Test
@@ -132,8 +133,8 @@ public class IfStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertTrue(helper.checkpoints().checkpointAccessed("inside-true"));
-        Assertions.assertFalse(helper.checkpoints().checkpointAccessed("inside-false"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-true")).isTrue();
+        assertThat(helper.checkpoints().checkpointAccessed("inside-false")).isFalse();
     }
 
     @Test
@@ -152,8 +153,8 @@ public class IfStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertFalse(helper.checkpoints().checkpointAccessed("inside-true"));
-        Assertions.assertTrue(helper.checkpoints().checkpointAccessed("inside-false"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-true")).isFalse();
+        assertThat(helper.checkpoints().checkpointAccessed("inside-false")).isTrue();
     }
 
     @Test
@@ -172,7 +173,7 @@ public class IfStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertFalse(helper.checkpoints().checkpointAccessed("inside-true"));
-        Assertions.assertTrue(helper.checkpoints().checkpointAccessed("inside-false"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-true")).isFalse();
+        assertThat(helper.checkpoints().checkpointAccessed("inside-false")).isTrue();
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ModuleStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ModuleStatementInterpreterTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.ast.statement;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.ScriptEvaluationError;
 import org.dockbox.hartshorn.hsl.modules.AmbiguousNativeLibraryFunction;
 import org.dockbox.hartshorn.hsl.modules.NativeLibrary;
@@ -26,15 +27,17 @@ import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ModuleStatementInterpreterTests {
+class ModuleStatementInterpreterTests {
 
     @Test
     void moduleStatementImportsKnownModuleFunctions(@Inject ApplicationContext applicationContext) {
@@ -46,26 +49,26 @@ public class ModuleStatementInterpreterTests {
 
         // Non-ambiguous function
         Object cosFunction = helper.findVariable("cos");
-        NativeLibrary nativeCosFunction =
-            Assertions.assertInstanceOf(NativeLibrary.class, cosFunction);
+        NativeLibrary nativeCosFunction = assertThat(cosFunction)
+                .asInstanceOf(InstanceOfAssertFactories.type(NativeLibrary.class))
+                .actual();
         MethodView<?, ?> originalMethod = nativeCosFunction.declaration().method();
-        Assertions.assertTrue(originalMethod.declaredBy().is(Math.class));
-        Assertions.assertEquals("cos", originalMethod.name());
-        Assertions.assertTrue(originalMethod.parameters().matches(double.class));
+        assertThat(originalMethod.declaredBy().is(Math.class)).isTrue();
+        assertThat(originalMethod.name()).isEqualTo("cos");
+        assertThat(originalMethod.parameters().matches(double.class)).isTrue();
 
         // Ambiguous function (overloaded)
         Object maxFunction = helper.findVariable("max");
-        AmbiguousNativeLibraryFunction ambiguousMaxFunction = Assertions.assertInstanceOf(
-            AmbiguousNativeLibraryFunction.class,
-            maxFunction
-        );
+        AmbiguousNativeLibraryFunction ambiguousMaxFunction = assertThat(maxFunction)
+                .asInstanceOf(InstanceOfAssertFactories.type(AmbiguousNativeLibraryFunction.class))
+                .actual();
         Set<NativeLibrary> overloadFunctions = ambiguousMaxFunction.libraries();
         // Math.max has 4 overloads: (int, int), (long, long), (float, float), (double, double)
-        Assertions.assertEquals(4, overloadFunctions.size());
+        assertThat(overloadFunctions).hasSize(4);
         for (NativeLibrary overloadFunction : overloadFunctions) {
             MethodView<?, ?> overloadMethod = overloadFunction.declaration().method();
-            Assertions.assertTrue(overloadMethod.declaredBy().is(Math.class));
-            Assertions.assertEquals("max", overloadMethod.name());
+            assertThat(overloadMethod.declaredBy().is(Math.class)).isTrue();
+            assertThat(overloadMethod.name()).isEqualTo("max");
         }
     }
 
@@ -75,10 +78,7 @@ public class ModuleStatementInterpreterTests {
             .statementParser(new ModuleStatementParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.MISSING_MODULE);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/NativeFunctionStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/NativeFunctionStatementInterpreterTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.ast.statement;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.modules.AmbiguousNativeLibraryFunction;
 import org.dockbox.hartshorn.hsl.modules.NativeLibrary;
 import org.dockbox.hartshorn.hsl.modules.UtilityClassNativeModule;
@@ -28,14 +29,15 @@ import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class NativeFunctionStatementInterpreterTests {
+class NativeFunctionStatementInterpreterTests {
 
     @Test
     void nativeFunctionImportsIndividualMethodFromModule(
@@ -53,15 +55,16 @@ public class NativeFunctionStatementInterpreterTests {
         helper.interpret();
 
         Object logFunction = helper.findVariable("log");
-        NativeLibrary nativeLogFunction =
-            Assertions.assertInstanceOf(NativeLibrary.class, logFunction);
+        NativeLibrary nativeLogFunction = assertThat(logFunction)
+                .asInstanceOf(InstanceOfAssertFactories.type(NativeLibrary.class))
+                .actual();
         MethodView<?, ?> originalMethod = nativeLogFunction.declaration().method();
-        Assertions.assertTrue(originalMethod.declaredBy().is(Math.class));
-        Assertions.assertEquals("log", originalMethod.name());
-        Assertions.assertTrue(originalMethod.parameters().matches(double.class));
+        assertThat(originalMethod.declaredBy().is(Math.class)).isTrue();
+        assertThat(originalMethod.name()).isEqualTo("log");
+        assertThat(originalMethod.parameters().matches(double.class)).isTrue();
 
         // Should not import other functions from the module
-        Assertions.assertNull(helper.findVariable("max"));
+        assertThat(helper.findVariable("max")).isNull();
     }
 
     @Test
@@ -81,17 +84,16 @@ public class NativeFunctionStatementInterpreterTests {
         helper.interpret();
 
         Object maxFunction = helper.findVariable("max");
-        AmbiguousNativeLibraryFunction ambiguousMaxFunction = Assertions.assertInstanceOf(
-            AmbiguousNativeLibraryFunction.class,
-            maxFunction
-        );
+        AmbiguousNativeLibraryFunction ambiguousMaxFunction = assertThat(maxFunction)
+                .asInstanceOf(InstanceOfAssertFactories.type(AmbiguousNativeLibraryFunction.class))
+                .actual();
         Set<NativeLibrary> overloadFunctions = ambiguousMaxFunction.libraries();
         // Math.max has 4 overloads: (int, int), (long, long), (float, float), (double, double)
-        Assertions.assertEquals(4, overloadFunctions.size());
+        assertThat(overloadFunctions).hasSize(4);
         for (NativeLibrary overloadFunction : overloadFunctions) {
             MethodView<?, ?> overloadMethod = overloadFunction.declaration().method();
-            Assertions.assertTrue(overloadMethod.declaredBy().is(Math.class));
-            Assertions.assertEquals("max", overloadMethod.name());
+            assertThat(overloadMethod.declaredBy().is(Math.class)).isTrue();
+            assertThat(overloadMethod.name()).isEqualTo("max");
         }
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/RepeatStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/RepeatStatementInterpreterTests.java
@@ -29,13 +29,15 @@ import org.dockbox.hartshorn.hsl.runtime.FormattedDiagnostic;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class RepeatStatementInterpreterTests {
+class RepeatStatementInterpreterTests {
 
     @Test
     void repeatWithNonZeroValueRepeatsExactlyNTimes(@Inject ApplicationContext applicationContext) {
@@ -56,7 +58,7 @@ public class RepeatStatementInterpreterTests {
         helper.interpret();
 
         Object counter = helper.findVariable("counter");
-        Assertions.assertEquals(3d, counter);
+        assertThat(counter).isEqualTo(3d);
     }
 
     @Test
@@ -68,10 +70,7 @@ public class RepeatStatementInterpreterTests {
             .expressionParser(new LiteralExpressionParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpret).actual();
         ScriptAssertions.assertEvaluationError(
             error,
             FormattedDiagnostic.of(DiagnosticMessage.ILLEGAL_NEGATIVE_NUMBER, -1d)
@@ -86,10 +85,7 @@ public class RepeatStatementInterpreterTests {
             .expressionParser(new LiteralExpressionParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpret).actual();
         ScriptAssertions.assertEvaluationError(
             error,
             FormattedDiagnostic.of(DiagnosticMessage.NON_NUMBER_OPERAND, (Object) null)

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ReturnStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/ReturnStatementInterpreterTests.java
@@ -29,13 +29,15 @@ import org.dockbox.hartshorn.hsl.token.type.ControlTokenType;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ReturnStatementInterpreterTests {
+class ReturnStatementInterpreterTests {
 
     @Inject
     private ApplicationContext applicationContext;
@@ -45,15 +47,14 @@ public class ReturnStatementInterpreterTests {
         HSLTestHelper helper = HSLTestHelper.of(this.applicationContext, "return 42")
             .statementParser(new ReturnStatementParser())
             .expressionParser(new LiteralExpressionParser())
-            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context -> {
+            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context ->
                 // Cannot return from top-level code, so we mark the current context
                 // as being inside a function
-                context.resolver().currentFunction(FunctionType.INLINE_FUNCTION);
-            }))
+                context.resolver().currentFunction(FunctionType.INLINE_FUNCTION)))
             .build();
 
-        Return returnCapture = Assertions.assertThrows(Return.class, helper::interpret);
-        Assertions.assertEquals(42d, returnCapture.value());
+        Return returnCapture = assertThatExceptionOfType(Return.class).isThrownBy(helper::interpret).actual();
+        assertThat(returnCapture.value()).isEqualTo(42d);
     }
 
     @Test
@@ -61,122 +62,85 @@ public class ReturnStatementInterpreterTests {
         HSLTestHelper helper = HSLTestHelper.of(this.applicationContext, "return 3.14")
             .statementParser(new ReturnStatementParser())
             .expressionParser(new LiteralExpressionParser())
-            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context -> {
+            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context ->
                 // Cannot return from top-level code, so we mark the current context
                 // as being inside a generator function
-                context.resolver().currentFunction(FunctionType.FIELD_MEMBER);
-            }))
+                context.resolver().currentFunction(FunctionType.FIELD_MEMBER)))
             .build();
 
-        Return returnCapture = Assertions.assertThrows(Return.class, helper::interpret);
-        Assertions.assertEquals(3.14d, returnCapture.value());
+        Return returnCapture = assertThatExceptionOfType(Return.class).isThrownBy(helper::interpret).actual();
+        assertThat(returnCapture.value()).isEqualTo(3.14d);
     }
 
     @Test
     void topLevelCodeCannotReturn() {
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            this.getBasicReturn(ControlTokenType.RETURN, FunctionType.NONE)::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(this.getBasicReturn(ControlTokenType.RETURN, FunctionType.NONE)::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.TOP_LEVEL_RETURN);
     }
 
     @Test
     void topLevelCodeCannotYield() {
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            this.getBasicReturn(ControlTokenType.YIELD, FunctionType.NONE)::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(this.getBasicReturn(ControlTokenType.YIELD, FunctionType.NONE)::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.TOP_LEVEL_RETURN);
     }
 
     @Test
     void inlineFunctionCanReturnWithExpression() {
-        Return returnCapture = Assertions.assertThrows(
-            Return.class,
-            this.getBasicReturn(ControlTokenType.RETURN, FunctionType.INLINE_FUNCTION)::interpret
-        );
-        Assertions.assertEquals(0d, returnCapture.value());
+        Return returnCapture = assertThatExceptionOfType(Return.class).isThrownBy(this.getBasicReturn(ControlTokenType.RETURN, FunctionType.INLINE_FUNCTION)::interpret).actual();
+        assertThat(returnCapture.value()).isEqualTo(0d);
     }
 
     @Test
     void inlineFunctionCannotYield() {
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            this.getBasicReturn(ControlTokenType.YIELD, FunctionType.INLINE_FUNCTION)::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(this.getBasicReturn(ControlTokenType.YIELD, FunctionType.INLINE_FUNCTION)::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.FUNCTION_YIELD);
     }
 
     @Test
     void classFunctionCanReturnWithExpression() {
-        Return returnCapture = Assertions.assertThrows(
-            Return.class,
-            this.getBasicReturn(ControlTokenType.RETURN, FunctionType.CLASS_FUNCTION)::interpret
-        );
-        Assertions.assertEquals(0d, returnCapture.value());
+        Return returnCapture = assertThatExceptionOfType(Return.class).isThrownBy(this.getBasicReturn(ControlTokenType.RETURN, FunctionType.CLASS_FUNCTION)::interpret).actual();
+        assertThat(returnCapture.value()).isEqualTo(0d);
     }
 
     @Test
     void classFunctionCannotYield() {
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            this.getBasicReturn(ControlTokenType.YIELD, FunctionType.CLASS_FUNCTION)::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(this.getBasicReturn(ControlTokenType.YIELD, FunctionType.CLASS_FUNCTION)::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.FUNCTION_YIELD);
     }
 
     @Test
-    void testFunctionCannotReturn() {
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            this.getBasicReturn(ControlTokenType.RETURN, FunctionType.TEST)::interpret
-        );
+    void functionCannotReturn() {
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(this.getBasicReturn(ControlTokenType.RETURN, FunctionType.TEST)::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.TEST_BLOCK_RETURN);
     }
 
     @Test
-    void testFunctionCanYieldWithExpression() {
-        Yield yieldCapture = Assertions.assertThrows(
-            Yield.class,
-            this.getBasicReturn(ControlTokenType.YIELD, FunctionType.TEST)::interpret
-        );
-        Assertions.assertEquals(0d, yieldCapture.value());
+    void functionCanYieldWithExpression() {
+        Yield yieldCapture = assertThatExceptionOfType(Yield.class).isThrownBy(this.getBasicReturn(ControlTokenType.YIELD, FunctionType.TEST)::interpret).actual();
+        assertThat(yieldCapture.value()).isEqualTo(0d);
     }
 
     @Test
     void fieldMemberCannotReturn() {
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            this.getBasicReturn(ControlTokenType.YIELD, FunctionType.FIELD_MEMBER)::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(this.getBasicReturn(ControlTokenType.YIELD, FunctionType.FIELD_MEMBER)::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.FIELD_MEMBER_YIELD);
     }
 
     @Test
     void fieldMemberCannotReturnWithExpression() {
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            this.getBasicReturn(ControlTokenType.YIELD, FunctionType.INITIALIZER)::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(this.getBasicReturn(ControlTokenType.YIELD, FunctionType.INITIALIZER)::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.INITIALIZER_RETURN);
     }
 
     @Test
     void initializerCanReturnWithExpression() {
-        Return returnCapture = Assertions.assertThrows(
-            Return.class,
-            this.getBasicReturn(ControlTokenType.RETURN, FunctionType.FIELD_MEMBER)::interpret
-        );
-        Assertions.assertEquals(0d, returnCapture.value());
+        Return returnCapture = assertThatExceptionOfType(Return.class).isThrownBy(this.getBasicReturn(ControlTokenType.RETURN, FunctionType.FIELD_MEMBER)::interpret).actual();
+        assertThat(returnCapture.value()).isEqualTo(0d);
     }
 
     @Test
     void initializerCannotYieldWithExpression() {
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            this.getBasicReturn(ControlTokenType.YIELD, FunctionType.INITIALIZER)::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(this.getBasicReturn(ControlTokenType.YIELD, FunctionType.INITIALIZER)::interpret).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.INITIALIZER_RETURN);
     }
 
@@ -185,15 +149,11 @@ public class ReturnStatementInterpreterTests {
         HSLTestHelper helper = HSLTestHelper.of(this.applicationContext, "return;")
             .statementParser(new ReturnStatementParser())
             .expressionParser(new LiteralExpressionParser())
-            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context -> {
-                context.resolver().currentFunction(FunctionType.INITIALIZER);
-            }))
+            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context ->
+                context.resolver().currentFunction(FunctionType.INITIALIZER)))
             .build();
-        Return returnCapture = Assertions.assertThrows(
-            Return.class,
-            helper::interpret
-        );
-        Assertions.assertNull(returnCapture.value());
+        Return returnCapture = assertThatExceptionOfType(Return.class).isThrownBy(helper::interpret).actual();
+        assertThat(returnCapture.value()).isNull();
     }
 
     @Test
@@ -201,15 +161,11 @@ public class ReturnStatementInterpreterTests {
         HSLTestHelper helper = HSLTestHelper.of(this.applicationContext, "yield;")
             .statementParser(new ReturnStatementParser())
             .expressionParser(new LiteralExpressionParser())
-            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context -> {
-                context.resolver().currentFunction(FunctionType.INITIALIZER);
-            }))
+            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context ->
+                context.resolver().currentFunction(FunctionType.INITIALIZER)))
             .build();
-        Yield yieldCapture = Assertions.assertThrows(
-            Yield.class,
-            helper::interpret
-        );
-        Assertions.assertNull(yieldCapture.value());
+        Yield yieldCapture = assertThatExceptionOfType(Yield.class).isThrownBy(helper::interpret).actual();
+        assertThat(yieldCapture.value()).isNull();
     }
 
     private HSLTestHelper getBasicReturn(ControlTokenType returnType, FunctionType functionType) {
@@ -217,9 +173,8 @@ public class ReturnStatementInterpreterTests {
                 "%s 0".formatted(returnType.representation()))
             .statementParser(new ReturnStatementParser())
             .expressionParser(new LiteralExpressionParser())
-            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context -> {
-                context.resolver().currentFunction(functionType);
-            }))
+            .customize(CodeCustomizer.of(Phase.SEMANTIC_ANALYSIS, context ->
+                context.resolver().currentFunction(functionType)))
             .build();
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/SwitchStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/SwitchStatementInterpreterTests.java
@@ -26,13 +26,15 @@ import org.dockbox.hartshorn.hsl.runtime.DiagnosticMessage;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class SwitchStatementInterpreterTests {
+class SwitchStatementInterpreterTests {
 
     @Test
     void defaultCaseMatchesIfNoCasesPresent(@Inject ApplicationContext applicationContext) {
@@ -52,7 +54,7 @@ public class SwitchStatementInterpreterTests {
 
         helper.interpret();
 
-        Assertions.assertTrue(helper.checkpoints().checkpointAccessed("default-case"));
+        assertThat(helper.checkpoints().checkpointAccessed("default-case")).isTrue();
     }
 
     @Test
@@ -76,8 +78,8 @@ public class SwitchStatementInterpreterTests {
 
         helper.interpret();
 
-        Assertions.assertTrue(helper.checkpoints().checkpointAccessed("matching-case"));
-        Assertions.assertFalse(helper.checkpoints().checkpointAccessed("default-case"));
+        assertThat(helper.checkpoints().checkpointAccessed("matching-case")).isTrue();
+        assertThat(helper.checkpoints().checkpointAccessed("default-case")).isFalse();
     }
 
     @Test
@@ -92,10 +94,7 @@ public class SwitchStatementInterpreterTests {
             .defineLocal("value", "some-value")
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::interpret
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::interpret).actual();
         ScriptAssertions.assertEvaluationError(
             error,
             DiagnosticMessage.SWITCH_MUST_HAVE_CASE_OR_DEFAULT

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/TestStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/TestStatementInterpreterTests.java
@@ -26,16 +26,18 @@ import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 import test.org.dockbox.hartshorn.hsl.support.ScriptAssertions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class TestStatementInterpreterTests {
+class TestStatementInterpreterTests {
 
     @Test
-    void testStatementWithYieldReturnsValue(@Inject ApplicationContext applicationContext) {
+    void statementWithYieldReturnsValue(@Inject ApplicationContext applicationContext) {
         HSLTestHelper helper = HSLTestHelper.of(applicationContext, """
                 test("explicit yield") {
                     yield true;
@@ -50,12 +52,12 @@ public class TestStatementInterpreterTests {
         helper.interpret();
 
         Option<?> explicitYield = helper.context().result("explicit yield");
-        Assertions.assertTrue(explicitYield.present());
-        Assertions.assertEquals(true, explicitYield.get());
+        assertThat(explicitYield.present()).isTrue();
+        assertThat(explicitYield.get()).isEqualTo(true);
     }
 
     @Test
-    void testStatementWithIncorrectReturnFailsParser(
+    void statementWithIncorrectReturnFailsParser(
         @Inject ApplicationContext applicationContext
     ) {
         HSLTestHelper helper = HSLTestHelper.of(applicationContext, """
@@ -69,16 +71,13 @@ public class TestStatementInterpreterTests {
             .expressionParser(new LiteralExpressionParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::parse
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::parse).actual();
         ScriptAssertions.assertEvaluationError(error,
             DiagnosticMessage.TEST_BODY_MUST_END_WITH_YIELD);
     }
 
     @Test
-    void testStatementWithoutYieldFailsParser(@Inject ApplicationContext applicationContext) {
+    void statementWithoutYieldFailsParser(@Inject ApplicationContext applicationContext) {
         HSLTestHelper helper = HSLTestHelper.of(applicationContext, """
                 test("implicit yield") {
                     true;
@@ -90,16 +89,13 @@ public class TestStatementInterpreterTests {
             .expressionParser(new LiteralExpressionParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::parse
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::parse).actual();
         ScriptAssertions.assertEvaluationError(error,
             DiagnosticMessage.TEST_BODY_MUST_END_WITH_YIELD);
     }
 
     @Test
-    void testStatementStatementsFailsParser(@Inject ApplicationContext applicationContext) {
+    void statementStatementsFailsParser(@Inject ApplicationContext applicationContext) {
         HSLTestHelper helper = HSLTestHelper.of(applicationContext, """
                 test("empty body") { }
                 """)
@@ -108,10 +104,7 @@ public class TestStatementInterpreterTests {
             .expressionParser(new LiteralExpressionParser())
             .build();
 
-        ScriptEvaluationError error = Assertions.assertThrows(
-            ScriptEvaluationError.class,
-            helper::parse
-        );
+        ScriptEvaluationError error = assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(helper::parse).actual();
         ScriptAssertions.assertEvaluationError(error, DiagnosticMessage.EMPTY_TEST_BODY);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/VariableStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/VariableStatementInterpreterTests.java
@@ -21,12 +21,13 @@ import org.dockbox.hartshorn.hsl.parser.statement.VariableDeclarationParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class VariableStatementInterpreterTests {
+class VariableStatementInterpreterTests {
 
     @Test
     void variableDeclarationWithInitializer(@Inject ApplicationContext applicationContext) {
@@ -37,7 +38,7 @@ public class VariableStatementInterpreterTests {
 
         helper.interpret();
         Object x = helper.findVariable("x");
-        Assertions.assertEquals(10d, x);
+        assertThat(x).isEqualTo(10d);
     }
 
     @Test
@@ -49,6 +50,6 @@ public class VariableStatementInterpreterTests {
 
         helper.interpret();
         Object y = helper.findVariable("y");
-        Assertions.assertNull(y);
+        assertThat(y).isNull();
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/WhileStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/WhileStatementInterpreterTests.java
@@ -25,15 +25,16 @@ import org.dockbox.hartshorn.hsl.parser.statement.WhileStatementParser;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import test.org.dockbox.hartshorn.hsl.support.HSLTestHelper;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class WhileStatementInterpreterTests {
+class WhileStatementInterpreterTests {
 
     @Test
     void whileWithFalseExpressionNeverExecutes(@Inject ApplicationContext applicationContext) {
@@ -48,7 +49,7 @@ public class WhileStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertFalse(helper.checkpoints().checkpointAccessed("inside-while"));
+        assertThat(helper.checkpoints().checkpointAccessed("inside-while")).isFalse();
     }
 
     @Test
@@ -71,6 +72,6 @@ public class WhileStatementInterpreterTests {
             .build();
 
         helper.interpret();
-        Assertions.assertEquals(3, helper.checkpoints().checkpointAccessCount("inside-while"));
+        assertThat(helper.checkpoints().checkpointAccessCount("inside-while")).isEqualTo(3);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/extension/AtNameModule.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/extension/AtNameModule.java
@@ -24,9 +24,10 @@ import org.dockbox.hartshorn.hsl.token.SimpleTokenCharacter;
 import org.dockbox.hartshorn.hsl.token.type.SimpleTokenType;
 import org.dockbox.hartshorn.hsl.token.type.TokenType;
 import org.dockbox.hartshorn.hsl.visitors.ExpressionVisitor;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.fail;
 
 public class AtNameModule implements ExpressionModule<AtNameExpression> {
 
@@ -72,6 +73,6 @@ public class AtNameModule implements ExpressionModule<AtNameExpression> {
         // Other visitors should not be in the default runtime, so we fail the test if
         // one is encountered. In regular implementations this method should be overridden
         // to handle visitor delegation.
-        return Assertions.fail("Expression should not be visited by default runtime");
+        return fail("Expression should not be visited by default runtime");
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/extension/LanguageExtensionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/extension/LanguageExtensionTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.extension;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.ExpressionScript;
 import org.dockbox.hartshorn.hsl.UseExpressionValidation;
 import org.dockbox.hartshorn.hsl.ast.expression.BinaryExpression;
@@ -30,20 +31,21 @@ import org.dockbox.hartshorn.hsl.runtime.ValidateExpressionRuntime;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest
 @UseExpressionValidation
-public class LanguageExtensionTests {
+class LanguageExtensionTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
-    void testLanguageExtensionCanInject() {
+    void languageExtensionCanInject() {
         ExpressionScript script = ExpressionScript.of(
             this.applicationContext,
             "(@hello == \"hello\") && (@world == \"world\")"
@@ -54,19 +56,21 @@ public class LanguageExtensionTests {
         customizer.expressionModules(module);
         script.runtime().customizer(customizer);
 
-        Assertions.assertTrue(script.valid());
-        Assertions.assertTrue(module.resolverAccessed());
+        assertThat(script.valid()).isTrue();
+        assertThat(module.resolverAccessed()).isTrue();
 
         List<Statement> statements = ValidateExpressionRuntime.actualStatements(script);
-        Assertions.assertEquals(1, statements.size());
+        assertThat(statements).hasSize(1);
 
         Statement statement = statements.getFirst();
-        ReturnStatement returnStatement =
-            Assertions.assertInstanceOf(ReturnStatement.class, statement);
+        ReturnStatement returnStatement = assertThat(statement)
+                .asInstanceOf(InstanceOfAssertFactories.type(ReturnStatement.class))
+                .actual();
         Expression expression = returnStatement.expression();
 
-        LogicalExpression logicalExpression =
-            Assertions.assertInstanceOf(LogicalExpression.class, expression);
+        LogicalExpression logicalExpression = assertThat(expression)
+                .asInstanceOf(InstanceOfAssertFactories.type(LogicalExpression.class))
+                .actual();
         Expression helloExpression = logicalExpression.leftExpression();
         Expression worldExpression = logicalExpression.rightExpression();
 
@@ -75,15 +79,17 @@ public class LanguageExtensionTests {
     }
 
     private static void assertExpressionContainsAtName(Expression expression) {
-        GroupingExpression groupingExpression =
-            Assertions.assertInstanceOf(GroupingExpression.class, expression);
-        BinaryExpression binaryExpression =
-            Assertions.assertInstanceOf(BinaryExpression.class, groupingExpression.expression());
+        GroupingExpression groupingExpression = assertThat(expression)
+                .asInstanceOf(InstanceOfAssertFactories.type(GroupingExpression.class))
+                .actual();
+        BinaryExpression binaryExpression = assertThat(groupingExpression.expression())
+                .asInstanceOf(InstanceOfAssertFactories.type(BinaryExpression.class))
+                .actual();
 
         Expression leftExpression = binaryExpression.leftExpression();
         Expression rightExpression = binaryExpression.rightExpression();
 
-        Assertions.assertInstanceOf(AtNameExpression.class, leftExpression);
-        Assertions.assertInstanceOf(LiteralExpression.class, rightExpression);
+        assertThat(leftExpression).isInstanceOf(AtNameExpression.class);
+        assertThat(rightExpression).isInstanceOf(LiteralExpression.class);
     }
 }

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/support/HSLTestHelper.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/support/HSLTestHelper.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.hsl.support;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.hsl.ExecutableScript;
 import org.dockbox.hartshorn.hsl.ExpressionScript;
 import org.dockbox.hartshorn.hsl.ParserCustomizer;
@@ -45,7 +46,6 @@ import org.dockbox.hartshorn.hsl.runtime.SimpleScriptRuntime;
 import org.dockbox.hartshorn.hsl.semantic.Resolver;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.util.configure.Customizer;
-import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 import org.mockito.internal.util.MockUtil;
 
@@ -55,6 +55,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * A helper class for testing HSL language features such as parsing and interpretation. This class
@@ -177,13 +180,12 @@ public class HSLTestHelper {
     public Expression expression() {
         List<Statement> statements = this.parse();
         if (statements.size() != 1) {
-            Assertions.fail("Expected exactly one statement but got " + statements.size());
+            fail("Expected exactly one statement but got " + statements.size());
         }
         Statement statement = statements.getFirst();
-        CaptureModule.CaptureStatement captureStatement = Assertions.assertInstanceOf(
-            CaptureModule.CaptureStatement.class,
-            statement
-        );
+        CaptureModule.CaptureStatement captureStatement = assertThat(statement)
+                .asInstanceOf(InstanceOfAssertFactories.type(CaptureModule.CaptureStatement.class))
+                .actual();
         return captureStatement.expression();
     }
 

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/support/ScriptAssertions.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/support/ScriptAssertions.java
@@ -21,9 +21,11 @@ import org.dockbox.hartshorn.hsl.ScriptEvaluationError;
 import org.dockbox.hartshorn.hsl.runtime.DiagnosticMessage;
 import org.dockbox.hartshorn.hsl.runtime.FormattedDiagnostic;
 import org.dockbox.hartshorn.util.StringUtilities;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 public class ScriptAssertions {
 
@@ -32,7 +34,7 @@ public class ScriptAssertions {
         FormattedDiagnostic diagnosticMessage
     ) {
         ScriptEvaluationError error =
-            Assertions.assertThrows(ScriptEvaluationError.class, executableScript::evaluate);
+            assertThatExceptionOfType(ScriptEvaluationError.class).isThrownBy(executableScript::evaluate).actual();
         assertEvaluationError(error, diagnosticMessage);
     }
 
@@ -41,12 +43,12 @@ public class ScriptAssertions {
         FormattedDiagnostic diagnosticMessage
     ) {
         if (diagnosticMessage.message().phase() != null) {
-            Assertions.assertEquals(diagnosticMessage.message().phase(), error.phase());
+            assertThat(error.phase()).isEqualTo(diagnosticMessage.message().phase());
         }
         String phase = error.phase().name().toLowerCase(Locale.ROOT);
         String expectedMessageStart = diagnosticMessage.format();
         String actualMessageStart = error.getMessage().split("While " + phase)[0].trim();
-        Assertions.assertEquals(expectedMessageStart, actualMessageStart);
+        assertThat(actualMessageStart).isEqualTo(expectedMessageStart);
     }
 
     public static void assertEvaluationError(
@@ -54,17 +56,14 @@ public class ScriptAssertions {
         DiagnosticMessage diagnosticMessage
     ) {
         if (diagnosticMessage.phase() != null) {
-            Assertions.assertEquals(diagnosticMessage.phase(), error.phase());
+            assertThat(error.phase()).isEqualTo(diagnosticMessage.phase());
         }
         String phase = error.phase().name().toLowerCase(Locale.ROOT);
         String actualMessageStart = error.getMessage().split("While " + phase)[0].trim();
         String rawMessage = diagnosticMessage.format();
-        Assertions.assertTrue(
-            StringUtilities.matchesFormatted(rawMessage, actualMessageStart),
-            "Expected message to match:\n" +
-                rawMessage + "\nbut was:\n" +
-                actualMessageStart
-        );
+        assertThat(StringUtilities.matchesFormatted(rawMessage, actualMessageStart)).as("Expected message to match:\n" +
+            rawMessage + "\nbut was:\n" +
+            actualMessageStart).isTrue();
     }
 
     public static void assertEvaluationFailedAtPosition(
@@ -72,7 +71,7 @@ public class ScriptAssertions {
         int line,
         int column
     ) {
-        Assertions.assertEquals(line, error.line());
-        Assertions.assertEquals(column, error.column());
+        assertThat(error.line()).isEqualTo(line);
+        assertThat(error.column()).isEqualTo(column);
     }
 }

--- a/hartshorn-inject-configurations/pom.xml
+++ b/hartshorn-inject-configurations/pom.xml
@@ -40,6 +40,12 @@
       <artifactId>groovy-all</artifactId>
       <type>pom</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>

--- a/hartshorn-inject/pom.xml
+++ b/hartshorn-inject/pom.xml
@@ -61,6 +61,10 @@
           <artifactId>groovy-test-junit5</artifactId>
           <groupId>org.apache.groovy</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/InjectorUtilities.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/InjectorUtilities.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.inject;
 
 import org.dockbox.hartshorn.util.Tristate;

--- a/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/ContextKeyTests.java
+++ b/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/ContextKeyTests.java
@@ -17,49 +17,50 @@
 package test.org.dockbox.hartshorn.inject;
 
 import org.dockbox.hartshorn.context.ContextIdentity;
-import org.dockbox.hartshorn.inject.ContextKey;
 import org.dockbox.hartshorn.context.ContextView;
-import org.junit.jupiter.api.Assertions;
+import org.dockbox.hartshorn.inject.ContextKey;
 import org.junit.jupiter.api.Test;
 
-public class ContextKeyTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class ContextKeyTests {
 
     @Test
-    void testContextKeyNameIsNullIfUndefined() {
+    void contextKeyNameIsNullIfUndefined() {
         ContextIdentity<ContextView> undefinedNameKey =
             ContextKey.builder(ContextView.class).build();
-        Assertions.assertNull(undefinedNameKey.name());
+        assertThat(undefinedNameKey.name()).isNull();
     }
 
     @Test
-    void testContextKeyNameIsNullIfEmpty() {
+    void contextKeyNameIsNullIfEmpty() {
         ContextIdentity<ContextView> emptyNameKey =
             ContextKey.builder(ContextView.class).name("").build();
-        Assertions.assertNull(emptyNameKey.name());
+        assertThat(emptyNameKey.name()).isNull();
     }
 
     @Test
-    void testContextKeyNameIsNullIfNull() {
-        ContextIdentity<ContextView> nullNameKey =
-            Assertions.assertDoesNotThrow(() -> ContextKey.builder(ContextView.class)
+    void contextKeyNameIsNullIfNull() {
+        ContextIdentity<ContextView> nullNameKey = ContextKey.builder(ContextView.class)
                 .name(null)
-                .build());
+                .build();
         // Ensure no NPE is thrown
-        Assertions.assertNull(nullNameKey.name());
+        assertThat(nullNameKey.name()).isNull();
     }
 
     @Test
-    void testCreateYieldsExceptionIfNoFallbackAndApplication() {
+    void createYieldsExceptionIfNoFallbackAndApplication() {
         ContextKey<ContextView> key = ContextKey.builder(ContextView.class).build();
-        Assertions.assertThrows(IllegalStateException.class, key::create);
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(key::create);
     }
 
     @Test
-    void testMutableKeyCreatesClone() {
+    void mutableKeyCreatesClone() {
         ContextKey<ContextView> key = ContextKey.builder(ContextView.class).build();
         ContextIdentity<ContextView> mutableKey = key.mutable().name("mutable").build();
-        Assertions.assertNotSame(key, mutableKey);
-        Assertions.assertNull(key.name());
-        Assertions.assertEquals("mutable", mutableKey.name());
+        assertThat(mutableKey).isNotSameAs(key);
+        assertThat(key.name()).isNull();
+        assertThat(mutableKey.name()).isEqualTo("mutable");
     }
 }

--- a/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/QualifierKeyTests.java
+++ b/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/QualifierKeyTests.java
@@ -19,40 +19,41 @@ package test.org.dockbox.hartshorn.inject;
 import org.dockbox.hartshorn.inject.CompositeQualifier;
 import org.dockbox.hartshorn.inject.QualifierKey;
 import org.dockbox.hartshorn.inject.annotations.Named;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-public class QualifierKeyTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class QualifierKeyTests {
 
     @Test
-    void testQualifierKeysWithoutMetaEqual() {
+    void qualifierKeysWithoutMetaEqual() {
         QualifierKey<SampleQualifier> expected = QualifierKey.of(SampleQualifier.class);
         QualifierKey<SampleQualifier> actual = QualifierKey.of(SampleQualifier.class);
-        Assertions.assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
-    void testQualifierKeysWithMetaEqual() {
+    void qualifierKeysWithMetaEqual() {
         QualifierKey<Named> expected = QualifierKey.of(Named.class, Map.of("value", "sample"));
         QualifierKey<Named> actual = QualifierKey.of(Named.class, Map.of("value", "sample"));
-        Assertions.assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
-    void testQualifierWithoutMetaFailsIfTypeRequiresMeta() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> QualifierKey.of(Named.class));
+    void qualifierWithoutMetaFailsIfTypeRequiresMeta() {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> QualifierKey.of(Named.class));
     }
 
     @Test
-    void testQualifierWithMetaFailsIfTypeDoesNotRequireMeta() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> QualifierKey.of(SampleQualifier.class, Map.of("value", "sample")));
+    void qualifierWithMetaFailsIfTypeDoesNotRequireMeta() {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> QualifierKey.of(SampleQualifier.class, Map.of("value", "sample")));
     }
 
     @Test
-    void testCompositeKeyEqualsIfKeysEqual() {
+    void compositeKeyEqualsIfKeysEqual() {
         QualifierKey<Named> namedQualifierOneA =
             QualifierKey.of(Named.class, Map.of("value", "sampleA"));
         QualifierKey<Named> namedQualifierOneB =
@@ -69,11 +70,11 @@ public class QualifierKeyTests {
         compositeQualifierTwo.add(namedQualifierTwoA);
         compositeQualifierTwo.add(namedQualifierTwoB);
 
-        Assertions.assertEquals(compositeQualifierOne, compositeQualifierTwo);
+        assertThat(compositeQualifierTwo).isEqualTo(compositeQualifierOne);
     }
 
     @Test
-    void testCompositeKeyDoesNotEqualIfOneKeyDoesNotEqual() {
+    void compositeKeyDoesNotEqualIfOneKeyDoesNotEqual() {
         QualifierKey<Named> namedQualifierOneA =
             QualifierKey.of(Named.class, Map.of("value", "sampleA"));
         CompositeQualifier compositeQualifierOne = new CompositeQualifier();
@@ -84,7 +85,7 @@ public class QualifierKeyTests {
         CompositeQualifier compositeQualifierTwo = new CompositeQualifier();
         compositeQualifierTwo.add(namedQualifierTwoB);
 
-        Assertions.assertNotEquals(compositeQualifierOne, compositeQualifierTwo);
+        assertThat(compositeQualifierTwo).isNotEqualTo(compositeQualifierOne);
     }
 
     public @interface SampleQualifier {

--- a/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/binding/BindingHierarchyTests.java
+++ b/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/binding/BindingHierarchyTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.inject.binding;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.annotations.Priority;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
@@ -25,44 +26,49 @@ import org.dockbox.hartshorn.inject.provider.CompositeInstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.InstantiationStrategy;
 import org.dockbox.hartshorn.inject.provider.PrototypeConstructorInstantiationStrategy;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map.Entry;
 
-public class BindingHierarchyTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BindingHierarchyTests {
 
     private HierarchicalBinder binder() {
         return new TestHierarchicalBinder();
     }
 
     @Test
-    void testIteratorIsSorted() {
+    void iteratorIsSorted() {
         BindingHierarchy<Contract> hierarchy =
             new NativePrunableBindingHierarchy<>(ComponentKey.of(Contract.class));
-        hierarchy.add(0,
-            PrototypeConstructorInstantiationStrategy.forSingleton(ComponentKey.of(ImplementationA.class)));
-        hierarchy.add(1,
-            PrototypeConstructorInstantiationStrategy.forSingleton(ComponentKey.of(ImplementationB.class)));
-        hierarchy.add(2,
-            PrototypeConstructorInstantiationStrategy.forSingleton(ComponentKey.of(ImplementationC.class)));
+        hierarchy.add(0, PrototypeConstructorInstantiationStrategy.forSingleton(
+                ComponentKey.of(ImplementationA.class)
+        ));
+        hierarchy.add(1, PrototypeConstructorInstantiationStrategy.forSingleton(
+                ComponentKey.of(ImplementationB.class)
+        ));
+        hierarchy.add(2, PrototypeConstructorInstantiationStrategy.forSingleton(
+                ComponentKey.of(ImplementationC.class)
+        ));
 
         int next = 2;
         for (Entry<Integer, InstantiationStrategy<Contract>> entry : hierarchy) {
             Integer priority = entry.getKey();
-            Assertions.assertEquals(next, priority.intValue());
+            assertThat(priority.intValue()).isEqualTo(next);
             next--;
         }
     }
 
     @Test
-    void testPriorityBindingsAreRetainedAndAccessible() {
+    void priorityBindingsAreRetainedAndAccessible() {
         ComponentKey<Contract> key = ComponentKey.of(Contract.class);
         HierarchicalBinder binder = this.binder();
 
         BindingHierarchy<Contract> secondHierarchy = new NativePrunableBindingHierarchy<>(key);
-        secondHierarchy.add(2,
-            PrototypeConstructorInstantiationStrategy.forSingleton(ComponentKey.of(ImplementationC.class)));
+        secondHierarchy.add(2, PrototypeConstructorInstantiationStrategy.forSingleton(
+                ComponentKey.of(ImplementationC.class)
+        ));
 
         binder.hierarchy(key)
             .add(0,
@@ -74,42 +80,57 @@ public class BindingHierarchyTests {
             .merge(secondHierarchy);
 
         BindingHierarchy<Contract> hierarchy = binder.hierarchy(key);
-        Assertions.assertNotNull(hierarchy);
+        assertThat(hierarchy).isNotNull();
 
-        Assertions.assertEquals(3, hierarchy.size());
+        assertThat(hierarchy.size()).isEqualTo(3);
 
         Option<InstantiationStrategy<Contract>> priorityZero = hierarchy.get(0);
-        Assertions.assertTrue(priorityZero.present());
-        Assertions.assertTrue(priorityZero.get() instanceof PrototypeConstructorInstantiationStrategy);
-        Assertions.assertSame(((PrototypeConstructorInstantiationStrategy<Contract>) priorityZero.get()).type(),
-            ImplementationA.class);
+        assertThat(priorityZero)
+                .asInstanceOf(InstanceOfAssertFactories.type(Option.class))
+                .matches(Option::present)
+                .extracting(Option::get)
+                .asInstanceOf(InstanceOfAssertFactories.type(
+                        PrototypeConstructorInstantiationStrategy.class
+                ))
+                .extracting(PrototypeConstructorInstantiationStrategy::type)
+                .isSameAs(ImplementationA.class);
 
         Option<InstantiationStrategy<Contract>> priorityOne = hierarchy.get(1);
-        Assertions.assertTrue(priorityOne.present());
-        Assertions.assertTrue(priorityOne.get() instanceof PrototypeConstructorInstantiationStrategy);
-        Assertions.assertSame(((PrototypeConstructorInstantiationStrategy<Contract>) priorityOne.get()).type(),
-            ImplementationB.class);
+        assertThat(priorityOne)
+                .asInstanceOf(InstanceOfAssertFactories.type(Option.class))
+                .matches(Option::present)
+                .extracting(Option::get)
+                .asInstanceOf(InstanceOfAssertFactories.type(
+                        PrototypeConstructorInstantiationStrategy.class
+                ))
+                .extracting(PrototypeConstructorInstantiationStrategy::type)
+                .isSameAs(ImplementationB.class);
 
         Option<InstantiationStrategy<Contract>> priorityTwo = hierarchy.get(2);
-        Assertions.assertTrue(priorityTwo.present());
-        Assertions.assertTrue(priorityTwo.get() instanceof PrototypeConstructorInstantiationStrategy);
-        Assertions.assertSame(((PrototypeConstructorInstantiationStrategy<Contract>) priorityTwo.get()).type(),
-            ImplementationC.class);
+        assertThat(priorityTwo)
+                .asInstanceOf(InstanceOfAssertFactories.type(Option.class))
+                .matches(Option::present)
+                .extracting(Option::get)
+                .asInstanceOf(InstanceOfAssertFactories.type(
+                        PrototypeConstructorInstantiationStrategy.class
+                ))
+                .extracting(PrototypeConstructorInstantiationStrategy::type)
+                .isSameAs(ImplementationC.class);
     }
 
     @Test
-    void testContextCreatesHierarchy() {
+    void contextCreatesHierarchy() {
         HierarchicalBinder binder = this.binder();
         binder.bind(LocalContract.class).to(LocalObject.class);
 
         BindingHierarchy<LocalContract> hierarchy =
             binder.hierarchy(ComponentKey.of(LocalContract.class));
-        Assertions.assertNotNull(hierarchy);
-        Assertions.assertEquals(1, hierarchy.size());
+        assertThat(hierarchy).isNotNull();
+        assertThat(hierarchy.size()).isOne();
 
         Option<InstantiationStrategy<LocalContract>> provider =
             hierarchy.get(Priority.DEFAULT_PRIORITY);
-        Assertions.assertTrue(provider.present());
+        assertThat(provider.present()).isTrue();
 
         InstantiationStrategy<LocalContract> contractStrategy = provider.get();
         if (contractStrategy instanceof CompositeInstantiationStrategy<LocalContract> composite) {
@@ -117,9 +138,12 @@ public class BindingHierarchyTests {
             contractStrategy = composite.provider();
         }
 
-        Assertions.assertTrue(contractStrategy instanceof PrototypeConstructorInstantiationStrategy);
-        Assertions.assertSame(((PrototypeConstructorInstantiationStrategy<LocalContract>) contractStrategy).type(),
-            LocalObject.class);
+        assertThat(contractStrategy)
+                .asInstanceOf(InstanceOfAssertFactories.type(
+                        PrototypeConstructorInstantiationStrategy.class
+                ))
+                .extracting(PrototypeConstructorInstantiationStrategy::type)
+                .isSameAs(LocalObject.class);
     }
 
     interface LocalContract {

--- a/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/graph/support/OverlappingAliasDependencyGraphValidatorTests.java
+++ b/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/graph/support/OverlappingAliasDependencyGraphValidatorTests.java
@@ -25,16 +25,18 @@ import org.dockbox.hartshorn.inject.graph.support.AmbiguousAliasException;
 import org.dockbox.hartshorn.inject.graph.support.OverlappingAliasDependencyGraphValidator;
 import org.dockbox.hartshorn.inject.provider.AliasCapableComponentProviderOrchestrator;
 import org.dockbox.hartshorn.util.graph.SimpleGraphNode;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Set;
 
-public class OverlappingAliasDependencyGraphValidatorTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class OverlappingAliasDependencyGraphValidatorTests {
 
     @Test
-    void testOverlappingAliasWithSamePriorityFails() {
+    void overlappingAliasWithSamePriorityFails() {
         DependencyGraphValidator validator = new OverlappingAliasDependencyGraphValidator();
         DependencyGraph graph = new DependencyGraph();
 
@@ -50,17 +52,14 @@ public class OverlappingAliasDependencyGraphValidatorTests {
             Mockito.mock(AliasCapableComponentProviderOrchestrator.class);
         Mockito.when(orchestrator.aliasNormalizer())
             .thenReturn(new DefaultBindingAliasNormalizer());
-        AmbiguousAliasException exception = Assertions.assertThrows(
-            AmbiguousAliasException.class,
-            () -> validator.validateBeforeConfiguration(graph, null, orchestrator)
-        );
+        AmbiguousAliasException exception = assertThatExceptionOfType(AmbiguousAliasException.class).isThrownBy(() -> validator.validateBeforeConfiguration(graph, null, orchestrator)).actual();
 
-        Assertions.assertEquals(2, exception.contexts().size());
-        Assertions.assertEquals(ComponentKey.of(CharSequence.class), exception.componentKey());
+        assertThat(exception.contexts()).hasSize(2);
+        assertThat(exception.componentKey()).isEqualTo(ComponentKey.of(CharSequence.class));
     }
 
     @Test
-    void testOverlappingAliasWithDifferentPrioritiesPasses() {
+    void overlappingAliasWithDifferentPrioritiesPasses() throws Exception {
         DependencyGraphValidator validator = new OverlappingAliasDependencyGraphValidator();
         DependencyGraph graph = new DependencyGraph();
 
@@ -79,9 +78,7 @@ public class OverlappingAliasDependencyGraphValidatorTests {
             Mockito.mock(AliasCapableComponentProviderOrchestrator.class);
         Mockito.when(orchestrator.aliasNormalizer())
             .thenReturn(new DefaultBindingAliasNormalizer());
-        Assertions.assertDoesNotThrow(() -> validator.validateBeforeConfiguration(graph,
-            null,
-            orchestrator));
+        validator.validateBeforeConfiguration(graph, null, orchestrator);
     }
 
     private static <T extends CharSequence> AliasableDependencyContext<T> createMockCharSequenceDependencyContext(

--- a/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/provider/InstantiationStrategySelectionStrategyTests.java
+++ b/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/provider/InstantiationStrategySelectionStrategyTests.java
@@ -30,14 +30,16 @@ import org.dockbox.hartshorn.inject.provider.selection.HighestPriorityProviderSe
 import org.dockbox.hartshorn.inject.provider.selection.MaximumPriorityProviderSelectionStrategy;
 import org.dockbox.hartshorn.inject.provider.selection.MinimumPriorityProviderSelectionStrategy;
 import org.dockbox.hartshorn.inject.provider.selection.ProviderSelectionStrategy;
+import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstantiationStrategySelectionStrategyTests {
 
@@ -73,75 +75,76 @@ public class InstantiationStrategySelectionStrategyTests {
 
     @ParameterizedTest
     @MethodSource("strategies")
-    void testStrategySelectsNullIfEmpty() {
+    void strategySelectsNullIfEmpty() {
         BindingHierarchy<String> hierarchy = createEmptyHierarchy();
         ProviderSelectionStrategy strategy = new MaximumPriorityProviderSelectionStrategy(0);
         InstantiationStrategy<?> provider = strategy.selectProvider(hierarchy);
-        Assertions.assertNull(provider);
+        assertThat(provider).isNull();
     }
 
     @Test
-    void testMaximumPriorityStrategySelectsMaximumExclusive() {
+    void maximumPriorityStrategySelectsMaximumExclusive() throws Exception {
         ProviderSelectionStrategy strategy = new MaximumPriorityProviderSelectionStrategy(1);
         this.assertValueWithStrategy(PRIORITY_ZERO_VALUE, strategy);
     }
 
     @Test
-    void testMaximumPriorityStrategySelectsNullIfOutOfRange() {
+    void maximumPriorityStrategySelectsNullIfOutOfRange() throws Exception {
         ProviderSelectionStrategy strategy = new MaximumPriorityProviderSelectionStrategy(-2);
         this.assertValueWithStrategy(null, strategy);
     }
 
     @Test
-    void testExactPriorityStrategySelectsExact() {
+    void exactPriorityStrategySelectsExact() throws Exception {
         ProviderSelectionStrategy strategy = new ExactPriorityProviderSelectionStrategy(0);
         this.assertValueWithStrategy(PRIORITY_ZERO_VALUE, strategy);
     }
 
     @Test
-    void testExactPriorityStrategySelectsNullIfOutOfRange() {
+    void exactPriorityStrategySelectsNullIfOutOfRange() throws Exception {
         ProviderSelectionStrategy strategy = new ExactPriorityProviderSelectionStrategy(-2);
         this.assertValueWithStrategy(null, strategy);
     }
 
     @Test
-    void testMinimumPriorityStrategySelectsMinimumInclusive() {
+    void minimumPriorityStrategySelectsMinimumInclusive() throws Exception {
         ProviderSelectionStrategy strategy = new MinimumPriorityProviderSelectionStrategy(1);
         this.assertValueWithStrategy(PRIORITY_ONE_VALUE, strategy);
     }
 
     @Test
-    void testMinimumPriorityStrategySelectsNullIfOutOfRange() {
+    void minimumPriorityStrategySelectsNullIfOutOfRange() throws Exception {
         ProviderSelectionStrategy strategy = new MinimumPriorityProviderSelectionStrategy(3);
         this.assertValueWithStrategy(null, strategy);
     }
 
     @Test
-    void testHighestPriorityStrategySelectsHighest() {
+    void highestPriorityStrategySelectsHighest() throws Exception {
         ProviderSelectionStrategy strategy = new HighestPriorityProviderSelectionStrategy();
         this.assertValueWithStrategy(PRIORITY_TWO_VALUE, strategy);
     }
 
-    protected void assertValueWithStrategy(String expected, ProviderSelectionStrategy strategy) {
+    protected void assertValueWithStrategy(String expected, ProviderSelectionStrategy strategy) throws ApplicationException {
         BindingHierarchy<?> hierarchy = this.createHierarchy();
 
         InstantiationStrategy<?> provider = strategy.selectProvider(hierarchy);
         if (expected == null) {
-            Assertions.assertNull(provider);
-            return;
+            assertThat(provider).isNull();
         }
         else {
-            Assertions.assertNotNull(provider);
+            assertThat(provider).isNotNull();
 
             // Don't need to provide application, all bindings are contextless singletons
-            Option<? extends ObjectContainer<?>> value = Assertions.assertDoesNotThrow(() -> {
-                return provider.provide(null, ComponentRequestContext.createForComponent(), null);
-            });
-            Assertions.assertTrue(value.present());
+            Option<? extends ObjectContainer<?>> value = provider.provide(
+                    null,
+                    ComponentRequestContext.createForComponent(),
+                    null
+            );
+            assertThat(value.present()).isTrue();
 
             ObjectContainer<?> container = value.get();
             Object instance = container.instance();
-            Assertions.assertEquals(expected, instance);
+            assertThat(instance).isEqualTo(expected);
         }
     }
 }

--- a/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/scope/ScopeKeyTests.java
+++ b/hartshorn-inject/src/test/java/test/org/dockbox/hartshorn/inject/scope/ScopeKeyTests.java
@@ -22,31 +22,34 @@ import org.dockbox.hartshorn.inject.scope.ScopeAdapter;
 import org.dockbox.hartshorn.inject.scope.ScopeAdapterKey;
 import org.dockbox.hartshorn.inject.scope.ScopeKey;
 import org.dockbox.hartshorn.util.introspect.ParameterizableType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ScopeKeyTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class ScopeKeyTests {
 
     @Test
-    void testScopeKeyTypeKeepsParameters() {
+    void scopeKeyTypeKeepsParameters() {
         ParameterizableType parameterType = ParameterizableType.create(String.class);
         ParameterizableType parameterizedType = ParameterizableType.builder(ScopeAdapter.class)
             .parameters(parameterType)
             .build();
 
         ScopeKey scopeKey = DirectScopeKey.of(parameterizedType);
-        Assertions.assertEquals(parameterizedType, scopeKey.scopeType());
+        assertThat(scopeKey.scopeType()).isEqualTo(parameterizedType);
     }
 
     @Test
-    void testRawScopeKeysEqual() {
+    void rawScopeKeysEqual() {
         ScopeKey scopeKey1 = DirectScopeKey.of(Scope.class);
         ScopeKey scopeKey2 = DirectScopeKey.of(Scope.class);
-        Assertions.assertEquals(scopeKey1, scopeKey2);
+        assertThat(scopeKey2).isEqualTo(scopeKey1);
     }
 
     @Test
-    void testParameterizedScopeKeysEqual() {
+    void parameterizedScopeKeysEqual() {
         ParameterizableType parameterType = ParameterizableType.create(String.class);
         ParameterizableType parameterizedType = ParameterizableType.builder(ScopeAdapter.class)
             .parameters(parameterType)
@@ -54,46 +57,43 @@ public class ScopeKeyTests {
 
         ScopeKey scopeKey1 = DirectScopeKey.of(parameterizedType);
         ScopeKey scopeKey2 = DirectScopeKey.of(parameterizedType);
-        Assertions.assertEquals(scopeKey1, scopeKey2);
+        assertThat(scopeKey2).isEqualTo(scopeKey1);
     }
 
     @Test
-    void testCreateFromParameterizedTypeRequiresScopeType() {
+    void createFromParameterizedTypeRequiresScopeType() {
         ParameterizableType parameterType = ParameterizableType.create(String.class);
         ParameterizableType parameterizedType = ParameterizableType.builder(ScopeAdapter.class)
             .parameters(parameterType)
             .build();
 
-        Assertions.assertDoesNotThrow(() -> DirectScopeKey.of(parameterizedType));
+        assertThatCode(() -> DirectScopeKey.of(parameterizedType)).doesNotThrowAnyException();
         // String not a scope type
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> DirectScopeKey.of(parameterType));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> DirectScopeKey.of(parameterType));
     }
 
     @Test
-    void testScopeAdapterKeyParameterizableTypeRequiresScopeAdapter() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> ScopeAdapterKey.of(ParameterizableType.create(String.class)));
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> ScopeAdapterKey.of(ParameterizableType.create(Scope.class)));
-        Assertions.assertDoesNotThrow(() -> {
+    void scopeAdapterKeyParameterizableTypeRequiresScopeAdapter() {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> ScopeAdapterKey.of(ParameterizableType.create(String.class)));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> ScopeAdapterKey.of(ParameterizableType.create(Scope.class)));
+        assertThatCode(() -> {
             ParameterizableType type = ParameterizableType.builder(ScopeAdapter.class)
                 .parameters(ParameterizableType.create(String.class))
                 .build();
             ScopeAdapterKey scopeAdapterKey = ScopeAdapterKey.of(type);
-            Assertions.assertNotNull(scopeAdapterKey);
-        });
+            assertThat(scopeAdapterKey).isNotNull();
+        }).doesNotThrowAnyException();
     }
 
     @Test
-    void testScopeAdapterKeysOfSameTypeEqual() {
+    void scopeAdapterKeysOfSameTypeEqual() {
         ScopeAdapter<Object> adapter1 = ScopeAdapter.of(new Object());
         ScopeAdapterKey key1 = ScopeAdapterKey.of(adapter1);
 
         ScopeAdapter<Object> adapter2 = ScopeAdapter.of(new Object());
         ScopeAdapterKey key2 = ScopeAdapterKey.of(adapter2);
 
-        Assertions.assertNotEquals(adapter1, adapter2);
-        Assertions.assertEquals(key1, key2);
+        assertThat(adapter2).isNotEqualTo(adapter1);
+        assertThat(key2).isEqualTo(key1);
     }
 }

--- a/hartshorn-integration-tests/pom.xml
+++ b/hartshorn-integration-tests/pom.xml
@@ -44,6 +44,10 @@
           <artifactId>groovy-test-junit5</artifactId>
           <groupId>org.apache.groovy</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/hartshorn-integration-tests/src/integration-test/groovy/test/org/dockbox/hartshorn/core/groovy/GroovyComponentTests.groovy
+++ b/hartshorn-integration-tests/src/integration-test/groovy/test/org/dockbox/hartshorn/core/groovy/GroovyComponentTests.groovy
@@ -47,7 +47,7 @@ class GroovyComponentTests {
 
   @ParameterizedTest
   @MethodSource("components")
-  <T> void testComponent(Class<T> componentType, applicationContextFunction,
+  <T> void component(Class<T> componentType, applicationContextFunction,
           applicationManagerFunction) {
     def component = this.applicationContext.get(componentType)
     Assertions.assertNotNull(component)

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/aliases/BindingAliasingTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/aliases/BindingAliasingTests.java
@@ -25,14 +25,17 @@ import org.dockbox.hartshorn.inject.provider.ComponentProvider;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class BindingAliasingTests {
+class BindingAliasingTests {
 
     @Test
-    void testAliasBindingsCanBeResolved(@Inject ApplicationContext applicationContext) {
+    void aliasBindingsCanBeResolved(@Inject ApplicationContext applicationContext) {
         applicationContext.bind(String.class)
             .alias(CharSequence.class)
             .singleton("Hello world");
@@ -40,29 +43,29 @@ public class BindingAliasingTests {
         String helloWorldString = applicationContext.get(String.class);
         CharSequence helloWorldCharSequence = applicationContext.get(CharSequence.class);
 
-        Assertions.assertSame(helloWorldString, helloWorldCharSequence);
+        assertThat(helloWorldCharSequence).isSameAs(helloWorldString);
     }
 
     @Test
     @TestComponents(BindingAliasingConfiguration.class)
-    void testAliasBindingsFromConfigurationCanBeResolved(@Inject ComponentProvider provider) {
+    void aliasBindingsFromConfigurationCanBeResolved(@Inject ComponentProvider provider) {
         String helloWorldString = provider.get(String.class);
         CharSequence helloWorldCharSequence = provider.get(CharSequence.class);
 
-        Assertions.assertSame(helloWorldString, helloWorldCharSequence);
+        assertThat(helloWorldCharSequence).isSameAs(helloWorldString);
     }
 
     @Test
     @TestComponents(OverlappingDefaultAndAliasBindingConfiguration.class)
-    void testOverlappingDefaultAndAliasBindingsFromConfigurationCanResolve(
+    void overlappingDefaultAndAliasBindingsFromConfigurationCanResolve(
         @Inject ComponentProvider provider
     ) {
-        Assertions.assertDoesNotThrow(() -> provider.get(String.class));
-        Assertions.assertDoesNotThrow(() -> provider.get(CharSequence.class));
+        assertThatCode(() -> provider.get(String.class)).doesNotThrowAnyException();
+        assertThatCode(() -> provider.get(CharSequence.class)).doesNotThrowAnyException();
     }
 
     @Test
-    void testOverlappingPriorityAliasBindingsFails(@Inject ApplicationContext applicationContext) {
+    void overlappingPriorityAliasBindingsFails(@Inject ApplicationContext applicationContext) {
         applicationContext.bind(String.class)
             .alias(CharSequence.class)
             .priority(1)
@@ -72,8 +75,7 @@ public class BindingAliasingTests {
             .priority(1)
             .singleton(new StringBuilder("Hello world"));
 
-        Assertions.assertThrows(AmbiguousComponentException.class,
-            () -> applicationContext.get(CharSequence.class));
+        assertThatExceptionOfType(AmbiguousComponentException.class).isThrownBy(() -> applicationContext.get(CharSequence.class));
     }
 
     @Configuration

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/binding/defaults/DefaultBindingsTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/binding/defaults/DefaultBindingsTests.java
@@ -16,12 +16,12 @@
 
 package test.org.dockbox.hartshorn.inject.binding.defaults;
 
+import org.assertj.core.api.Assertions;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.inject.component.ComponentContainer;
 import org.dockbox.hartshorn.inject.component.ComponentRegistry;
 import org.dockbox.hartshorn.test.annotations.TestProperties;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
@@ -41,8 +41,8 @@ class DefaultBindingsTests {
     void loggerUsesContainerNameIfEnabled(@Inject Logger loggerParameter) {
         assertThat(loggerParameter).isNotNull();
         // Name should match the consuming class' name, and not the name of the configuration that uses it
-        ComponentContainer<?> container =
-            this.componentRegistry.container(this.getClass()).orElseGet(Assertions::fail);
+        ComponentContainer<?> container = this.componentRegistry.container(this.getClass())
+                .orElseGet(Assertions::fail);
         String expectedName = container.name();
         assertThat(loggerParameter.getName()).isEqualTo(expectedName);
 

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/binding/defaults/DefaultBindingsTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/binding/defaults/DefaultBindingsTests.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class DefaultBindingsTests {
+class DefaultBindingsTests {
 
     @Inject
     private Logger loggerField;
@@ -37,35 +39,35 @@ public class DefaultBindingsTests {
     @Test
     @TestProperties("hartshorn.logging.naming.use-container-names=true")
     void loggerUsesContainerNameIfEnabled(@Inject Logger loggerParameter) {
-        Assertions.assertNotNull(loggerParameter);
+        assertThat(loggerParameter).isNotNull();
         // Name should match the consuming class' name, and not the name of the configuration that uses it
         ComponentContainer<?> container =
             this.componentRegistry.container(this.getClass()).orElseGet(Assertions::fail);
         String expectedName = container.name();
-        Assertions.assertEquals(expectedName, loggerParameter.getName());
+        assertThat(loggerParameter.getName()).isEqualTo(expectedName);
 
-        Assertions.assertNotNull(this.loggerField);
-        Assertions.assertEquals(expectedName, this.loggerField.getName());
+        assertThat(this.loggerField).isNotNull();
+        assertThat(this.loggerField.getName()).isEqualTo(expectedName);
     }
 
     @Test
     @TestProperties("hartshorn.logging.naming.use-container-names=false")
     void loggerUsesClassNameIfDisabled(@Inject Logger loggerParameter) {
-        Assertions.assertNotNull(loggerParameter);
+        assertThat(loggerParameter).isNotNull();
         String expectedName = this.getClass().getName();
-        Assertions.assertEquals(expectedName, loggerParameter.getName());
+        assertThat(loggerParameter.getName()).isEqualTo(expectedName);
 
-        Assertions.assertNotNull(this.loggerField);
-        Assertions.assertEquals(expectedName, this.loggerField.getName());
+        assertThat(this.loggerField).isNotNull();
+        assertThat(this.loggerField.getName()).isEqualTo(expectedName);
     }
 
     @Test
     void loggerUsesClassNameByDefault(@Inject Logger loggerParameter) {
-        Assertions.assertNotNull(loggerParameter);
+        assertThat(loggerParameter).isNotNull();
         String expectedName = this.getClass().getName();
-        Assertions.assertEquals(expectedName, loggerParameter.getName());
+        assertThat(loggerParameter.getName()).isEqualTo(expectedName);
 
-        Assertions.assertNotNull(this.loggerField);
-        Assertions.assertEquals(expectedName, this.loggerField.getName());
+        assertThat(this.loggerField).isNotNull();
+        assertThat(this.loggerField.getName()).isEqualTo(expectedName);
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/binding/priority/PriorityBindingTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/binding/priority/PriorityBindingTests.java
@@ -23,8 +23,9 @@ import org.dockbox.hartshorn.inject.annotations.configuration.Prototype;
 import org.dockbox.hartshorn.inject.annotations.Priority;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class PriorityBindingTests {
@@ -39,47 +40,47 @@ public class PriorityBindingTests {
     @Test
     @TestComponents({ZeroAndDefaultPriorityConfiguration.class,
         ImplicitPriorityConfiguration.class})
-    void testProvisionWithImplicitPriority() {
+    void provisionWithImplicitPriority() {
         TestPriorityComponent component = this.applicationContext.get(TestPriorityComponent.class);
-        Assertions.assertEquals(PRIORITY_ZERO + PRIORITY_ONE, component.name());
+        assertThat(component.name()).isEqualTo(PRIORITY_ZERO + PRIORITY_ONE);
     }
 
     @Test
     @TestComponents({ZeroAndDefaultPriorityConfiguration.class,
         ExplicitPriorityConfiguration.class})
-    void testProvisionWithExplicitPriority() {
+    void provisionWithExplicitPriority() {
         TestPriorityComponent component = this.applicationContext.get(TestPriorityComponent.class);
-        Assertions.assertEquals(PRIORITY_DEFAULT + PRIORITY_ONE, component.name());
+        assertThat(component.name()).isEqualTo(PRIORITY_DEFAULT + PRIORITY_ONE);
     }
 
     @Test
-    void testPrioritySingletonBinding() {
+    void prioritySingletonBinding() {
         this.applicationContext.bind(String.class).singleton("Hello world!");
         this.applicationContext.bind(String.class).priority(0).singleton("Hello modified world!");
 
         String binding = this.applicationContext.get(String.class);
-        Assertions.assertEquals("Hello modified world!", binding);
+        assertThat(binding).isEqualTo("Hello modified world!");
 
         this.applicationContext.bind(String.class)
             .priority(-2)
             .singleton("Hello low priority world!");
         String binding2 = this.applicationContext.get(String.class);
-        Assertions.assertEquals("Hello modified world!", binding2);
+        assertThat(binding2).isEqualTo("Hello modified world!");
     }
 
     @Test
-    void testPrioritySupplierBinding() {
+    void prioritySupplierBinding() {
         this.applicationContext.bind(String.class).to(() -> "Hello world!");
         this.applicationContext.bind(String.class).priority(0).to(() -> "Hello modified world!");
 
         String binding = this.applicationContext.get(String.class);
-        Assertions.assertEquals("Hello modified world!", binding);
+        assertThat(binding).isEqualTo("Hello modified world!");
 
         this.applicationContext.bind(String.class)
             .priority(-2)
             .to(() -> "Hello low priority world!");
         String binding2 = this.applicationContext.get(String.class);
-        Assertions.assertEquals("Hello modified world!", binding2);
+        assertThat(binding2).isEqualTo("Hello modified world!");
     }
 
     @Configuration

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/callbacks/OnInitializedCallbackTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/callbacks/OnInitializedCallbackTests.java
@@ -19,19 +19,20 @@ package test.org.dockbox.hartshorn.inject.callbacks;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class OnInitializedCallbackTests {
+class OnInitializedCallbackTests {
 
     @Test
     @TestComponents(TypeWithPostConstructableInjectField.class)
-    void testPostConstructInjectDoesNotInjectTwice(
+    void postConstructInjectDoesNotInjectTwice(
         @Inject TypeWithPostConstructableInjectField instance
     ) {
-        Assertions.assertNotNull(instance);
-        Assertions.assertNotNull(instance.postConstructableObject());
-        Assertions.assertEquals(1, instance.postConstructableObject().getTimesConstructed());
+        assertThat(instance).isNotNull();
+        assertThat(instance.postConstructableObject()).isNotNull();
+        assertThat(instance.postConstructableObject().getTimesConstructed()).isOne();
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/circular/CircularDependencyTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/circular/CircularDependencyTests.java
@@ -26,6 +26,7 @@ import org.dockbox.hartshorn.inject.graph.ConfigurableDependencyContext;
 import org.dockbox.hartshorn.inject.graph.DependencyGraph;
 import org.dockbox.hartshorn.inject.graph.DependencyGraphBuilder;
 import org.dockbox.hartshorn.inject.graph.DependencyMap;
+import org.dockbox.hartshorn.inject.graph.DependencyResolutionException;
 import org.dockbox.hartshorn.inject.graph.DependencyResolutionType;
 import org.dockbox.hartshorn.inject.graph.DependencyResolver;
 import org.dockbox.hartshorn.inject.graph.TypePathNode;
@@ -45,7 +46,6 @@ import org.dockbox.hartshorn.util.graph.GraphNode;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.introspect.view.View;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -64,6 +64,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
 public class CircularDependencyTests {
 
@@ -72,228 +74,232 @@ public class CircularDependencyTests {
 
     @Test
     @TestComponents({CircularDependencyA.class, CircularDependencyB.class})
-    void testCircularDependenciesAreCorrectOnFieldInject() {
-        CircularDependencyA a =
-            Assertions.assertDoesNotThrow(() -> this.applicationContext.get(CircularDependencyA.class));
-        CircularDependencyB b =
-            Assertions.assertDoesNotThrow(() -> this.applicationContext.get(CircularDependencyB.class));
+    void circularDependenciesAreCorrectOnFieldInject() {
+        CircularDependencyA a = this.applicationContext.get(CircularDependencyA.class);
+        CircularDependencyB b = this.applicationContext.get(CircularDependencyB.class);
 
-        Assertions.assertNotNull(a);
-        Assertions.assertNotNull(b);
+        assertThat(a).isNotNull();
+        assertThat(b).isNotNull();
 
-        Assertions.assertSame(a, b.a());
-        Assertions.assertSame(b, a.b());
+        assertThat(b.a()).isSameAs(a);
+        assertThat(a.b()).isSameAs(b);
     }
 
     public static Stream<Arguments> circularDelayedResolution() {
         return Stream.of(
-            // Circular, but can use delayed resolution
-            Arguments.of(List.of(CircularDependencyA.class, CircularDependencyB.class)),
-            Arguments.of(List.of(CircularDependencyB.class, CircularDependencyA.class))
+                // Circular, but can use delayed resolution
+                Arguments.of(List.of(CircularDependencyA.class, CircularDependencyB.class)),
+                Arguments.of(List.of(CircularDependencyB.class, CircularDependencyA.class))
         );
     }
 
     public static Stream<Arguments> circularImmediateResolution() {
         return Stream.of(
-            // Circular, needs immediate resolution but cannot
-            Arguments.of(List.of(CircularConstructorA.class, CircularConstructorB.class)),
-            Arguments.of(List.of(CircularConstructorB.class, CircularConstructorA.class)),
-            // Circular, but in longer cycles
-            Arguments.of(List.of(LongCycleA.class,
-                LongCycleB.class,
-                LongCycleC.class,
-                LongCycleD.class)),
-            Arguments.of(List.of(LongCycleB.class,
-                LongCycleC.class,
-                LongCycleD.class,
-                LongCycleA.class)),
-            Arguments.of(List.of(LongCycleC.class,
-                LongCycleD.class,
-                LongCycleA.class,
-                LongCycleB.class)),
-            Arguments.of(List.of(LongCycleD.class,
-                LongCycleA.class,
-                LongCycleB.class,
-                LongCycleC.class))
+                // Circular, needs immediate resolution but cannot
+                Arguments.of(List.of(CircularConstructorA.class, CircularConstructorB.class)),
+                Arguments.of(List.of(CircularConstructorB.class, CircularConstructorA.class)),
+                // Circular, but in longer cycles
+                Arguments.of(List.of(LongCycleA.class,
+                        LongCycleB.class,
+                        LongCycleC.class,
+                        LongCycleD.class)),
+                Arguments.of(List.of(LongCycleB.class,
+                        LongCycleC.class,
+                        LongCycleD.class,
+                        LongCycleA.class)),
+                Arguments.of(List.of(LongCycleC.class,
+                        LongCycleD.class,
+                        LongCycleA.class,
+                        LongCycleB.class)),
+                Arguments.of(List.of(LongCycleD.class,
+                        LongCycleA.class,
+                        LongCycleB.class,
+                        LongCycleC.class))
         );
     }
 
     @ParameterizedTest
     @MethodSource("circularImmediateResolution")
-    void testImmediateCircularDependencyPathCanBeDetermined(List<Class<?>> path) {
+    void immediateCircularDependencyPathCanBeDetermined(List<Class<?>> path)
+            throws Exception {
         DependencyGraph dependencyGraph = this.buildDependencyGraph(path);
         CyclicDependencyGraphValidator validator = new CyclicDependencyGraphValidator();
 
         Set<GraphNode<DependencyContext<?>>> roots = dependencyGraph.roots();
-        Assertions.assertEquals(0, roots.size()); // Cyclic, thus no roots
+        // Cyclic, thus no roots
+        assertThat(roots).isEmpty();
 
         Set<GraphNode<DependencyContext<?>>> nodes = dependencyGraph.nodes();
-        Assertions.assertEquals(path.size(),
-            nodes.size()); // N nodes, no duplicates, but does contain all nodes
+        // N nodes, no duplicates, but does contain all nodes
+        assertThat(nodes).hasSameSizeAs(path);
 
         Map<? extends Class<?>, GraphNode<DependencyContext<?>>> nodesByType = nodes.stream()
-            .collect(Collectors.toMap(node -> node.value().componentKey().type(),
-                Function.identity()));
-        GraphNode<DependencyContext<?>> firstNode = nodesByType.get(path.get(0));
+                .collect(Collectors.toMap(node -> node.value().componentKey().type(),
+                        Function.identity()));
+        GraphNode<DependencyContext<?>> firstNode = nodesByType.get(path.getFirst());
 
         List<GraphNode<DependencyContext<?>>> recursivePath =
-            validator.checkNodeNotCyclicRecursive(firstNode, new ArrayList<>());
+                validator.checkNodeNotCyclicRecursive(firstNode, new ArrayList<>());
         ComponentDiscoveryList discoveryList = validator.createDiscoveryList(recursivePath,
-            this.applicationContext.environment().introspector());
-        Assertions.assertNotNull(discoveryList);
+                this.applicationContext.environment().introspector());
+        assertThat(discoveryList).isNotNull();
 
         List<DiscoveredComponent> discoveredComponents = discoveryList.discoveredComponents();
-        Assertions.assertEquals(path.size(), discoveredComponents.size());
+        assertThat(discoveredComponents).hasSameSizeAs(path);
 
         List<? extends Class<?>> discoveredTypes = discoveredComponents.stream()
-            .map(DiscoveredComponent::node)
-            .map(TypePathNode::type)
-            .map(TypeView::type)
-            .toList();
-        int startIndex = discoveredTypes.indexOf(path.get(0));
+                .map(DiscoveredComponent::node)
+                .map(TypePathNode::type)
+                .map(TypeView::type)
+                .toList();
+        int startIndex = discoveredTypes.indexOf(path.getFirst());
 
         for (int i = 0; i < path.size(); i++) {
-            Assertions.assertSame(path.get(i), discoveredTypes.get((startIndex + i) % path.size()));
+            assertThat(discoveredTypes.get((startIndex + i) % path.size())).isSameAs(path.get(i));
         }
     }
 
     @ParameterizedTest
     @MethodSource("circularDelayedResolution")
-    void testDelayedCircularDependencyPathIsEmpty(List<Class<?>> path) {
+    void delayedCircularDependencyPathIsEmpty(List<Class<?>> path)
+            throws Exception {
         DependencyGraph dependencyGraph = this.buildDependencyGraph(path);
         CyclicDependencyGraphValidator validator = new CyclicDependencyGraphValidator();
 
         Set<GraphNode<DependencyContext<?>>> roots = dependencyGraph.roots();
-        Assertions.assertEquals(0, roots.size()); // Cyclic, thus no roots
+        // Cyclic, thus no roots
+        assertThat(roots).isEmpty();
 
         Set<GraphNode<DependencyContext<?>>> nodes = dependencyGraph.nodes();
-        Assertions.assertEquals(path.size(),
-            nodes.size()); // N nodes, no duplicates, but does contain all nodes
+        // N nodes, no duplicates, but does contain all nodes
+        assertThat(nodes).hasSameSizeAs(path);
 
         Map<? extends Class<?>, GraphNode<DependencyContext<?>>> nodesByType = nodes.stream()
-            .collect(Collectors.toMap(node -> node.value().componentKey().type(),
-                Function.identity()));
-        GraphNode<DependencyContext<?>> firstNode = nodesByType.get(path.get(0));
+                .collect(Collectors.toMap(node -> node.value().componentKey().type(),
+                        Function.identity()));
+        GraphNode<DependencyContext<?>> firstNode = nodesByType.get(path.getFirst());
 
         List<GraphNode<DependencyContext<?>>> recursivePath =
-            validator.checkNodeNotCyclicRecursive(firstNode, new ArrayList<>());
+                validator.checkNodeNotCyclicRecursive(firstNode, new ArrayList<>());
         ComponentDiscoveryList discoveryList = validator.createDiscoveryList(recursivePath,
-            this.applicationContext.environment().introspector());
-        Assertions.assertNotNull(discoveryList);
+                this.applicationContext.environment().introspector());
+        assertThat(discoveryList).isNotNull();
 
         List<DiscoveredComponent> discoveredComponents = discoveryList.discoveredComponents();
-        Assertions.assertTrue(discoveredComponents.isEmpty());
+        assertThat(discoveredComponents).isEmpty();
     }
 
-    private DependencyGraph buildDependencyGraph(List<Class<?>> components) {
+    private DependencyGraph buildDependencyGraph(List<Class<?>> components)
+            throws DependencyResolutionException {
         Set<DependencyContext<?>> dependencyContexts = new HashSet<>();
         ApplicationEnvironment environment = this.applicationContext.environment();
         IntrospectionDependencyResolver dependencyResolver = new IntrospectionDependencyResolver(
-            environment.injectionPointsResolver(),
-            environment.componentKeyResolver()
+                environment.injectionPointsResolver(),
+                environment.componentKeyResolver()
         );
         for (Class<?> component : components) {
             ComponentKey<?> componentKey = ComponentKey.of(component);
             TypeView<?> typeView = environment.introspector().introspect(component);
 
             DependencyMap dependencyMap = DependencyMap.create()
-                // Fields and methods are always delayed, as they are not required for instantiation
-                .delayed(dependencyResolver.resolveDependencies(typeView));
+                    // Fields and methods are always delayed, as they are not required for
+                    // instantiation
+                    .delayed(dependencyResolver.resolveDependencies(typeView));
 
             View origin = typeView;
             if (!typeView.isInterface()) {
                 List<? extends ConstructorView<?>> constructorViews =
-                    typeView.constructors().all().stream()
-                        .filter(environment.injectionPointsResolver()::isInjectable)
-                        .toList();
+                        typeView.constructors().all().stream()
+                                .filter(environment.injectionPointsResolver()::isInjectable)
+                                .toList();
                 if (!constructorViews.isEmpty()) {
-                    Assertions.assertEquals(1, constructorViews.size());
-                    ConstructorView<?> constructorView = constructorViews.get(0);
+                    assertThat(constructorViews).hasSize(1);
+                    ConstructorView<?> constructorView = constructorViews.getFirst();
                     origin = constructorView;
-                    // Constructors are always immediate, as they are required to instantiate the component
+                    // Constructors are always immediate, as they are required to instantiate the
+                    // component
                     Set<ComponentKey<?>> immediateDependencies =
-                        dependencyResolver.resolveDependencies(constructorView);
+                            dependencyResolver.resolveDependencies(constructorView);
                     dependencyMap.putAll(DependencyResolutionType.IMMEDIATE, immediateDependencies);
                 }
             }
 
             ConfigurableDependencyContext<?> dependencyContext =
-                ConfigurableDependencyContext.builder(componentKey)
-                    .dependencies(dependencyMap)
-                    .priority(Priority.DEFAULT_PRIORITY)
-                    .memberType(ComponentMemberType.STANDALONE)
-                    .view(origin)
-                    .supplier(PrototypeInstantiationStrategy.empty())
-                    .build();
+                    ConfigurableDependencyContext.builder(componentKey)
+                            .dependencies(dependencyMap)
+                            .priority(Priority.DEFAULT_PRIORITY)
+                            .memberType(ComponentMemberType.STANDALONE)
+                            .view(origin)
+                            .supplier(PrototypeInstantiationStrategy.empty())
+                            .build();
             dependencyContexts.add(dependencyContext);
         }
 
         SimpleSingleElementContext<InjectionCapableApplication> context =
-            SimpleSingleElementContext.create(this.applicationContext);
+                SimpleSingleElementContext.create(this.applicationContext);
         DependencyResolver resolver =
-            ApplicationDependencyResolver.create(Customizer.useDefaults()).initialize(context);
+                ApplicationDependencyResolver.create(Customizer.useDefaults()).initialize(context);
         DependencyGraphBuilder dependencyGraphBuilder = DependencyGraphBuilder.create(
-            resolver,
-            this.applicationContext.defaultBinder(),
-            this.applicationContext.environment().introspector()
+                resolver,
+                this.applicationContext.defaultBinder(),
+                this.applicationContext.environment().introspector()
         );
-        return Assertions.assertDoesNotThrow(() -> dependencyGraphBuilder.buildDependencyGraph(
-            dependencyContexts));
+        return dependencyGraphBuilder.buildDependencyGraph(dependencyContexts);
     }
 
     @Test
-    void testCircularDependencyPathOnBoundTypeCanBeDetermined() {
+    void circularDependencyPathOnBoundTypeCanBeDetermined() throws Exception {
         // Bindings should be resolved during graph construction.
         this.applicationContext
-            .bind(InterfaceCircularDependencyA.class).to(BoundCircularDependencyA.class)
-            .bind(InterfaceCircularDependencyB.class).to(BoundCircularDependencyB.class);
+                .bind(InterfaceCircularDependencyA.class).to(BoundCircularDependencyA.class)
+                .bind(InterfaceCircularDependencyB.class).to(BoundCircularDependencyB.class);
 
         DependencyGraph dependencyGraph = this.buildDependencyGraph(List.of(
-            InterfaceCircularDependencyA.class,
-            InterfaceCircularDependencyB.class));
+                InterfaceCircularDependencyA.class,
+                InterfaceCircularDependencyB.class));
         CyclicDependencyGraphValidator validator = new CyclicDependencyGraphValidator();
 
         Set<GraphNode<DependencyContext<?>>> roots = dependencyGraph.roots();
-        Assertions.assertEquals(0, roots.size()); // Cyclic, so no roots
+        assertThat(roots).isEmpty(); // Cyclic, so no roots
 
         Set<GraphNode<DependencyContext<?>>> nodes = dependencyGraph.nodes();
-        Assertions.assertEquals(4, nodes.size()); // 4 nodes, 2 interfaces, 2 implementations
+        assertThat(nodes).hasSize(4); // 4 nodes, 2 interfaces, 2 implementations
 
         Map<? extends Class<?>, GraphNode<DependencyContext<?>>> nodesByType = nodes.stream()
-            .collect(Collectors.toMap(node -> node.value().componentKey().type(),
-                Function.identity()));
+                .collect(Collectors.toMap(node -> node.value().componentKey().type(),
+                        Function.identity()));
         GraphNode<DependencyContext<?>> firstNode = nodesByType.get(BoundCircularDependencyA.class);
 
         List<GraphNode<DependencyContext<?>>> recursivePath =
-            validator.checkNodeNotCyclicRecursive(firstNode, new ArrayList<>());
+                validator.checkNodeNotCyclicRecursive(firstNode, new ArrayList<>());
 
         ComponentDiscoveryList discoveryList = validator.createDiscoveryList(recursivePath,
-            this.applicationContext.environment().introspector());
+                this.applicationContext.environment().introspector());
         List<DiscoveredComponent> discoveredComponentsNonCyclic =
-            discoveryList.discoveredComponents();
-        Assertions.assertEquals(2, discoveredComponentsNonCyclic.size());
+                discoveryList.discoveredComponents();
+        assertThat(discoveredComponentsNonCyclic).hasSize(2);
 
         List<DiscoveredComponent> discoveredComponents = discoveryList.discoveredComponentsCyclic();
-        Assertions.assertEquals(3, discoveredComponents.size());
+        assertThat(discoveredComponents).hasSize(3);
 
-        DiscoveredComponent discoveredComponentA1 = discoveredComponents.get(0);
-        Assertions.assertSame(InterfaceCircularDependencyA.class,
-            discoveredComponentA1.node().type().type());
-        Assertions.assertSame(BoundCircularDependencyA.class,
-            discoveredComponentA1.actualType().type());
+        DiscoveredComponent discoveredComponentA1 = discoveredComponents.getFirst();
+        assertThat(discoveredComponentA1.node().type().type())
+                .isSameAs(InterfaceCircularDependencyA.class);
+        assertThat(discoveredComponentA1.actualType().type())
+                .isSameAs(BoundCircularDependencyA.class);
 
         DiscoveredComponent discoveredComponentB = discoveredComponents.get(1);
-        Assertions.assertSame(InterfaceCircularDependencyB.class,
-            discoveredComponentB.node().type().type());
-        Assertions.assertSame(BoundCircularDependencyB.class,
-            discoveredComponentB.actualType().type());
+        assertThat(discoveredComponentB.node().type().type())
+                .isSameAs(InterfaceCircularDependencyB.class);
+        assertThat(discoveredComponentB.actualType().type())
+                .isSameAs(BoundCircularDependencyB.class);
 
         DiscoveredComponent discoveredComponentA2 = discoveredComponents.get(2);
-        Assertions.assertSame(InterfaceCircularDependencyA.class,
-            discoveredComponentA2.node().type().type());
-        Assertions.assertSame(BoundCircularDependencyA.class,
-            discoveredComponentA2.actualType().type());
+        assertThat(discoveredComponentA2.node().type().type())
+                .isSameAs(InterfaceCircularDependencyA.class);
+        assertThat(discoveredComponentA2.actualType().type())
+                .isSameAs(BoundCircularDependencyA.class);
 
-        Assertions.assertEquals(discoveredComponentA1, discoveredComponentA2);
+        assertThat(discoveredComponentA2).isEqualTo(discoveredComponentA1);
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/collection/CollectionScopeTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/collection/CollectionScopeTests.java
@@ -16,9 +16,7 @@
 
 package test.org.dockbox.hartshorn.inject.collection;
 
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
@@ -31,48 +29,52 @@ import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.collections.CollectionUtilities;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class CollectionScopeTests {
+class CollectionScopeTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
     @DisplayName("Collection component registration creates valid hierarchy")
-    void testCollectionComponentRegistrationCreatesValidHierarchy() {
+    void collectionComponentRegistrationCreatesValidHierarchy() {
         this.applicationContext.bind(String.class).collect(collector -> {
             collector.singleton("John Doe");
             collector.supplier(() -> "Jane Doe");
         });
 
         ComponentKey<ComponentCollection<String>> componentKey = ComponentKey.collect(String.class);
-        BindingHierarchy<ComponentCollection<String>> hierarchy =
-            this.applicationContext.hierarchy(componentKey);
-        Assertions.assertTrue(hierarchy instanceof CollectionBindingHierarchy<String>);
+        BindingHierarchy<ComponentCollection<String>> hierarchy = this.applicationContext
+                .hierarchy(componentKey);
+        assertThat(hierarchy).isInstanceOf(CollectionBindingHierarchy.class);
 
-        Assertions.assertEquals(1, hierarchy.size());
+        assertThat(hierarchy.size()).isOne();
 
         int highestPriority = hierarchy.highestPriority();
         Option<InstantiationStrategy<ComponentCollection<String>>> candidateProvider =
             hierarchy.get(highestPriority);
-        Assertions.assertTrue(candidateProvider.present());
+        assertThat(candidateProvider.present()).isTrue();
 
         InstantiationStrategy<ComponentCollection<String>> strategy = candidateProvider.get();
-        Assertions.assertTrue(strategy instanceof CollectionInstantiationStrategy<String>);
-
-        CollectionInstantiationStrategy<String> collectionProvider =
-            (CollectionInstantiationStrategy<String>) strategy;
-        Set<InstantiationStrategy<String>> strategies = collectionProvider.providers();
-        Assertions.assertEquals(2, strategies.size());
+        assertThat(strategy)
+                .asInstanceOf(InstanceOfAssertFactories.type(CollectionInstantiationStrategy.class))
+                .extracting(CollectionInstantiationStrategy::providers)
+                .asInstanceOf(InstanceOfAssertFactories.collection(InstantiationStrategy.class))
+                .hasSize(2);
     }
 
     @Test
     @DisplayName("Collection components can be provided")
-    void testCollectionComponentsCanBeProvided() {
+    void collectionComponentsCanBeProvided() {
         ComponentKey<String> nameKey = ComponentKey.of(String.class, "names");
         List<String> names = List.of("John", "Jane", "Joe");
         this.applicationContext.bind(nameKey)
@@ -82,16 +84,17 @@ public class CollectionScopeTests {
             nameKey.mutable().collector().build();
         ComponentCollection<String> nameCollection = this.applicationContext.get(collectionKey);
 
-        Assertions.assertEquals(3, nameCollection.size());
-        Assertions.assertTrue(nameCollection.contains("John"));
-        Assertions.assertTrue(nameCollection.contains("Jane"));
-        Assertions.assertTrue(nameCollection.contains("Joe"));
+        assertThat(nameCollection)
+                .hasSize(3)
+                .contains("John")
+                .contains("Jane")
+                .contains("Joe");
     }
 
     @Test
     @DisplayName("Collection components can be provided to a non-specific collection (List)")
     @TestComponents(ComponentWithCollectionDependencies.class)
-    void testComponentInjectionWithoutExplicitCollection() {
+    void componentInjectionWithoutExplicitCollection() {
         ComponentKey<String> nameKey = ComponentKey.of(String.class, "names");
         this.applicationContext.bind(nameKey).collect(collector -> {
             collector.singleton("Foo");
@@ -102,16 +105,16 @@ public class CollectionScopeTests {
             this.applicationContext.get(ComponentWithCollectionDependencies.class);
         List<String> names = component.names();
 
-        Assertions.assertNotNull(names);
-        Assertions.assertEquals(2, names.size());
-        Assertions.assertTrue(names.contains("Foo"));
-        Assertions.assertTrue(names.contains("Bar"));
+        assertThat(names)
+                .hasSize(2)
+                .contains("Foo")
+                .contains("Bar");
     }
 
     @Test
     @DisplayName("Collection components can be provided to a specific collection (Set -> TreeSet)")
     @TestComponents(ComponentWithCollectionDependencies.class)
-    void testComponentInjectionWithExplicitCollection() {
+    void componentInjectionWithExplicitCollection() {
         ComponentKey<Integer> ageKey = ComponentKey.of(Integer.class, "ages");
         this.applicationContext.bind(ageKey).collect(collector -> {
             collector.singleton(1);
@@ -122,23 +125,23 @@ public class CollectionScopeTests {
             this.applicationContext.get(ComponentWithCollectionDependencies.class);
         Set<Integer> ages = component.ages();
 
-        Assertions.assertNotNull(ages);
-        Assertions.assertTrue(ages instanceof TreeSet<Integer>);
-        Assertions.assertEquals(2, ages.size());
-        Assertions.assertTrue(ages.contains(1));
-        Assertions.assertTrue(ages.contains(2));
+        assertThat(ages)
+                .isInstanceOf(TreeSet.class)
+                .hasSize(2)
+                .contains(1)
+                .contains(2);
     }
 
     @Test
     @DisplayName("Collection components can be obtained with a collection component key")
     @TestComponents(CompositeMembersConfiguration.class)
-    void testCollectionsAreCollected() {
+    void collectionsAreCollected() {
         ComponentKey<ComponentCollection<StaticComponent>> componentKey =
             ComponentKey.collect(StaticComponent.class);
         ComponentCollection<StaticComponent> collection = this.applicationContext.get(componentKey);
         // Even if no bindings are present, the collection should be created
-        Assertions.assertNotNull(collection);
-        Assertions.assertEquals(0, collection.size());
+        assertThat(collection).isNotNull();
+        assertThat(collection).isEmpty();
 
         String[] names = {
             CompositeMembersConfiguration.USER,
@@ -148,8 +151,8 @@ public class CollectionScopeTests {
         for (String name : names) {
             componentKey = componentKey.mutable().name(name).build();
             collection = this.applicationContext.get(componentKey);
-            Assertions.assertEquals(1, collection.size());
-            Assertions.assertEquals(name, CollectionUtilities.first(collection).name());
+            assertThat(collection).hasSize(1);
+            assertThat(CollectionUtilities.first(collection).name()).isEqualTo(name);
         }
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/collection/ComponentCollectionTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/collection/ComponentCollectionTests.java
@@ -19,23 +19,25 @@ package test.org.dockbox.hartshorn.inject.collection;
 import java.util.Set;
 
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.collection.ComponentCollection;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.dockbox.hartshorn.inject.annotations.Inject;
 
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ComponentCollectionTests {
+class ComponentCollectionTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
-    void testPriority() {
+    void priority() {
         Set<String> strings = Set.of("Hello", "World", "!");
         this.applicationContext.bind(String.class).collect(collector -> {
             for (String string : strings) {
@@ -47,20 +49,22 @@ public class ComponentCollectionTests {
 
         ComponentCollection<String> collection =
             this.applicationContext.get(ComponentKey.collect(String.class));
-        Assertions.assertEquals(3, collection.size());
-        Assertions.assertTrue(collection.containsAll(strings));
+        assertThat(collection)
+                .hasSize(3)
+                .containsAll(strings);
 
         String hello = this.applicationContext.get(String.class);
-        Assertions.assertEquals("Hello world!", hello);
+        assertThat(hello).isEqualTo("Hello world!");
     }
 
     @Test
     @TestComponents(CollectionConfiguration.class)
-    void testConfigurationLoadsWithDependencies() {
+    void configurationLoadsWithDependencies() {
         ComponentCollection<String> collection =
             this.applicationContext.get(ComponentKey.collect(String.class));
-        Assertions.assertEquals(2, collection.size());
-        Assertions.assertTrue(collection.contains("Hello"));
-        Assertions.assertTrue(collection.contains("World"));
+        assertThat(collection)
+                .hasSize(2)
+                .contains("Hello")
+                .contains("World");
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/compatibility/JakartaCompatibilityTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/compatibility/JakartaCompatibilityTests.java
@@ -30,15 +30,17 @@ import org.dockbox.hartshorn.launchpad.environment.ConfigurableApplicationEnviro
 import org.dockbox.hartshorn.test.TestApplicationCustomizer;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.configure.ContextualInitializer;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @HartshornIntegrationTest(
     includeBasePackages = false,
     customizers = DisableSingleConstructorFallbackTestCustomizer.class
 )
-public class JakartaCompatibilityTests {
+class JakartaCompatibilityTests {
 
     /**
      * Test application customizer that enables support for Jakarta annotations in the test
@@ -50,11 +52,11 @@ public class JakartaCompatibilityTests {
         @Override
         public void customizeApplication(SimpleApplicationContext.Configurer configurer) {
             configurer.componentProvider(HierarchicalComponentProviderOrchestrator.create(
-                orchestrator -> {
-                    orchestrator.componentPostConstructor(AnnotatedMethodComponentPostConstructor.create(
-                        AnnotatedMethodComponentPostConstructor.Configurer::withJakartaAnnotations
-                    ));
-                }));
+                orchestrator -> orchestrator.componentPostConstructor(
+                        AnnotatedMethodComponentPostConstructor.create(
+                                AnnotatedMethodComponentPostConstructor.Configurer::withJakartaAnnotations
+                        )
+                )));
         }
 
         @Override
@@ -74,90 +76,83 @@ public class JakartaCompatibilityTests {
     @Test
     @HartshornIntegrationTest(customizers = EnableJakartaTestApplicationCustomizer.class)
     @DisplayName("Jakarta annotations are supported for field injection, if enabled")
-    void testJakartaFieldInjectSupportedIfEnabled() {
+    void jakartaFieldInjectSupportedIfEnabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         FieldJakartaComponent component =
             this.applicationContext.defaultProvider().get(FieldJakartaComponent.class);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
-        Assertions.assertEquals("Hello, World!", component.messageAsInject);
-        Assertions.assertEquals("Hello, World!", component.messageAsResource);
+        assertThat(component.messageAsInject).isEqualTo("Hello, World!");
+        assertThat(component.messageAsResource).isEqualTo("Hello, World!");
     }
 
     @Test
     @DisplayName("Jakarta annotations are not supported for field injection, if disabled")
-    void testJakartaFieldInjectFailsIfDisabled() {
+    void jakartaFieldInjectFailsIfDisabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         FieldJakartaComponent component =
             this.applicationContext.defaultProvider().get(FieldJakartaComponent.class);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
-        Assertions.assertNull(component.messageAsInject,
-            "Field injection with @jakarta.inject.Inject should not be supported when Jakarta compatibility is disabled");
-        Assertions.assertNull(component.messageAsResource,
-            "Field injection with @jakarta.annotation.Resource should not be supported when Jakarta compatibility is disabled");
+        assertThat(component.messageAsInject).isNull();
+        assertThat(component.messageAsResource).isNull();
     }
 
     @Test
     @HartshornIntegrationTest(customizers = EnableJakartaTestApplicationCustomizer.class)
     @DisplayName("Jakarta annotations are supported for constructor injection, if enabled")
-    void testJakartaConstructorInjectSupportedIfEnabled() {
+    void jakartaConstructorInjectSupportedIfEnabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         ConstructorJakartaComponent component =
             this.applicationContext.defaultProvider().get(ConstructorJakartaComponent.class);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
-        Assertions.assertEquals("Hello, World!", component.messageAsInject);
+        assertThat(component.messageAsInject).isEqualTo("Hello, World!");
     }
 
     @Test
     @DisplayName("Jakarta annotations are not supported for constructor injection, if disabled")
-    void testJakartaConstructorInjectFailsIfDisabled() {
+    void jakartaConstructorInjectFailsIfDisabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         // No compatible constructor should be found, as Jakarta compatibility is disabled
-        ComponentResolutionException componentResolutionException = Assertions.assertThrows(
-            ComponentResolutionException.class,
-            () -> this.applicationContext.defaultProvider().get(ConstructorJakartaComponent.class),
-            "Constructor injection with @jakarta.inject.Inject should not be supported when Jakarta compatibility is disabled"
-        );
-        Assertions.assertInstanceOf(
-            MissingInjectConstructorException.class,
-            componentResolutionException.getCause(),
-            "Constructor injection with @jakarta.inject.Inject should not be supported when Jakarta compatibility is disabled"
-        );
+        Throwable componentResolutionException =
+                assertThatThrownBy(() -> {
+                    this.applicationContext.defaultProvider()
+                        .get(ConstructorJakartaComponent.class);
+                }).isInstanceOf(ComponentResolutionException.class).actual();
+        assertThat(componentResolutionException.getCause())
+                .isInstanceOf(MissingInjectConstructorException.class);
     }
 
     @Test
     @HartshornIntegrationTest(customizers = EnableJakartaTestApplicationCustomizer.class)
     @DisplayName("Jakarta annotations are supported for method injection, if enabled")
-    void testJakartaMethodInjectSupportedIfEnabled() {
+    void jakartaMethodInjectSupportedIfEnabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         MethodJakartaComponent component =
             this.applicationContext.defaultProvider().get(MethodJakartaComponent.class);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
-        Assertions.assertEquals("Hello, World!", component.messageAsInject);
-        Assertions.assertEquals("Hello, World!", component.messageAsResource);
+        assertThat(component.messageAsInject).isEqualTo("Hello, World!");
+        assertThat(component.messageAsResource).isEqualTo("Hello, World!");
     }
 
     @Test
     @DisplayName("Jakarta annotations are not supported for method injection, if disabled")
-    void testJakartaMethodInjectFailsIfDisabled() {
+    void jakartaMethodInjectFailsIfDisabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         MethodJakartaComponent component =
             this.applicationContext.defaultProvider().get(MethodJakartaComponent.class);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
-        Assertions.assertNull(component.messageAsInject,
-            "Method injection with @jakarta.inject.Inject should not be supported when Jakarta compatibility is disabled");
-        Assertions.assertNull(component.messageAsResource,
-            "Method injection with @jakarta.annotation.Resource should not be supported when Jakarta compatibility is disabled");
+        assertThat(component.messageAsInject).isNull();
+        assertThat(component.messageAsResource).isNull();
     }
 
     private static class FieldJakartaComponent {

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/compatibility/JavaxCompatibilityTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/compatibility/JavaxCompatibilityTests.java
@@ -28,18 +28,20 @@ import org.dockbox.hartshorn.launchpad.environment.ConfigurableApplicationEnviro
 import org.dockbox.hartshorn.test.TestApplicationCustomizer;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.configure.ContextualInitializer;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Resource;
 import javax.inject.Inject;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 @HartshornIntegrationTest(
     includeBasePackages = false,
     customizers = DisableSingleConstructorFallbackTestCustomizer.class
 )
-public class JavaxCompatibilityTests {
+class JavaxCompatibilityTests {
 
     /**
      * Test application customizer that enables support for Javax annotations in the test
@@ -50,11 +52,12 @@ public class JavaxCompatibilityTests {
         @Override
         public void customizeApplication(SimpleApplicationContext.Configurer configurer) {
             configurer.componentProvider(HierarchicalComponentProviderOrchestrator.create(
-                orchestrator -> {
-                    orchestrator.componentPostConstructor(AnnotatedMethodComponentPostConstructor.create(
-                        AnnotatedMethodComponentPostConstructor.Configurer::withJavaxAnnotations
-                    ));
-                }));
+                orchestrator -> orchestrator.componentPostConstructor(
+                        AnnotatedMethodComponentPostConstructor.create(
+                                AnnotatedMethodComponentPostConstructor.Configurer
+                                        ::withJavaxAnnotations
+                        )
+                )));
         }
 
         @Override
@@ -74,91 +77,82 @@ public class JavaxCompatibilityTests {
     @Test
     @HartshornIntegrationTest(customizers = EnableJavaxTestApplicationCustomizer.class)
     @DisplayName("Javax annotations are supported for field injection, if enabled")
-    void testJavaxFieldInjectSupportedIfEnabled() {
+    void javaxFieldInjectSupportedIfEnabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         FieldJavaxComponent component =
             this.applicationContext.defaultProvider().get(FieldJavaxComponent.class);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
-        Assertions.assertEquals("Hello, World!", component.messageAsInject);
-        Assertions.assertEquals("Hello, World!", component.messageAsResource);
+        assertThat(component.messageAsInject).isEqualTo("Hello, World!");
+        assertThat(component.messageAsResource).isEqualTo("Hello, World!");
     }
 
     @Test
     @DisplayName("Javax annotations are not supported for field injection, if disabled")
-    void testJavaxFieldInjectFailsIfDisabled() {
+    void javaxFieldInjectFailsIfDisabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         FieldJavaxComponent component =
             this.applicationContext.defaultProvider().get(FieldJavaxComponent.class);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
-        Assertions.assertNull(component.messageAsInject,
-            "Field injection with @javax.inject.Inject should not be supported when Javax compatibility is disabled");
-        Assertions.assertNull(component.messageAsResource,
-            "Field injection with @javax.annotation.Resource should not be supported when Javax compatibility is disabled");
+        assertThat(component.messageAsInject).isNull();
+        assertThat(component.messageAsResource).isNull();
     }
 
     @Test
     @HartshornIntegrationTest(customizers = EnableJavaxTestApplicationCustomizer.class)
     @DisplayName("Javax annotations are supported for constructor injection, if enabled")
-    void testJavaxConstructorInjectSupportedIfEnabled() {
+    void javaxConstructorInjectSupportedIfEnabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         ConstructorJavaxComponent component =
             this.applicationContext.defaultProvider().get(ConstructorJavaxComponent.class);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
-        Assertions.assertEquals("Hello, World!", component.messageAsInject);
+        assertThat(component.messageAsInject).isEqualTo("Hello, World!");
     }
 
     @Test
     @DisplayName("Javax annotations are not supported for constructor injection, if disabled")
-    void testJavaxConstructorInjectFailsIfDisabled() {
+    void javaxConstructorInjectFailsIfDisabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         // No compatible constructor should be found, as Javax compatibility is disabled
-        ComponentResolutionException componentResolutionException = Assertions.assertThrows(
-            ComponentResolutionException.class,
-            () -> this.applicationContext.defaultProvider()
-                .get(JavaxCompatibilityTests.ConstructorJavaxComponent.class),
-            "Constructor injection with @javax.inject.Inject should not be supported when Javax compatibility is disabled"
-        );
-        Assertions.assertInstanceOf(
-            MissingInjectConstructorException.class,
-            componentResolutionException.getCause(),
-            "Constructor injection with @javax.inject.Inject should not be supported when Javax compatibility is disabled"
-        );
+        Throwable componentResolutionException = assertThatThrownBy(() -> {
+            this.applicationContext.defaultProvider()
+                .get(JavaxCompatibilityTests.ConstructorJavaxComponent.class);
+        }).isInstanceOf(ComponentResolutionException.class).actual();
+        assertThat(componentResolutionException.getCause())
+                .isInstanceOf(MissingInjectConstructorException.class);
     }
 
     @Test
     @HartshornIntegrationTest(customizers = EnableJavaxTestApplicationCustomizer.class)
     @DisplayName("Javax annotations are supported for method injection, if enabled")
-    void testJavaxMethodInjectSupportedIfEnabled() {
+    void javaxMethodInjectSupportedIfEnabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         MethodJavaxComponent component =
             this.applicationContext.defaultProvider().get(MethodJavaxComponent.class);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
-        Assertions.assertEquals("Hello, World!", component.messageAsInject);
-        Assertions.assertEquals("Hello, World!", component.messageAsResource);
+        assertThat(component.messageAsInject).isEqualTo("Hello, World!");
+        assertThat(component.messageAsResource).isEqualTo("Hello, World!");
     }
 
     @Test
     @DisplayName("Javax annotations are not supported for method injection, if disabled")
-    void testJavaxMethodInjectFailsIfDisabled() {
+    void javaxMethodInjectFailsIfDisabled() {
         this.applicationContext.defaultBinder().bind(String.class).singleton("Hello, World!");
 
         MethodJavaxComponent component =
             this.applicationContext.defaultProvider().get(MethodJavaxComponent.class);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
-        Assertions.assertNull(component.messageAsInject,
-            "Method injection with @javax.inject.Inject should not be supported when Javax compatibility is disabled");
-        Assertions.assertNull(component.messageAsResource,
-            "Method injection with @javax.annotation.Resource should not be supported when Javax compatibility is disabled");
+        assertThat(component.messageAsInject).isNull();
+        assertThat(component.messageAsResource).isNull();
     }
 
     private static class FieldJavaxComponent {

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/conditions/ConditionTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/conditions/ConditionTests.java
@@ -35,13 +35,14 @@ import org.dockbox.hartshorn.test.annotations.TestProperties;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("unused")
 @HartshornIntegrationTest(includeBasePackages = false)
@@ -71,24 +72,24 @@ public class ConditionTests {
     @ParameterizedTest
     @MethodSource("properties")
     @TestComponents(ConditionalConfiguration.class)
-    void testPropertyConditions(String name, boolean present) {
+    void propertyConditions(String name, boolean present) {
         ComponentKey<String> key = ComponentKey.builder(String.class).name(name).build();
         BindingHierarchy<String> hierarchy = this.applicationContext.hierarchy(key);
-        Assertions.assertEquals(present ? 1 : 0, hierarchy.size());
+        assertThat(hierarchy.size()).isEqualTo(present ? 1 : 0);
 
         String value = this.applicationContext.get(key);
         if (present) {
-            Assertions.assertEquals(name, value);
+            assertThat(value).isEqualTo(name);
         }
         else {
-            Assertions.assertEquals("", value); // Default value, not null
+            assertThat(value).isEmpty(); // Default value, not null
         }
     }
 
     @Test
-    void testActivatorConditions() {
-        Assertions.assertTrue(this.applicationContext.activators()
-            .hasActivator(DemoActivator.class));
+    void activatorConditions() {
+        assertThat(this.applicationContext.activators()
+            .hasActivator(DemoActivator.class)).isTrue();
 
         MethodView<ConditionTests, ?> method = this.applicationContext.environment()
             .introspector()
@@ -103,7 +104,7 @@ public class ConditionTests {
         Condition condition = new ActivatorCondition();
 
         ConditionResult result = condition.matches(context);
-        Assertions.assertTrue(result.matches());
+        assertThat(result.matches()).isTrue();
     }
 
     @RequiresActivator(DemoActivator.class)
@@ -111,7 +112,7 @@ public class ConditionTests {
     }
 
     @Test
-    void testClassConditions() {
+    void classConditions() {
         TypeView<ConditionTests> type =
             this.applicationContext.environment().introspector().introspect(ConditionTests.class);
         Condition condition = new ClassCondition();
@@ -122,7 +123,7 @@ public class ConditionTests {
         ConditionContext contextForPresent = new ConditionContext(this.applicationContext,
             requiresClass,
             new AnnotationConditionDeclaration(annotationForPresent));
-        Assertions.assertTrue(condition.matches(contextForPresent).matches());
+        assertThat(condition.matches(contextForPresent).matches()).isTrue();
 
         MethodView<ConditionTests, ?> requiresAbsentClass =
             type.methods().named("requiresAbsentClass").get();
@@ -131,7 +132,7 @@ public class ConditionTests {
         ConditionContext contextForAbsent = new ConditionContext(this.applicationContext,
             requiresAbsentClass,
             new AnnotationConditionDeclaration(annotationForAbsent));
-        Assertions.assertFalse(condition.matches(contextForAbsent).matches());
+        assertThat(condition.matches(contextForAbsent).matches()).isFalse();
     }
 
     @RequiresClass("java.lang.String")
@@ -143,18 +144,18 @@ public class ConditionTests {
     }
 
     @Test
-    void testEnclosedViewsIncludeParentCondition() {
+    void enclosedViewsIncludeParentCondition() {
         TypeView<ParentClass> type =
             this.applicationContext.environment().introspector().introspect(ParentClass.class);
         ConditionMatcher matcher = new ConditionMatcher(() -> this.applicationContext);
-        Assertions.assertFalse(matcher.match(type));
+        assertThat(matcher.match(type)).isFalse();
 
         MethodView<ParentClass, ?> methodView = type.methods().named("requiresClass").get();
         matcher.includeEnclosingConditions(false);
-        Assertions.assertTrue(matcher.match(methodView));
+        assertThat(matcher.match(methodView)).isTrue();
 
         matcher.includeEnclosingConditions(true);
-        Assertions.assertFalse(matcher.match(methodView));
+        assertThat(matcher.match(methodView)).isFalse();
     }
 
     @RequiresClass("java.gnal.String")

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/context/ContextInjectionTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/context/ContextInjectionTests.java
@@ -20,11 +20,12 @@ import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.inject.populate.ComponentPopulator;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ContextInjectionTests {
+class ContextInjectionTests {
 
     @Inject
     private ComponentPopulator componentPopulator;
@@ -33,26 +34,26 @@ public class ContextInjectionTests {
     private ApplicationContext applicationContext;
 
     @Test
-    void testContextFieldsAreInjected() {
+    void contextFieldsAreInjected() {
         String contextName = "InjectedContext";
         this.applicationContext.addContext(new SampleContext(contextName));
 
         ContextInjectedType instance = this.componentPopulator.populate(new ContextInjectedType(),
             this.applicationContext.scope());
 
-        Assertions.assertNotNull(instance.context());
-        Assertions.assertEquals(contextName, instance.context().name());
+        assertThat(instance.context()).isNotNull();
+        assertThat(instance.context().name()).isEqualTo(contextName);
     }
 
     @Test
-    void testNamedContextFieldsAreInjected() {
+    void namedContextFieldsAreInjected() {
         String contextName = "InjectedContext";
         this.applicationContext.addContext("another", new SampleContext(contextName));
 
         ContextInjectedType instance = this.componentPopulator.populate(new ContextInjectedType(),
             this.applicationContext.scope());
 
-        Assertions.assertNotNull(instance.anotherContext());
-        Assertions.assertEquals(contextName, instance.anotherContext().name());
+        assertThat(instance.anotherContext()).isNotNull();
+        assertThat(instance.anotherContext().name()).isEqualTo(contextName);
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/exception/ExceptionHandlerTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/exception/ExceptionHandlerTests.java
@@ -22,14 +22,15 @@ import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.launchpad.environment.ConfigurableApplicationEnvironment;
 import org.dockbox.hartshorn.test.TestApplicationCustomizer;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(
     includeBasePackages = false,
     customizers = ExceptionHandlerTests.ExceptionHandlerTestsCustomizer.class
 )
-public class ExceptionHandlerTests {
+class ExceptionHandlerTests {
 
     public static class ExceptionHandlerTestsCustomizer implements TestApplicationCustomizer {
         @Override
@@ -44,53 +45,53 @@ public class ExceptionHandlerTests {
     private static CachingExceptionHandler HANDLE;
 
     @Test
-    public void testExceptKeepsPreferences() {
+    void exceptKeepsPreferences() {
         this.applicationContext.environment().printStackTraces(true);
 
         Throwable throwable = new Exception("Test");
         this.applicationContext.handle("Test", throwable);
 
-        Assertions.assertTrue(HANDLE.stacktrace());
-        Assertions.assertEquals("Test", HANDLE.message());
-        Assertions.assertSame(throwable, HANDLE.exception());
+        assertThat(HANDLE.stacktrace()).isTrue();
+        assertThat(HANDLE.message()).isEqualTo("Test");
+        assertThat(HANDLE.exception()).isSameAs(throwable);
     }
 
     @Test
-    public void testExceptUsesExceptionMessageIfNoneProvided() {
+    void exceptUsesExceptionMessageIfNoneProvided() {
         Exception throwable = new Exception("Something broke!");
         this.applicationContext.handle(throwable);
 
-        Assertions.assertSame(throwable, HANDLE.exception());
-        Assertions.assertEquals("Something broke!", HANDLE.message());
+        assertThat(HANDLE.exception()).isSameAs(throwable);
+        assertThat(HANDLE.message()).isEqualTo("Something broke!");
     }
 
     @Test
-    public void testExceptUsesFirstExceptionMessageIfNoneProvided() {
+    void exceptUsesFirstExceptionMessageIfNoneProvided() {
         Exception cause = new Exception("I caused it!");
         Exception throwable = new Exception("Something broke!", cause);
         this.applicationContext.handle(throwable);
 
-        Assertions.assertSame(throwable, HANDLE.exception());
-        Assertions.assertEquals("Something broke!", HANDLE.message());
+        assertThat(HANDLE.exception()).isSameAs(throwable);
+        assertThat(HANDLE.message()).isEqualTo("Something broke!");
     }
 
     @Test
-    public void testGetFirstUsesParentFirst() {
+    void getFirstUsesParentFirst() {
         Exception cause = new Exception("I caused it!");
         Exception throwable = new Exception("Something broke!", cause);
 
         String message = LoggingExceptionHandler.firstMessage(throwable);
 
-        Assertions.assertEquals("Something broke!", message);
+        assertThat(message).isEqualTo("Something broke!");
     }
 
     @Test
-    public void testGetFirstUsesCauseIfParentMessageAbsent() {
+    void getFirstUsesCauseIfParentMessageAbsent() {
         Exception cause = new Exception("I caused it!");
         Exception throwable = new Exception(null, cause);
 
         String message = LoggingExceptionHandler.firstMessage(throwable);
 
-        Assertions.assertEquals("I caused it!", message);
+        assertThat(message).isEqualTo("I caused it!");
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/populate/ComponentPopulationTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/populate/ComponentPopulationTests.java
@@ -35,7 +35,6 @@ import org.dockbox.hartshorn.util.configure.Customizer;
 import org.dockbox.hartshorn.util.introspect.view.FieldView;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.inject.provider.SampleImplementation;
 import test.org.dockbox.hartshorn.inject.provider.SampleInterface;
@@ -43,14 +42,17 @@ import test.org.dockbox.hartshorn.inject.provider.SampleInterface;
 import java.util.List;
 import java.util.function.Function;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ComponentPopulationTests {
+class ComponentPopulationTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
-    void testContextFieldPopulation() {
+    void contextFieldPopulation() {
         SampleContext sampleContext = new SampleContext();
         this.applicationContext.addContext(sampleContext);
 
@@ -60,12 +62,13 @@ public class ComponentPopulationTests {
 
         PopulationTestComponent component = this.createAndPopulateComponent(strategy,
             type -> createFieldInjectionPoint("context", type));
-        Assertions.assertNotNull(component.context);
-        Assertions.assertSame(sampleContext, component.context);
+        assertThat(component.context)
+                .isNotNull()
+                .isSameAs(sampleContext);
     }
 
     @Test
-    void testInjectFieldPopulation() {
+    void injectFieldPopulation() {
         ComponentPopulationStrategy strategy =
             InjectPopulationStrategy.create(Customizer.useDefaults())
                 .initialize(SimpleSingleElementContext.create(this.applicationContext));
@@ -73,12 +76,13 @@ public class ComponentPopulationTests {
         PopulationTestComponent component =
             this.createAndPopulateComponent(strategy,
                 type -> createFieldInjectionPoint("applicationContext", type));
-        Assertions.assertNotNull(component.applicationContext);
-        Assertions.assertSame(this.applicationContext, component.applicationContext);
+        assertThat(component.applicationContext)
+                .isNotNull()
+                .isSameAs(this.applicationContext);
     }
 
     @Test
-    void testInjectMethodPopulation() {
+    void injectMethodPopulation() {
         ComponentPopulationStrategy strategy =
             InjectPopulationStrategy.create(Customizer.useDefaults())
                 .initialize(SimpleSingleElementContext.create(this.applicationContext));
@@ -87,12 +91,13 @@ public class ComponentPopulationTests {
             type -> createMethodInjectionPoint("setApplicationContext",
                 List.of(ApplicationContext.class),
                 type));
-        Assertions.assertNotNull(component.applicationContext);
-        Assertions.assertSame(this.applicationContext, component.applicationContext);
+        assertThat(component.applicationContext)
+                .isNotNull()
+                .isSameAs(this.applicationContext);
     }
 
     @Test
-    void testInjectMixedMethodPopulation() {
+    void injectMixedMethodPopulation() {
         SampleContext sampleContext = new SampleContext();
         this.applicationContext.addContext(sampleContext);
 
@@ -104,22 +109,24 @@ public class ComponentPopulationTests {
             type -> createMethodInjectionPoint("setContexts",
                 List.of(ApplicationContext.class, SampleContext.class),
                 type));
-        Assertions.assertNotNull(component.applicationContext);
-        Assertions.assertSame(this.applicationContext, component.applicationContext);
+        assertThat(component.applicationContext)
+                .isNotNull()
+                .isSameAs(this.applicationContext);
 
-        Assertions.assertNotNull(component.context);
-        Assertions.assertSame(sampleContext, component.context);
+        assertThat(component.context)
+                .isNotNull()
+                .isSameAs(sampleContext);
     }
 
     @Test
     @TestComponents(SampleConfiguration.class)
-    public void testTypesCanBePopulated(@Inject ComponentPopulator populator) {
+    void typesCanBePopulated(@Inject ComponentPopulator populator) {
         PopulatedType populatedType = new PopulatedType();
-        Assertions.assertNull(populatedType.sampleInterface());
+        assertThat(populatedType.sampleInterface()).isNull();
 
         populator.populate(populatedType, this.applicationContext.scope());
-        Assertions.assertNotNull(populatedType.sampleInterface());
-        Assertions.assertEquals(SampleImplementation.NAME, populatedType.sampleInterface().name());
+        assertThat(populatedType.sampleInterface()).isNotNull();
+        assertThat(populatedType.sampleInterface().name()).isEqualTo(SampleImplementation.NAME);
     }
 
     @Configuration
@@ -146,7 +153,8 @@ public class ComponentPopulationTests {
 
         ComponentInjectionPoint<PopulationTestComponent> injectionPoint =
             injectionPointProvider.apply(typeView);
-        Assertions.assertDoesNotThrow(() -> strategy.populate(componentContext, injectionPoint));
+        assertThatCode(() -> strategy.populate(componentContext, injectionPoint))
+                .doesNotThrowAnyException();
 
         return component;
     }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/populate/ContextConfiguringComponentProcessorTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/populate/ContextConfiguringComponentProcessorTests.java
@@ -23,43 +23,44 @@ import org.dockbox.hartshorn.proxy.ProxyOrchestrator;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(
     includeBasePackages = false,
     componentPostProcessors = SimpleContextConfiguringComponentProcessor.class
 )
-public class ContextConfiguringComponentProcessorTests {
+class ContextConfiguringComponentProcessorTests {
 
     @Test
     @TestComponents(EmptyComponent.class)
-    void testNonContextComponentIsProcessed(
+    void nonContextComponentIsProcessed(
         @Inject EmptyComponent emptyComponent,
         @Inject ProxyOrchestrator proxyOrchestrator
     ) {
-        Assertions.assertNotNull(emptyComponent);
-        Assertions.assertTrue(proxyOrchestrator.isProxy(emptyComponent));
+        assertThat(emptyComponent).isNotNull();
+        assertThat(proxyOrchestrator.isProxy(emptyComponent)).isTrue();
 
         Proxy<EmptyComponent> component = (Proxy<EmptyComponent>) emptyComponent;
         Option<SimpleContext> context =
             component.manager().firstContext(ContextKey.of(SimpleContext.class));
-        Assertions.assertTrue(context.present());
-        Assertions.assertEquals("Foo", context.get().value());
+        assertThat(context.present()).isTrue();
+        assertThat(context.get().value()).isEqualTo("Foo");
     }
 
     @Test
     @TestComponents(ContextComponent.class)
-    void testContextComponentIsProcessed(
+    void contextComponentIsProcessed(
         @Inject ContextComponent contextComponent,
         @Inject ProxyOrchestrator proxyOrchestrator
     ) {
-        Assertions.assertNotNull(contextComponent);
-        Assertions.assertFalse(proxyOrchestrator.isProxy(contextComponent));
+        assertThat(contextComponent).isNotNull();
+        assertThat(proxyOrchestrator.isProxy(contextComponent)).isFalse();
 
         Option<SimpleContext> context =
             contextComponent.firstContext(ContextKey.of(SimpleContext.class));
-        Assertions.assertTrue(context.present());
-        Assertions.assertEquals("Foo", context.get().value());
+        assertThat(context.present()).isTrue();
+        assertThat(context.get().value()).isEqualTo("Foo");
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/processing/BinderProcessorTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/processing/BinderProcessorTests.java
@@ -22,21 +22,22 @@ import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
 import org.dockbox.hartshorn.inject.binding.HierarchicalBinder;
 import org.dockbox.hartshorn.inject.provider.ComponentProvider;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false, binderPostProcessors = SampleBinderPostProcessor.class)
-public class BinderProcessorTests {
+class BinderProcessorTests {
 
     @Test
-    void testBinderPostProcessorIsCalled(
+    void binderPostProcessorIsCalled(
         @Inject HierarchicalBinder binder,
         @Inject ComponentProvider provider
     ) {
         BindingHierarchy<String> hierarchy = binder.hierarchy(ComponentKey.of(String.class));
-        Assertions.assertTrue(hierarchy.size() > 0);
+        assertThat(hierarchy.size()).isPositive();
 
         String message = provider.get(String.class);
-        Assertions.assertEquals(SampleBinderPostProcessor.HELLO_WORLD, message);
+        assertThat(message).isEqualTo(SampleBinderPostProcessor.HELLO_WORLD);
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/processing/ComponentProcessorTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/processing/ComponentProcessorTests.java
@@ -19,16 +19,17 @@ package test.org.dockbox.hartshorn.inject.processing;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false, componentPostProcessors = NonProcessableTypeProcessor.class)
-public class ComponentProcessorTests {
+class ComponentProcessorTests {
 
     @Test
     @TestComponents(NonProcessableType.class)
-    void testNonProcessableComponent(@Inject NonProcessableType nonProcessableType) {
-        Assertions.assertNotNull(nonProcessableType);
-        Assertions.assertNull(nonProcessableType.nonNullIfProcessed());
+    void nonProcessableComponent(@Inject NonProcessableType nonProcessableType) {
+        assertThat(nonProcessableType).isNotNull();
+        assertThat(nonProcessableType.nonNullIfProcessed()).isNull();
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/processing/NonProcessableTypeProcessor.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/processing/NonProcessableTypeProcessor.java
@@ -20,8 +20,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.dockbox.hartshorn.inject.InjectionCapableApplication;
 import org.dockbox.hartshorn.inject.processing.ComponentPostProcessor;
 import org.dockbox.hartshorn.inject.processing.ComponentProcessingContext;
-import org.dockbox.hartshorn.inject.processing.ProcessingPriority;
-import org.junit.jupiter.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class NonProcessableTypeProcessor extends ComponentPostProcessor {
 
@@ -32,16 +32,13 @@ public class NonProcessableTypeProcessor extends ComponentPostProcessor {
         ComponentProcessingContext<T> processingContext
     ) {
         if (instance instanceof NonProcessableType) {
-            try {
+            assertThatCode(() -> {
                 processingContext.type()
                     .fields()
                     .named("nonNullIfProcessed")
                     .get()
                     .set(instance, "processed");
-            }
-            catch (Throwable throwable) {
-                Assertions.fail(throwable);
-            }
+            }).doesNotThrowAnyException();
         }
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/provided/ProvidedMethodTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/provided/ProvidedMethodTests.java
@@ -24,12 +24,13 @@ import org.dockbox.hartshorn.proxy.Proxy;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.types.TypeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @TestComponents(ProviderComponent.class)
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ProvidedMethodTests {
+class ProvidedMethodTests {
 
     @Inject
     private ProviderComponent providerComponent;
@@ -37,32 +38,34 @@ public class ProvidedMethodTests {
     private Binder binder;
 
     @Test
-    void testProviderWithoutQualifiers() {
+    void providerWithoutQualifiers() {
         this.binder.bind(String.class).singleton("Hello World");
 
-        Assertions.assertNotNull(this.providerComponent);
-        Assertions.assertInstanceOf(Proxy.class, this.providerComponent);
+        assertThat(this.providerComponent)
+                .isInstanceOf(Proxy.class);
 
         String message = this.providerComponent.get();
-        Assertions.assertNotNull(message);
-        Assertions.assertEquals("Hello World", message);
+        assertThat(message)
+                .isNotNull()
+                .isEqualTo("Hello World");
     }
 
     @Test
-    void testProviderWithNamedQualifier() {
+    void providerWithNamedQualifier() {
         this.binder.bind(String.class).singleton("Hello World");
         this.binder.bind(ComponentKey.of(String.class, "test")).singleton("Hello Test World");
 
-        Assertions.assertNotNull(this.providerComponent);
-        Assertions.assertInstanceOf(Proxy.class, this.providerComponent);
+        assertThat(this.providerComponent)
+                .isInstanceOf(Proxy.class);
 
         String message = this.providerComponent.getNamed();
-        Assertions.assertNotNull(message);
-        Assertions.assertEquals("Hello Test World", message);
+        assertThat(message)
+                .isNotNull()
+                .isEqualTo("Hello Test World");
     }
 
     @Test
-    void testProviderWithCustomQualifiers() {
+    void providerWithCustomQualifiers() {
         this.binder.bind(String.class).singleton("Hello Red World");
         this.binder.bind(ComponentKey.builder(String.class)
             .qualifier(QualifierKey.of(TypeUtils.annotation(Color.class, Colors.RED)))
@@ -73,15 +76,17 @@ public class ProvidedMethodTests {
             .build()
         ).singleton("Hello Blue World");
 
-        Assertions.assertNotNull(this.providerComponent);
-        Assertions.assertInstanceOf(Proxy.class, this.providerComponent);
+        assertThat(this.providerComponent)
+                .isInstanceOf(Proxy.class);
 
         String redMessage = this.providerComponent.getRed();
-        Assertions.assertNotNull(redMessage);
-        Assertions.assertEquals("Hello Red World", redMessage);
+        assertThat(redMessage)
+                .isNotNull()
+                .isEqualTo("Hello Red World");
 
         String blueMessage = this.providerComponent.getBlue();
-        Assertions.assertNotNull(blueMessage);
-        Assertions.assertEquals("Hello Blue World", blueMessage);
+        assertThat(blueMessage)
+                .isNotNull()
+                .isEqualTo("Hello Blue World");
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/provider/FuzzyInjectionTest.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/provider/FuzzyInjectionTest.java
@@ -27,45 +27,47 @@ import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.ComponentResolutionException;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.Tristate;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 public class FuzzyInjectionTest {
 
     @Test
-    void testFuzzyModeMatchesCompatibleBinding(@Inject ApplicationContext context) {
+    void fuzzyModeMatchesCompatibleBinding(@Inject ApplicationContext context) {
         context.bind(String.class).singleton("Hello World");
         ComponentKey<CharSequence> key = ComponentKey.builder(CharSequence.class)
                 .fuzzy()
                 .build();
         CharSequence sequence = context.get(key);
-        Assertions.assertEquals("Hello World", sequence);
+        assertThat(sequence).isEqualTo("Hello World");
     }
 
     @Test
-    void testStrictModeOnlyMatchesExactBinding(@Inject ApplicationContext context) {
+    void strictModeOnlyMatchesExactBinding(@Inject ApplicationContext context) {
         context.bind(String.class).singleton("Hello World");
         ComponentKey<CharSequence> key = ComponentKey.builder(CharSequence.class)
                 .strict()
                 .build();
-        Assertions.assertThrows(ComponentResolutionException.class, () -> context.get(key));
+        assertThatExceptionOfType(ComponentResolutionException.class).isThrownBy(() -> context.get(key));
     }
 
     @Test
-    void testStrictModeIsUndefinedByDefault() {
+    void strictModeIsUndefinedByDefault() {
         ComponentKey<CharSequence> componentKey = ComponentKey.of(CharSequence.class);
-        Assertions.assertSame(Tristate.UNDEFINED, componentKey.strict());
+        assertThat(componentKey.strict()).isSameAs(Tristate.UNDEFINED);
     }
 
     @Test
-    void testEnvironmentStrictModeIsEnabledByDefault() {
+    void environmentStrictModeIsEnabledByDefault() {
         ApplicationEnvironment environment = HartshornApplication.create(FuzzyInjectionTest.class, application -> {
             application.applicationContextFactory(StandardApplicationContextFactory.create(constructor -> {
                 constructor.includeBasePackages(false);
             }));
         }).environment();
-        Assertions.assertTrue(environment.isStrictMode());
+        assertThat(environment.isStrictMode()).isTrue();
     }
 
     public static void main(String[] args) {
@@ -78,7 +80,7 @@ public class FuzzyInjectionTest {
 
 
     @Test
-    void testCustomizingEnvironmentStrictModeAffectsLookup() {
+    void customizingEnvironmentStrictModeAffectsLookup() {
         ApplicationContext applicationContext = HartshornApplication.create(FuzzyInjectionTest.class, application -> {
             application.applicationContextFactory(StandardApplicationContextFactory.create(constructor -> {
                 constructor.includeBasePackages(false);
@@ -86,13 +88,13 @@ public class FuzzyInjectionTest {
             }));
         });
         ApplicationEnvironment environment = applicationContext.environment();
-        Assertions.assertFalse(environment.isStrictMode());
+        assertThat(environment.isStrictMode()).isFalse();
 
         applicationContext.bind(String.class).singleton("Hello World");
         ComponentKey<CharSequence> key = ComponentKey.builder(CharSequence.class).build();
-        Assertions.assertSame(Tristate.UNDEFINED, key.strict());
+        assertThat(key.strict()).isSameAs(Tristate.UNDEFINED);
 
         CharSequence sequence = applicationContext.get(key);
-        Assertions.assertEquals("Hello World", sequence);
+        assertThat(sequence).isEqualTo("Hello World");
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/provider/NonProcessableTypeProcessor.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/provider/NonProcessableTypeProcessor.java
@@ -20,8 +20,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.dockbox.hartshorn.inject.InjectionCapableApplication;
 import org.dockbox.hartshorn.inject.processing.ComponentPostProcessor;
 import org.dockbox.hartshorn.inject.processing.ComponentProcessingContext;
-import org.dockbox.hartshorn.inject.processing.ProcessingPriority;
-import org.junit.jupiter.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class NonProcessableTypeProcessor extends ComponentPostProcessor {
 
@@ -32,16 +32,13 @@ public class NonProcessableTypeProcessor extends ComponentPostProcessor {
         ComponentProcessingContext<T> processingContext
     ) {
         if (instance instanceof NonProcessableType) {
-            try {
+            assertThatCode(() -> {
                 processingContext.type()
                     .fields()
                     .named("nonNullIfProcessed")
                     .get()
                     .set(instance, "processed");
-            }
-            catch (Throwable throwable) {
-                Assertions.fail(throwable);
-            }
+            }).doesNotThrowAnyException();
         }
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/provider/ProviderBehaviorTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/provider/ProviderBehaviorTests.java
@@ -25,7 +25,6 @@ import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.ApplicationException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -34,111 +33,113 @@ import test.org.dockbox.hartshorn.inject.populate.PopulatedType;
 
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ProviderBehaviorTests {
+class ProviderBehaviorTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
-    public void testStaticBindingCanBeProvided() {
+    void staticBindingCanBeProvided() {
         this.applicationContext.bind(SampleInterface.class).to(SampleImplementation.class);
         SampleInterface provided = this.applicationContext.get(SampleInterface.class);
-        Assertions.assertNotNull(provided);
+        assertThat(provided).isNotNull();
 
         Class<? extends SampleInterface> providedClass = provided.getClass();
-        Assertions.assertSame(SampleImplementation.class, providedClass);
+        assertThat(providedClass).isSameAs(SampleImplementation.class);
 
-        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
+        assertThat(provided.name()).isEqualTo(SampleImplementation.NAME);
     }
 
     @Test
-    public void testStaticBindingWithMetaCanBeProvided() {
+    void staticBindingWithMetaCanBeProvided() {
         ComponentKey<SampleInterface> key = ComponentKey.of(SampleInterface.class, "demo");
         this.applicationContext.bind(key).to(SampleImplementation.class);
         SampleInterface provided = this.applicationContext.get(key);
-        Assertions.assertNotNull(provided);
+        assertThat(provided).isNotNull();
 
         Class<? extends SampleInterface> providedClass = provided.getClass();
-        Assertions.assertSame(SampleImplementation.class, providedClass);
+        assertThat(providedClass).isSameAs(SampleImplementation.class);
 
-        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
+        assertThat(provided.name()).isEqualTo(SampleImplementation.NAME);
     }
 
     @Test
-    public void testInstanceBindingCanBeProvided() {
+    void instanceBindingCanBeProvided() {
         this.applicationContext.bind(SampleInterface.class).singleton(new SampleImplementation());
         SampleInterface provided = this.applicationContext.get(SampleInterface.class);
-        Assertions.assertNotNull(provided);
+        assertThat(provided).isNotNull();
 
         Class<? extends SampleInterface> providedClass = provided.getClass();
-        Assertions.assertSame(SampleImplementation.class, providedClass);
+        assertThat(providedClass).isSameAs(SampleImplementation.class);
 
-        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
+        assertThat(provided.name()).isEqualTo(SampleImplementation.NAME);
     }
 
     @Test
-    public void testInstanceBindingWithMetaCanBeProvided() {
+    void instanceBindingWithMetaCanBeProvided() {
         ComponentKey<SampleInterface> key = ComponentKey.of(SampleInterface.class, "demo");
         this.applicationContext.bind(key).singleton(new SampleImplementation());
         SampleInterface provided = this.applicationContext.get(key);
-        Assertions.assertNotNull(provided);
+        assertThat(provided).isNotNull();
 
         Class<? extends SampleInterface> providedClass = provided.getClass();
-        Assertions.assertSame(SampleImplementation.class, providedClass);
+        assertThat(providedClass).isSameAs(SampleImplementation.class);
 
-        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
+        assertThat(provided.name()).isEqualTo(SampleImplementation.NAME);
     }
 
     @Test
-    public void testProviderBindingCanBeProvided() {
+    void providerBindingCanBeProvided() {
         this.applicationContext.bind(SampleInterface.class).to(SampleImplementation::new);
         SampleInterface provided = this.applicationContext.get(SampleInterface.class);
-        Assertions.assertNotNull(provided);
+        assertThat(provided).isNotNull();
 
         Class<? extends SampleInterface> providedClass = provided.getClass();
-        Assertions.assertSame(SampleImplementation.class, providedClass);
+        assertThat(providedClass).isSameAs(SampleImplementation.class);
 
-        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
+        assertThat(provided.name()).isEqualTo(SampleImplementation.NAME);
     }
 
     @Test
-    public void testProviderBindingWithMetaCanBeProvided() {
+    void providerBindingWithMetaCanBeProvided() {
         ComponentKey<SampleInterface> key = ComponentKey.of(SampleInterface.class, "demo");
         this.applicationContext.bind(key).to(SampleImplementation::new);
         SampleInterface provided = this.applicationContext.get(key);
-        Assertions.assertNotNull(provided);
+        assertThat(provided).isNotNull();
 
         Class<? extends SampleInterface> providedClass = provided.getClass();
-        Assertions.assertSame(SampleImplementation.class, providedClass);
+        assertThat(providedClass).isSameAs(SampleImplementation.class);
 
-        Assertions.assertEquals(SampleImplementation.NAME, provided.name());
+        assertThat(provided.name()).isEqualTo(SampleImplementation.NAME);
     }
 
     @Test
     @TestComponents(SampleNamedConfiguration.class)
-    public void testScannedMetaBindingsCanBeProvided() {
-
+    void scannedMetaBindingsCanBeProvided() {
         // Ensure that the binding is not bound to the default name
-        Assertions.assertThrows(ComponentResolutionException.class,
-            () -> this.applicationContext.get(SampleInterface.class));
+        assertThatExceptionOfType(ComponentResolutionException.class)
+                .isThrownBy(() -> this.applicationContext.get(SampleInterface.class));
 
         SampleInterface provided =
             this.applicationContext.get(ComponentKey.of(SampleInterface.class, "meta"));
-        Assertions.assertNotNull(provided);
+        assertThat(provided).isNotNull();
 
         Class<? extends SampleInterface> providedClass = provided.getClass();
-        Assertions.assertSame(SampleMetaAnnotatedImplementation.class, providedClass);
+        assertThat(providedClass).isSameAs(SampleMetaAnnotatedImplementation.class);
 
-        Assertions.assertEquals("MetaAnnotatedHartshorn", provided.name());
+        assertThat(provided.name()).isEqualTo("MetaAnnotatedHartshorn");
     }
 
     @Test
     @TestComponents({PopulatedType.class, SampleConfiguration.class})
-    public void unboundTypesCanBeProvided() {
+    void unboundTypesCanBeProvided() {
         PopulatedType provided = this.applicationContext.get(PopulatedType.class);
-        Assertions.assertNotNull(provided);
-        Assertions.assertNotNull(provided.sampleInterface());
+        assertThat(provided).isNotNull();
+        assertThat(provided.sampleInterface()).isNotNull();
     }
 
     @Configuration
@@ -151,49 +152,49 @@ public class ProviderBehaviorTests {
     }
 
     @Test
-    void testFailureInComponentConstructorYieldsInitializationException() {
-        ComponentResolutionException exception = Assertions.assertThrows(
-            ComponentResolutionException.class,
-            () -> this.applicationContext.get(
-                ErrorInConstructorObject.class));
+    void failureInComponentConstructorYieldsInitializationException() {
+        ComponentResolutionException exception = assertThatExceptionOfType(
+                ComponentResolutionException.class
+        ).isThrownBy(() -> this.applicationContext.get(ErrorInConstructorObject.class)).actual();
         Throwable cause = exception.getCause();
-        Assertions.assertNotNull(cause);
-        Assertions.assertTrue(cause instanceof ApplicationException);
+        assertThat(cause).isInstanceOf(ApplicationException.class);
 
         ApplicationException applicationException = (ApplicationException) cause;
-        Assertions.assertEquals("Failed to create instance of type "
-            + ErrorInConstructorObject.class.getName(), applicationException.getMessage());
+        assertThat(applicationException.getMessage()).isEqualTo(
+                "Failed to create instance of type "
+                        + ErrorInConstructorObject.class.getName()
+        );
     }
 
     @Test
-    void testFailingConstructorIsRethrown() {
-        ComponentResolutionException exception = Assertions.assertThrows(
-            ComponentResolutionException.class,
-            () -> this.applicationContext.get(
-                TypeWithFailingConstructor.class));
-        Assertions.assertTrue(exception.getCause() instanceof ApplicationException);
+    void failingConstructorIsRethrown() {
+        ComponentResolutionException exception = assertThatExceptionOfType(
+                ComponentResolutionException.class
+        ).isThrownBy(() -> this.applicationContext.get(TypeWithFailingConstructor.class)).actual();
+        Throwable cause = exception.getCause();
+        assertThat(cause).isInstanceOf(ApplicationException.class);
 
-        ApplicationException applicationException = (ApplicationException) exception.getCause();
-        Assertions.assertTrue(applicationException.getCause() instanceof IllegalStateException);
+        ApplicationException applicationException = (ApplicationException) cause;
+        assertThat(applicationException.getCause()).isInstanceOf(IllegalStateException.class);
 
-        IllegalStateException illegalStateException =
-            (IllegalStateException) applicationException.getCause();
-        Assertions.assertEquals(TypeWithFailingConstructor.ERROR_MESSAGE,
-            illegalStateException.getMessage());
+        IllegalStateException illegalStateException = (IllegalStateException) applicationException
+                .getCause();
+        assertThat(illegalStateException.getMessage())
+                .isEqualTo(TypeWithFailingConstructor.ERROR_MESSAGE);
     }
 
     @Test
-    void testStringProvision() {
+    void stringProvision() {
         ComponentKey<String> key = ComponentKey.of(String.class, "license");
         this.applicationContext.bind(key).singleton("MIT");
         String license = this.applicationContext.get(key);
-        Assertions.assertEquals("MIT", license);
+        assertThat(license).isEqualTo("MIT");
     }
 
     @ParameterizedTest
     @MethodSource("providers")
     @TestComponents({SampleFieldImplementation.class, SampleProviderConfiguration.class})
-    void testProvidersCanApply(
+    void providersCanApply(
         String meta,
         String name,
         boolean field,
@@ -217,11 +218,11 @@ public class ProviderBehaviorTests {
         else {
             provided = this.applicationContext.get(ComponentKey.of(ProvidedInterface.class, meta));
         }
-        Assertions.assertNotNull(provided);
+        assertThat(provided).isNotNull();
 
         String actual = provided.name();
-        Assertions.assertNotNull(name);
-        Assertions.assertEquals(name, actual);
+        assertThat(name).isNotNull();
+        assertThat(actual).isEqualTo(name);
 
         if (singleton) {
             ProvidedInterface second;
@@ -232,8 +233,9 @@ public class ProviderBehaviorTests {
                 second =
                     this.applicationContext.get(ComponentKey.of(ProvidedInterface.class, meta));
             }
-            Assertions.assertNotNull(second);
-            Assertions.assertSame(provided, second);
+            assertThat(second)
+                    .isNotNull()
+                    .isSameAs(provided);
         }
     }
 

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/scope/ScopeBindingTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/scope/ScopeBindingTests.java
@@ -23,20 +23,21 @@ import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.introspect.ParameterizableType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import test.org.dockbox.hartshorn.inject.scope.ScopedBindingConfiguration.SampleScope;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ScopeBindingTests {
+class ScopeBindingTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
-    void testScopeBindingIsNotAccessibleFromApplication() {
+    void scopeBindingIsNotAccessibleFromApplication() {
         Scope scope = ScopeAdapter.of(new Object(), ParameterizableType.create(Object.class));
         ComponentKey<String> key = ComponentKey.builder(String.class)
             .scope(scope)
@@ -44,16 +45,16 @@ public class ScopeBindingTests {
 
         this.applicationContext.bind(key).singleton("test");
         String value = this.applicationContext.get(key);
-        Assertions.assertEquals("test", value);
+        assertThat(value).isEqualTo("test");
 
         ComponentKey<String> componentKeyNoScope = ComponentKey.of(String.class);
 
         String valueNoScope = this.applicationContext.get(componentKeyNoScope);
-        Assertions.assertEquals("", valueNoScope); // Default value for primitives
+        assertThat(valueNoScope).isEmpty(); // Default value for primitives
     }
 
     @Test
-    void testApplicationBindingIsAccessibleFromScope() {
+    void applicationBindingIsAccessibleFromScope() {
         this.applicationContext.bind(String.class).singleton("test");
 
         Scope scope = ScopeAdapter.of(new Object(), ParameterizableType.create(Object.class));
@@ -62,17 +63,17 @@ public class ScopeBindingTests {
             .build();
 
         String value = this.applicationContext.get(key);
-        Assertions.assertEquals("test", value);
+        assertThat(value).isEqualTo("test");
     }
 
     @Test
     @TestComponents(ScopedBindingConfiguration.class)
-    void testConfigurationScopedValuesAreInstalled() {
+    void configurationScopedValuesAreInstalled() {
         String applicationScope = this.applicationContext.get(String.class);
         String scopedValue = this.applicationContext.get(ComponentKey.builder(String.class)
             .scope(new SampleScope())
             .build());
-        Assertions.assertEquals("", applicationScope);
-        Assertions.assertEquals("test", scopedValue);
+        assertThat(applicationScope).isEmpty();
+        assertThat(scopedValue).isEqualTo("test");
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/scope/provider/ScopedInjectionTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/scope/provider/ScopedInjectionTests.java
@@ -29,56 +29,56 @@ import org.dockbox.hartshorn.inject.scope.ScopeKey;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 @TestComponents({
     ScopedInjectionTests.ScopedConfiguration.class,
     ScopedInjectionTests.TestManagedComponent.class,
 })
-public class ScopedInjectionTests {
+class ScopedInjectionTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
     @DisplayName("Scoped requests of unmanaged components should have dependencies from the same scope")
-    void testScopedRequestOfUnmanagedComponentHasScopedDependencies() {
+    void scopedRequestOfUnmanagedComponentHasScopedDependencies() {
         TestScope scope = new TestScope();
 
         ComponentKey<String> scopedStringKey =
             ComponentKey.builder(String.class).scope(scope).build();
-        Assertions.assertEquals("testScopedString", this.applicationContext.get(scopedStringKey));
+        assertThat(this.applicationContext.get(scopedStringKey)).isEqualTo("testScopedString");
 
         TestComponent component =
             this.applicationContext.get(ComponentKey.builder(TestComponent.class)
                 .scope(scope)
                 .build());
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
         // Injected String should inherit the scope from the component
-        Assertions.assertEquals("testScopedString", component.scopedString);
+        assertThat(component.scopedString).isEqualTo("testScopedString");
     }
 
     @Test
     @DisplayName("Unscoped requests of components should have application dependencies")
-    void testUnscopedRequestOfUnmanagedComponentHasApplicationDependencies() {
+    void unscopedRequestOfUnmanagedComponentHasApplicationDependencies() {
         ComponentKey<String> applicationStringKey = ComponentKey.of(String.class);
-        Assertions.assertEquals("applicationScopedString",
-            this.applicationContext.get(applicationStringKey));
+        assertThat(this.applicationContext.get(applicationStringKey)).isEqualTo("applicationScopedString");
 
         TestComponent component = this.applicationContext.get(TestComponent.class);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
         // Injected String should be the application scoped value
-        Assertions.assertEquals("applicationScopedString", component.scopedString);
+        assertThat(component.scopedString).isEqualTo("applicationScopedString");
     }
 
     @Test
     @DisplayName("Scoped requests of components with context dependencies should have the scoped context")
-    void testScopedRequestOfUnmanagedComponentWithScopeContextHasScopedContext() {
+    void scopedRequestOfUnmanagedComponentWithScopeContextHasScopedContext() {
         TestScope scope = new TestScope();
         scope.addContext(new SampleContext("test"));
         this.applicationContext.addContext(new SampleContext("application"));
@@ -87,16 +87,16 @@ public class ScopedInjectionTests {
             .scope(scope)
             .build();
         TestComponent component = this.applicationContext.get(scopedComponentKey);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
         // Injected context should be the scoped context
-        Assertions.assertNotNull(component.context);
-        Assertions.assertEquals("test", component.context.value);
+        assertThat(component.context).isNotNull();
+        assertThat(component.context.value).isEqualTo("test");
     }
 
     @Test
     @DisplayName("Scoped requests of components with context dependencies which are absent in the scope context should have global context")
-    void testScopedRequestOfUnmanagedComponentWithAbsentContextHasGlobalContext() {
+    void scopedRequestOfUnmanagedComponentWithAbsentContextHasGlobalContext() {
         TestScope scope = new TestScope();
         this.applicationContext.addContext(new SampleContext("application"));
 
@@ -104,16 +104,16 @@ public class ScopedInjectionTests {
             .scope(scope)
             .build();
         TestComponent component = this.applicationContext.get(scopedComponentKey);
-        Assertions.assertNotNull(component);
+        assertThat(component).isNotNull();
 
         // Injected context should be the application context, as the context is not present in the scope
-        Assertions.assertNotNull(component.context);
-        Assertions.assertEquals("application", component.context.value);
+        assertThat(component.context).isNotNull();
+        assertThat(component.context.value).isEqualTo("application");
     }
 
     @Test
     @DisplayName("Managed components should always be application scoped, even if the request is scoped")
-    void testScopedRequestOfManagedComponentIsApplicationRedirect() {
+    void scopedRequestOfManagedComponentIsApplicationRedirect() {
         TestScope scope = new TestScope();
 
         ComponentKey<TestManagedComponent> scopedManagedComponentKey =
@@ -122,20 +122,20 @@ public class ScopedInjectionTests {
                 .build();
         TestManagedComponent scopedManagedComponent =
             this.applicationContext.get(scopedManagedComponentKey);
-        Assertions.assertNotNull(scopedManagedComponent);
+        assertThat(scopedManagedComponent).isNotNull();
 
         // Managed components should always be application scoped, even if the request for it is scoped
         TestManagedComponent applicationManagedComponent =
             this.applicationContext.get(TestManagedComponent.class);
-        Assertions.assertSame(applicationManagedComponent, scopedManagedComponent);
+        assertThat(scopedManagedComponent).isSameAs(applicationManagedComponent);
 
         // The dependency should be the application scoped value
-        Assertions.assertEquals("applicationScopedString", scopedManagedComponent.scopedString);
+        assertThat(scopedManagedComponent.scopedString).isEqualTo("applicationScopedString");
     }
 
     @Test
     @DisplayName("Scoped requests with the same scope type but different scope instances should yield different components")
-    void testScopedRequestOfDifferentContextWithSameTypeIsDifferentComponent() {
+    void scopedRequestOfDifferentContextWithSameTypeIsDifferentComponent() {
         TestScope scope1 = new TestScope();
         scope1.addContext(new SampleContext("test1"));
         TestScope scope2 = new TestScope();
@@ -149,18 +149,17 @@ public class ScopedInjectionTests {
         TestComponent scopedComponent1 = this.applicationContext.get(scopedComponentKey1);
         TestComponent scopedComponent2 = this.applicationContext.get(scopedComponentKey2);
 
-        Assertions.assertNotNull(scopedComponent1);
-        Assertions.assertNotNull(scopedComponent2);
-
-        // Each scoped component should have its own instance, even if they are of the same type
-        Assertions.assertNotSame(scopedComponent1, scopedComponent2);
+        assertThat(scopedComponent1).isNotNull();
+        assertThat(scopedComponent2)
+                // Each scoped component should have its own instance, even if they are of the same type
+                .isNotSameAs(scopedComponent1);
 
         // Each component should have its own context
-        Assertions.assertNotNull(scopedComponent1.context);
-        Assertions.assertNotNull(scopedComponent2.context);
+        assertThat(scopedComponent1.context).isNotNull();
+        assertThat(scopedComponent2.context).isNotNull();
 
-        Assertions.assertEquals("test1", scopedComponent1.context.value);
-        Assertions.assertEquals("test2", scopedComponent2.context.value);
+        assertThat(scopedComponent1.context.value).isEqualTo("test1");
+        assertThat(scopedComponent2.context.value).isEqualTo("test2");
     }
 
     public static class TestComponent {

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/singleton/SingletonCacheTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/singleton/SingletonCacheTests.java
@@ -21,14 +21,15 @@ import org.dockbox.hartshorn.inject.binding.Binder;
 import org.dockbox.hartshorn.inject.provider.ComponentProvider;
 import org.dockbox.hartshorn.inject.provider.singleton.SingletonCache;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import org.dockbox.hartshorn.inject.annotations.Inject;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class SingletonCacheTests {
+class SingletonCacheTests {
 
     @Inject
     private ComponentProvider componentProvider;
@@ -41,24 +42,24 @@ public class SingletonCacheTests {
 
     @Test
     @DisplayName("Lazy singletons should be cached in the scoped singleton cache after request")
-    void testLazySingletonIsCachedAfterRequest() {
+    void lazySingletonIsCachedAfterRequest() {
         // Given
         ComponentKey<String> key = ComponentKey.of(String.class);
         this.binder.bind(key).lazySingleton(scope -> "Hello, World!");
 
         // Then
-        Assertions.assertFalse(this.cache.contains(key));
+        assertThat(this.cache.contains(key)).isFalse();
 
         // When
         this.componentProvider.get(key);
 
         // Then
-        Assertions.assertTrue(this.cache.contains(key));
+        assertThat(this.cache.contains(key)).isTrue();
     }
 
     @Test
     @DisplayName("Unprocessable non-lazy singletons should be cached in the scoped singleton cache after binding")
-    void testNonLazySingletonWithoutProcessingIsCachedAfterBinding() {
+    void nonLazySingletonWithoutProcessingIsCachedAfterBinding() {
         // Given
         ComponentKey<String> key = ComponentKey.of(String.class);
         this.binder.bind(key)
@@ -66,23 +67,23 @@ public class SingletonCacheTests {
             .singleton("Hello, World!");
 
         // Then
-        Assertions.assertTrue(this.cache.contains(key));
+        assertThat(this.cache.contains(key)).isTrue();
     }
 
     @Test
     @DisplayName("Singletons should not be cached in the scoped singleton cache if they require processing")
-    void testSingletonIsNotCachedIfProcessingIsRequired() {
+    void singletonIsNotCachedIfProcessingIsRequired() {
         // Given
         ComponentKey<String> key = ComponentKey.of(String.class);
         this.binder.bind(key).singleton("Hello, World!");
 
         // Then
-        Assertions.assertFalse(this.cache.contains(key));
+        assertThat(this.cache.contains(key)).isFalse();
 
         // When
         this.componentProvider.get(key);
 
         // Then
-        Assertions.assertTrue(this.cache.contains(key));
+        assertThat(this.cache.contains(key)).isTrue();
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/stereotype/ComponentStereotypeTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/stereotype/ComponentStereotypeTests.java
@@ -21,11 +21,13 @@ import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ComponentStereotypeTests {
+class ComponentStereotypeTests {
 
     @Inject
     private ApplicationContext applicationContext;
@@ -35,29 +37,27 @@ public class ComponentStereotypeTests {
     void servicesAreSingletonsByDefault() {
         EmptyComponent emptyComponent = this.applicationContext.get(EmptyComponent.class);
         EmptyComponent emptyComponent2 = this.applicationContext.get(EmptyComponent.class);
-        Assertions.assertSame(emptyComponent, emptyComponent2);
+        assertThat(emptyComponent2).isSameAs(emptyComponent);
     }
 
     @Test
-    void testNonComponentsAreNotProxied() {
-        Assertions.assertThrows(ComponentResolutionException.class,
-            () -> this.applicationContext.get(NonComponentType.class));
+    void nonComponentsAreNotProxied() {
+        assertThatExceptionOfType(ComponentResolutionException.class).isThrownBy(() -> this.applicationContext.get(NonComponentType.class));
     }
 
     @Test
     @TestComponents(ComponentType.class)
-    void testPermittedComponentsAreProxiedWhenRegularProvisionFails() {
+    void permittedComponentsAreProxiedWhenRegularProvisionFails() {
         ComponentType instance = this.applicationContext.get(ComponentType.class);
-        Assertions.assertNotNull(instance);
-        Assertions.assertTrue(this.applicationContext.environment()
+        assertThat(instance).isNotNull();
+        assertThat(this.applicationContext.environment()
             .proxyOrchestrator()
-            .isProxy(instance));
+            .isProxy(instance)).isTrue();
     }
 
     @Test
     @TestComponents(NonProxyComponentType.class)
-    void testNonPermittedComponentsAreNotProxied() {
-        Assertions.assertThrows(ComponentResolutionException.class,
-            () -> this.applicationContext.get(NonProxyComponentType.class));
+    void nonPermittedComponentsAreNotProxied() {
+        assertThatExceptionOfType(ComponentResolutionException.class).isThrownBy(() -> this.applicationContext.get(NonProxyComponentType.class));
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/strategies/SetterInjectionTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/strategies/SetterInjectionTests.java
@@ -21,52 +21,56 @@ import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import test.org.dockbox.hartshorn.inject.stereotype.ComponentType;
 import test.org.dockbox.hartshorn.inject.context.SampleContext;
+import test.org.dockbox.hartshorn.inject.stereotype.ComponentType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 @HartshornIntegrationTest(includeBasePackages = false)
-public class SetterInjectionTests {
+class SetterInjectionTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
     @TestComponents({SetterInjectedComponent.class, ComponentType.class})
-    void testSetterInjectionWithRegularComponent() {
+    void setterInjectionWithRegularComponent() {
         SetterInjectedComponent component =
             this.applicationContext.get(SetterInjectedComponent.class);
-        Assertions.assertNotNull(component);
-        Assertions.assertNotNull(component.component());
+        assertThat(component).isNotNull();
+        assertThat(component.component()).isNotNull();
     }
 
     @Test
     @TestComponents(SetterInjectedComponentWithAbsentBinding.class)
-    void testSetterInjectionWithAbsentRequiredComponent() {
-        Assertions.assertThrows(ComponentResolutionException.class,
-            () -> this.applicationContext.get(SetterInjectedComponentWithAbsentBinding.class));
+    void setterInjectionWithAbsentRequiredComponent() {
+        assertThatExceptionOfType(ComponentResolutionException.class)
+                .isThrownBy(() -> this.applicationContext.get(
+                        SetterInjectedComponentWithAbsentBinding.class
+                ));
     }
 
     @Test
     @TestComponents(SetterInjectedComponentWithNonRequiredAbsentBinding.class)
-    void testSetterInjectionWithAbsentComponent() {
-        var component = Assertions.assertDoesNotThrow(() -> this.applicationContext.get(
-            SetterInjectedComponentWithNonRequiredAbsentBinding.class));
-        Assertions.assertNotNull(component);
-        Assertions.assertNull(component.object());
+    void setterInjectionWithAbsentComponent() {
+        var component = this.applicationContext.get(
+                SetterInjectedComponentWithNonRequiredAbsentBinding.class
+        );
+        assertThat(component).isNotNull();
+        assertThat(component.object()).isNull();
     }
 
     @Test
     @TestComponents({SetterInjectedComponent.class, ComponentType.class})
-    void testSetterInjectionWithContext() {
+    void setterInjectionWithContext() {
         SampleContext sampleContext = new SampleContext("setter");
         this.applicationContext.addContext("setter", sampleContext);
         SetterInjectedComponent component =
             this.applicationContext.get(SetterInjectedComponent.class);
-        Assertions.assertNotNull(component);
-        Assertions.assertNotNull(component.context());
-        Assertions.assertSame(sampleContext, component.context());
+        assertThat(component).isNotNull();
+        assertThat(component.context()).isNotNull();
+        assertThat(component.context()).isSameAs(sampleContext);
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/context/ApplicationContextTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/context/ApplicationContextTests.java
@@ -19,17 +19,18 @@ package test.org.dockbox.hartshorn.launchpad.context;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ApplicationContextTests {
+class ApplicationContextTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
-    void testContextLoads() {
-        Assertions.assertNotNull(this.applicationContext);
+    void contextLoads() {
+        assertThat(this.applicationContext).isNotNull();
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/launch/scanning/ActivatorScanningTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/launch/scanning/ActivatorScanningTests.java
@@ -23,7 +23,6 @@ import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.introspect.scan.TypeReferenceCollector;
 import org.dockbox.hartshorn.util.introspect.scan.TypeReferenceCollectorContext;
 import org.dockbox.hartshorn.util.introspect.scan.classpath.ClasspathTypeReferenceCollector;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import test.org.dockbox.hartshorn.launchpad.launch.scanning.discover.ConcreteDiscoverableComponent;
@@ -32,36 +31,39 @@ import test.org.dockbox.hartshorn.launchpad.launch.scanning.discover.Discoverabl
 import test.org.dockbox.hartshorn.launchpad.launch.scanning.discover.ComponentInterface;
 import test.org.dockbox.hartshorn.launchpad.launch.scanning.discover.PackageScanningActivator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 @PackageScanningActivator
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ActivatorScanningTests {
+class ActivatorScanningTests {
 
     @Test
-    void testPrefixFromActivatorIsRegistered(@Inject TypeReferenceCollectorContext context) {
+    void prefixFromActivatorIsRegistered(@Inject TypeReferenceCollectorContext context) {
         for (TypeReferenceCollector collector : context.collectors()) {
             if (collector instanceof ClasspathTypeReferenceCollector referenceCollector
                 && PackageScanningActivator.PACKAGE.equals(referenceCollector.packageName())) {
                 return;
             }
         }
-        Assertions.fail("No collector found for package %s".formatted(PackageScanningActivator.PACKAGE));
+        fail("No collector found for package %s".formatted(PackageScanningActivator.PACKAGE));
     }
 
     @Test
     @TestComponents(DiscoverableComponentConfiguration.class)
-    void testBindingsFromActivatorPrefixArePresent(@Inject DiscoverableComponent component) {
-        Assertions.assertNotNull(component);
-        Assertions.assertEquals("Demo", component.message());
-        Assertions.assertInstanceOf(ConcreteDiscoverableComponent.class, component);
+    void bindingsFromActivatorPrefixArePresent(@Inject DiscoverableComponent component) {
+        assertThat(component).isNotNull();
+        assertThat(component.message()).isEqualTo("Demo");
+        assertThat(component).isInstanceOf(ConcreteDiscoverableComponent.class);
     }
 
     @Test
     @TestComponents(ComponentInterface.class)
-    void testServicesFromActivatorPrefixArePresent(
+    void servicesFromActivatorPrefixArePresent(
         @Inject ComponentInterface service,
         @Inject ProxyOrchestrator proxyOrchestrator
     ) {
-        Assertions.assertNotNull(service);
-        Assertions.assertTrue(proxyOrchestrator.isProxy(service));
+        assertThat(service).isNotNull();
+        assertThat(proxyOrchestrator.isProxy(service)).isTrue();
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/launch/scanning/SpecificPackageTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/launch/scanning/SpecificPackageTests.java
@@ -18,11 +18,12 @@ package test.org.dockbox.hartshorn.launchpad.launch.scanning;
 
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import test.org.dockbox.hartshorn.launchpad.launch.scanning.discover.ScanSpecificPackageActivator;
 import test.org.dockbox.hartshorn.launchpad.launch.scanning.components.CountingComponentPreProcessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This test is associated with <a
@@ -36,10 +37,10 @@ import test.org.dockbox.hartshorn.launchpad.launch.scanning.components.CountingC
     scanPackages = "test.org.dockbox.hartshorn.launchpad.launch.scanning",
     componentPreProcessors = {CountingComponentPreProcessor.class}
 )
-public class SpecificPackageTests {
+class SpecificPackageTests {
 
     @Test
-    public void specificPackageFilterIsApplied(@Inject CountingComponentPreProcessor processor) {
-        Assertions.assertEquals(1, processor.processed());
+    void specificPackageFilterIsApplied(@Inject CountingComponentPreProcessor processor) {
+        assertThat(processor.processed()).isOne();
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/observer/LifecycleObserverTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/observer/LifecycleObserverTests.java
@@ -31,13 +31,16 @@ import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.annotations.TestProperties;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.stream.CollectorUtilities;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.fail;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 @TestComponents(LifecycleObserverTests.ObserverConfiguration.class)
 @TestProperties("hartshorn.container.close.reentry-policy=IGNORE")
-public class LifecycleObserverTests {
+class LifecycleObserverTests {
 
     @Configuration
     public static class ObserverConfiguration {
@@ -53,48 +56,48 @@ public class LifecycleObserverTests {
     private ApplicationContext applicationContext;
 
     @Test
-    void testServiceLifecycleObserverIsPresentAndObserving() {
+    void serviceLifecycleObserverIsPresentAndObserving() {
         TestLifecycleObserver observer = getObserver(TestLifecycleObserver.class);
 
-        Assertions.assertTrue(observer.started());
+        assertThat(observer.started()).isTrue();
 
-        Assertions.assertDoesNotThrow(applicationContext::close);
-        Assertions.assertTrue(observer.stopped());
+        assertThatCode(applicationContext::close).doesNotThrowAnyException();
+        assertThat(observer.stopped()).isTrue();
     }
 
     @Test
-    void testNonRegisteredObserverIsNotPresentOnStart() {
+    void nonRegisteredObserverIsNotPresentOnStart() {
         NonRegisteredObserver observer = applicationContext.get(NonRegisteredObserver.class);
-        Assertions.assertFalse(observer.started());
-        Assertions.assertFalse(observer.stopped());
+        assertThat(observer.started()).isFalse();
+        assertThat(observer.stopped()).isFalse();
 
         ApplicationEnvironment environment = applicationContext.environment();
-        Assertions.assertTrue(environment instanceof ObservableApplicationEnvironment);
+        assertThat(environment).isInstanceOf(ObservableApplicationEnvironment.class);
 
         ((LifecycleObservable) environment).register(observer);
-        Assertions.assertDoesNotThrow(applicationContext::close);
+        assertThatCode(applicationContext::close).doesNotThrowAnyException();
 
         // Do not late-fire events
-        Assertions.assertFalse(observer.started());
-        Assertions.assertTrue(observer.stopped());
+        assertThat(observer.started()).isFalse();
+        assertThat(observer.stopped()).isTrue();
     }
 
     @Test
-    void testRegistrationFromClassIsValid() {
+    void registrationFromClassIsValid() {
         // Static as observer instance is lazily created by the observable, so we cannot
         // access it directly.
-        Assertions.assertFalse(StaticNonRegisteredObserver.started());
-        Assertions.assertFalse(StaticNonRegisteredObserver.stopped());
+        assertThat(StaticNonRegisteredObserver.started()).isFalse();
+        assertThat(StaticNonRegisteredObserver.stopped()).isFalse();
 
         ApplicationEnvironment environment = applicationContext.environment();
-        Assertions.assertTrue(environment instanceof ObservableApplicationEnvironment);
+        assertThat(environment).isInstanceOf(ObservableApplicationEnvironment.class);
 
         ((LifecycleObservable) environment).register(StaticNonRegisteredObserver.class);
-        Assertions.assertDoesNotThrow(applicationContext::close);
+        assertThatCode(applicationContext::close).doesNotThrowAnyException();
 
         // Do not late-fire events
-        Assertions.assertFalse(StaticNonRegisteredObserver.started());
-        Assertions.assertTrue(StaticNonRegisteredObserver.stopped());
+        assertThat(StaticNonRegisteredObserver.started()).isFalse();
+        assertThat(StaticNonRegisteredObserver.stopped()).isTrue();
     }
 
     private <T extends LifecycleObserver> T getObserver(Class<T> type) {
@@ -105,6 +108,6 @@ public class LifecycleObserverTests {
                 .filter(type::isInstance)
                 .collect(CollectorUtilities.toOption())
                 .cast(type)
-                .orElseGet(() -> Assertions.fail("Expected %s to be present in observers".formatted(type.getSimpleName())));
+                .orElseGet(() -> fail("Expected %s to be present in observers".formatted(type.getSimpleName())));
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/resources/ResourceLookupTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/launchpad/resources/ResourceLookupTests.java
@@ -21,7 +21,6 @@ import org.dockbox.hartshorn.launchpad.environment.FileSystemProvider;
 import org.dockbox.hartshorn.launchpad.resources.ResourceLookup;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.collections.CollectionUtilities;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -31,8 +30,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ResourceLookupTests {
+class ResourceLookupTests {
 
     @Inject
     private ResourceLookup resourceLookup;
@@ -41,32 +42,34 @@ public class ResourceLookupTests {
     private FileSystemProvider fileSystemProvider;
 
     @Test
-    void testClasspathLookup() {
+    void classpathLookup() {
         this.testResourceLookup("classpath:sample.txt");
     }
 
     @Test
-    void testFilesystemLookup() throws IOException {
+    void filesystemLookup() throws Exception {
         this.createLocalFile();
         this.testResourceLookup("fs:sample.txt");
     }
 
     @Test
-    void testUnnamedResourceLookup() throws IOException {
+    void unnamedResourceLookup() throws Exception {
         this.createLocalFile();
         this.testResourceLookup("sample.txt");
     }
 
     private void testResourceLookup(String path) {
         Set<URI> lookup = this.resourceLookup.lookup(path);
-        Assertions.assertFalse(lookup.isEmpty());
-        Assertions.assertEquals(1, lookup.size());
+        assertThat(lookup)
+                .isNotEmpty()
+                .hasSize(1);
 
         URI uri = CollectionUtilities.first(lookup);
         File file = new File(uri);
 
-        Assertions.assertEquals("sample.txt", file.getName());
-        Assertions.assertTrue(file.exists());
+        assertThat(file)
+                .hasName("sample.txt")
+                .exists();
     }
 
     private void createLocalFile() throws IOException {

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/properties/ProfilePropertiesTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/properties/ProfilePropertiesTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.properties;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.profiles.support.ConfigurationProfileRegistryFactory;
 import org.dockbox.hartshorn.profiles.ProfilePropertyRegistry;
@@ -25,36 +26,37 @@ import org.dockbox.hartshorn.properties.ValueProperty;
 import org.dockbox.hartshorn.test.annotations.TestProfiles;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @TestProfiles("ProfilePropertiesTests")
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ProfilePropertiesTests {
+class ProfilePropertiesTests {
 
     @Inject
     private PropertyRegistry propertyRegistry;
 
     @Test
-    void testPropertyRegistryHasProfilesInIntegrationTest() {
-        ProfilePropertyRegistry registry =
-            Assertions.assertInstanceOf(ProfilePropertyRegistry.class, propertyRegistry);
+    void propertyRegistryHasProfilesInIntegrationTest() {
+        ProfilePropertyRegistry registry = assertThat(propertyRegistry)
+                .asInstanceOf(InstanceOfAssertFactories.type(ProfilePropertyRegistry.class))
+                .actual();
         ProfileRegistry profileRegistry = registry.profileRegistry();
-        Assertions.assertEquals(2, profileRegistry.profiles().size());
+        assertThat(profileRegistry.profiles()).hasSize(2);
 
-        Assertions.assertTrue(profileRegistry.profile(ConfigurationProfileRegistryFactory.DEFAULT_PROFILE_NAME)
-            .present());
-        Assertions.assertTrue(profileRegistry.profile("ProfilePropertiesTests").present());
+        assertThat(profileRegistry.profile(ConfigurationProfileRegistryFactory.DEFAULT_PROFILE_NAME)
+            .present()).isTrue();
+        assertThat(profileRegistry.profile("ProfilePropertiesTests").present()).isTrue();
     }
 
     @Test
-    void testProfilePropertiesLoadInIntegrationTest() {
+    void profilePropertiesLoadInIntegrationTest() {
         Option<ValueProperty> propertyOption = this.propertyRegistry.get("test.property");
-        Assertions.assertTrue(propertyOption.present());
-        Assertions.assertTrue(propertyOption.flatMap(ValueProperty::value).present());
+        assertThat(propertyOption.present()).isTrue();
+        assertThat(propertyOption.flatMap(ValueProperty::value).present()).isTrue();
 
         ValueProperty property = propertyOption.get();
-        Assertions.assertEquals("This is a profile-specific property value.",
-            property.value().get());
+        assertThat(property.value().get()).isEqualTo("This is a profile-specific property value.");
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/properties/PropertiesBootstrapTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/properties/PropertiesBootstrapTests.java
@@ -24,39 +24,40 @@ import org.dockbox.hartshorn.properties.ValueProperty;
 import org.dockbox.hartshorn.properties.value.StandardValuePropertyParsers;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @PropertiesSource("classpath:it-additional-config.yml")
 @HartshornIntegrationTest(includeBasePackages = false)
-public class PropertiesBootstrapTests {
+class PropertiesBootstrapTests {
 
     @Test
-    void testConfigurationValueWasLoaded_AccessedByRegistry(
+    void configurationValueWasLoadedAccessedByRegistry(
         @Inject PropertyRegistry propertyRegistry
     ) {
         Option<Boolean> isAdditionalConfigPresent = propertyRegistry.value(
             "hartshorn.test.additional-config",
             StandardValuePropertyParsers.BOOLEAN
         );
-        Assertions.assertTrue(isAdditionalConfigPresent.test(Boolean::booleanValue));
+        assertThat(isAdditionalConfigPresent.test(Boolean::booleanValue)).isTrue();
     }
 
     @Test
-    void testConfigurationValueWasLoaded_AccessedByInjector(
+    void configurationValueWasLoadedAccessedByInjector(
         @PropertyValue(name = "hartshorn.test.additional-config") boolean additionalConfig
     ) {
-        Assertions.assertTrue(additionalConfig);
+        assertThat(additionalConfig).isTrue();
     }
 
     @Test
-    void testConfigurationPropertyWasLoaded_AccessedByInjector(
+    void configurationPropertyWasLoadedAccessedByInjector(
         @PropertyValue(name = "hartshorn.test.additional-config") ValueProperty property
     ) {
-        Assertions.assertNotNull(property);
+        assertThat(property).isNotNull();
 
         Option<String> value = property.value();
-        Assertions.assertTrue(value.present());
-        Assertions.assertEquals("true", value.get());
+        assertThat(value.present()).isTrue();
+        assertThat(value.get()).isEqualTo("true");
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/proxy/delegate/ApplicationContextCarrierDelegationTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/proxy/delegate/ApplicationContextCarrierDelegationTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.proxy.delegate;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.launchpad.context.ApplicationContextCarrier;
@@ -23,60 +24,63 @@ import org.dockbox.hartshorn.proxy.Proxy;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ApplicationContextCarrierDelegationTests {
+class ApplicationContextCarrierDelegationTests {
 
     @Test
     @TestComponents(ContextCarrierComponent.class)
-    void testContextCarrierDelegation(@Inject ContextCarrierComponent component) throws NoSuchMethodException {
+    void contextCarrierDelegation(@Inject ContextCarrierComponent component) throws Exception {
         Option<ApplicationContextCarrier> delegate = findTypeDelegate(component);
-        Assertions.assertTrue(delegate.present());
+        assertThat(delegate.present()).isTrue();
 
         Option<?> methodDelegate = findMethodDelegate(component);
-        Assertions.assertTrue(methodDelegate.absent());
+        assertThat(methodDelegate.absent()).isTrue();
 
-        Assertions.assertNotNull(component.applicationContext());
+        assertThat(component.applicationContext()).isNotNull();
     }
 
     @Test
     @TestComponents(OverrideContextCarrierComponentInterface.class)
-    void testDefaultCarrierDelegation(@Inject OverrideContextCarrierComponentInterface component) throws NoSuchMethodException {
+    void defaultCarrierDelegation(@Inject OverrideContextCarrierComponentInterface component) throws Exception {
         Option<ApplicationContextCarrier> delegate = findTypeDelegate(component);
-        Assertions.assertTrue(delegate.absent());
+        assertThat(delegate.absent()).isTrue();
 
         Option<?> methodDelegate = findMethodDelegate(component);
-        Assertions.assertTrue(methodDelegate.absent());
+        assertThat(methodDelegate.absent()).isTrue();
 
         // Default method, should return null (see OverrideContextCarrierComponentInterface)
-        Assertions.assertNull(component.applicationContext());
+        assertThat(component.applicationContext()).isNull();
     }
 
     @Test
     @TestComponents(ContextCarrierComponentInterface.class)
-    void testCarrierDelegation(
+    void carrierDelegation(
         @Inject ContextCarrierComponentInterface component,
         @Inject ApplicationContext applicationContext
-    ) throws NoSuchMethodException {
-        Assertions.assertTrue(component instanceof Proxy<?>);
+    ) throws Exception {
+        assertThat(component).isInstanceOf(Proxy.class);
         Method method = ApplicationContextCarrier.class.getMethod("applicationContext");
         Option<?> methodDelegate = ((Proxy<?>) component).manager()
             .advisor()
             .resolver()
             .method(method)
             .delegate();
-        Assertions.assertTrue(methodDelegate.present());
+        assertThat(methodDelegate.present()).isTrue();
 
-        Assertions.assertNotNull(component.applicationContext());
-        Assertions.assertSame(component.applicationContext(), applicationContext);
+        assertThat(component.applicationContext()).isNotNull();
+        assertThat(applicationContext).isSameAs(component.applicationContext());
     }
 
     private static Option<ApplicationContextCarrier> findTypeDelegate(Object object) {
-        Proxy<?> proxy = Assertions.assertInstanceOf(Proxy.class, object);
+        Proxy<?> proxy = assertThat(object)
+                .asInstanceOf(InstanceOfAssertFactories.type(Proxy.class))
+                .actual();
         return proxy.manager()
                 .advisor()
                 .resolver()
@@ -85,7 +89,9 @@ public class ApplicationContextCarrierDelegationTests {
     }
 
     private static Option<?> findMethodDelegate(Object object) throws NoSuchMethodException {
-        Proxy<?> proxy = Assertions.assertInstanceOf(Proxy.class, object);
+        Proxy<?> proxy = assertThat(object)
+                .asInstanceOf(InstanceOfAssertFactories.type(Proxy.class))
+                .actual();
         Method method = ApplicationContextCarrier.class.getMethod("applicationContext");
 
         return proxy.manager()

--- a/hartshorn-introspect-reflection/src/test/java/test/org/dockbox/hartshorn/util/introspect/ReflectionTypeIntrospectionTests.java
+++ b/hartshorn-introspect-reflection/src/test/java/test/org/dockbox/hartshorn/util/introspect/ReflectionTypeIntrospectionTests.java
@@ -22,12 +22,12 @@ import org.dockbox.hartshorn.util.introspect.annotations.VirtualHierarchyAnnotat
 import org.dockbox.hartshorn.util.introspect.reflect.ReflectionIntrospector;
 import org.junit.jupiter.api.BeforeEach;
 
-public class ReflectionTypeIntrospectionTests extends TypeIntrospectionTests {
+class ReflectionTypeIntrospectionTests extends TypeIntrospectionTests {
 
     private Introspector introspector;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         // Re-use the same introspector while inside a single test, so caching can be tested
         this.introspector = new ReflectionIntrospector(new NativeProxyLookup(),
             new VirtualHierarchyAnnotationLookup());

--- a/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/ConversionServiceTests.java
+++ b/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/ConversionServiceTests.java
@@ -27,7 +27,6 @@ import org.dockbox.hartshorn.util.introspect.convert.GenericConverters;
 import org.dockbox.hartshorn.util.introspect.convert.NullAccess;
 import org.dockbox.hartshorn.util.introspect.convert.StandardConversionService;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.util.introspect.support.basic.TestEnumType;
 
@@ -37,6 +36,9 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 /**
  * Tests for the {@link ConversionService} interface, driven by configurable {@link Introspector}
@@ -55,171 +57,175 @@ public abstract class ConversionServiceTests {
     }
 
     @Test
-    void testPrimitiveWrapperFromEmptyString() {
+    void primitiveWrapperFromEmptyString() {
         ConversionService conversionService = this.conversionService();
         Integer empty = conversionService.convert("", Integer.class);
-        Assertions.assertNotNull(empty);
-        Assertions.assertEquals(0, empty);
+        assertThat(empty)
+                .isZero();
     }
 
     @Test
-    void testNumberFromString() {
+    void numberFromString() {
         ConversionService conversionService = this.conversionService();
         Integer valid = conversionService.convert("12", Integer.class);
-        Assertions.assertNotNull(valid);
-        Assertions.assertEquals(12, valid);
+        assertThat(valid)
+                .isNotNull()
+                .isEqualTo(12);
     }
 
     @Test
-    void testPrimitiveFromString() {
+    void primitiveFromString() {
         ConversionService conversionService = this.conversionService();
         int primitive = conversionService.convert("12", int.class);
-        Assertions.assertEquals(12, primitive);
+        assertThat(primitive).isEqualTo(12);
     }
 
     @Test
-    void testEnumFromString() {
+    void enumFromString() {
         ConversionService conversionService = this.conversionService();
         TestEnumType a = conversionService.convert("A", TestEnumType.class);
-        Assertions.assertNotNull(a);
-        Assertions.assertSame(TestEnumType.A, a);
+        assertThat(a)
+                .isNotNull()
+                .isSameAs(TestEnumType.A);
 
         TestEnumType d = conversionService.convert("D", TestEnumType.class);
-        Assertions.assertNull(d);
+        assertThat(d).isNull();
     }
 
     @Test
-    void testOptionFromObject() {
+    void optionFromObject() {
         ConversionService conversionService = this.conversionService();
         Option<?> option = conversionService.convert("test", Option.class);
-        Assertions.assertNotNull(option);
-        Assertions.assertTrue(option.present());
-        Assertions.assertEquals("test", option.get());
+        assertThat(option).isNotNull();
+        assertThat(option.present()).isTrue();
+        assertThat(option.get()).isEqualTo("test");
     }
 
     @Test
-    void testObjectFromOption() {
+    void objectFromOption() {
         ConversionService conversionService = this.conversionService();
         String converted = conversionService.convert(Option.of("test"), String.class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals("test", converted);
+        assertThat(converted)
+                .isNotNull()
+                .isEqualTo("test");
     }
 
     @Test
-    void testOptionDefaultValue() {
+    void optionDefaultValue() {
         ConversionService conversionService = this.conversionService();
         Option<?> optionFromNull = conversionService.convert(null, Option.class);
-        Assertions.assertNotNull(optionFromNull);
-        Assertions.assertFalse(optionFromNull.present());
+        assertThat(optionFromNull).isNotNull();
+        assertThat(optionFromNull.present()).isFalse();
     }
 
     @Test
-    void testStringDefaultValue() {
+    void stringDefaultValue() {
         ConversionService conversionService = this.conversionService();
         String stringFromNull = conversionService.convert(null, String.class);
-        Assertions.assertNotNull(stringFromNull);
-        Assertions.assertEquals("", stringFromNull);
+        assertThat(stringFromNull).isNotNull();
+        assertThat(stringFromNull).isEmpty();
     }
 
     @Test
-    void testPrimitiveDefaultValue() {
+    void primitiveDefaultValue() {
         ConversionService conversionService = this.conversionService();
         int intFromNull = conversionService.convert(null, int.class);
-        Assertions.assertEquals(0, intFromNull);
+        assertThat(intFromNull).isZero();
     }
 
     @Test
-    void testPrimitiveWrapperDefaultValue() {
+    void primitiveWrapperDefaultValue() {
         ConversionService conversionService = this.conversionService();
         Integer integerFromNull = conversionService.convert(null, Integer.class);
-        Assertions.assertNotNull(integerFromNull);
-        Assertions.assertEquals(0, integerFromNull);
+        assertThat(integerFromNull)
+                .isZero();
     }
 
     @Test
-    void testConcreteSetDefaultValue() {
+    void concreteSetDefaultValue() {
         ConversionService conversionService = this.conversionService();
         Set<?> hashSet = conversionService.convert(null, TreeSet.class);
-        Assertions.assertNotNull(hashSet);
-        Assertions.assertTrue(hashSet.isEmpty());
-        Assertions.assertTrue(hashSet instanceof TreeSet);
+        assertThat(hashSet)
+                .isInstanceOf(TreeSet.class)
+                .isEmpty();
     }
 
     @Test
-    void testSetDefaultValue() {
+    void setDefaultValue() {
         ConversionService conversionService = this.conversionService();
         Set<?> set = conversionService.convert(null, Set.class);
-        Assertions.assertNotNull(set);
-        Assertions.assertTrue(set.isEmpty());
+        assertThat(set).isNotNull();
+        assertThat(set).isEmpty();
     }
 
     @Test
-    void testListDefaultValue() {
+    void listDefaultValue() {
         ConversionService conversionService = this.conversionService();
         List<?> list = conversionService.convert(null, List.class);
-        Assertions.assertNotNull(list);
-        Assertions.assertTrue(list.isEmpty());
+        assertThat(list).isNotNull();
+        assertThat(list).isEmpty();
     }
 
     @Test
-    void testConcreteListDefaultValue() {
+    void concreteListDefaultValue() {
         ConversionService conversionService = this.conversionService();
         List<?> arrayList = conversionService.convert(null, CopyOnWriteArrayList.class);
-        Assertions.assertNotNull(arrayList);
-        Assertions.assertTrue(arrayList.isEmpty());
-        Assertions.assertTrue(arrayList instanceof CopyOnWriteArrayList);
+        assertThat(arrayList)
+                .isInstanceOf(CopyOnWriteArrayList.class)
+                .isEmpty();
     }
 
     @Test
-    void testCollectionFromObject() {
+    void collectionFromObject() {
         ConversionService conversionService = this.conversionService();
         List<?> linkedList = conversionService.convert("test", LinkedList.class);
-        Assertions.assertNotNull(linkedList);
-        Assertions.assertFalse(linkedList.isEmpty());
-        Assertions.assertEquals("test", linkedList.get(0));
+        assertThat(linkedList)
+                .isNotEmpty()
+                .first()
+                .isEqualTo("test");
     }
 
     @Test
-    void testCollectionFromCollection() {
+    void collectionFromCollection() {
         ConversionService conversionService = this.conversionService();
         Set<?> setFromList = conversionService.convert(List.of(1, 2, 3), Set.class);
-        Assertions.assertNotNull(setFromList);
-        Assertions.assertFalse(setFromList.isEmpty());
-        Assertions.assertEquals(3, setFromList.size());
+        assertThat(setFromList)
+                .isNotEmpty()
+                .hasSize(3);
     }
 
     @Test
-    void testCollectionFromOption() {
+    void collectionFromOption() {
         ConversionService conversionService = this.conversionService();
         List<?> listFromOption = conversionService.convert(Option.of("123"), List.class);
-        Assertions.assertNotNull(listFromOption);
-        Assertions.assertFalse(listFromOption.isEmpty());
-        Assertions.assertEquals(1, listFromOption.size());
-        Assertions.assertEquals("123", listFromOption.get(0));
+        assertThat(listFromOption)
+                .isNotEmpty()
+                .hasSize(1);
+        assertThat(listFromOption.get(0)).isEqualTo("123");
     }
 
     @Test
-    void testArrayFromCollection() {
+    void arrayFromCollection() {
         ConversionService conversionService = this.conversionService();
         String[] array = conversionService.convert(List.of("1", "2", "3"), String[].class);
-        Assertions.assertNotNull(array);
-        Assertions.assertEquals(3, array.length);
-        Assertions.assertEquals("1", array[0]);
-        Assertions.assertEquals("2", array[1]);
-        Assertions.assertEquals("3", array[2]);
+        assertThat(array).isNotNull();
+        assertThat(array.length).isEqualTo(3);
+        assertThat(array[0]).isEqualTo("1");
+        assertThat(array[1]).isEqualTo("2");
+        assertThat(array[2]).isEqualTo("3");
     }
 
     @Test
-    void testArrayFromObject() {
+    void arrayFromObject() {
         ConversionService conversionService = this.conversionService();
         String[] array = conversionService.convert("test", String[].class);
-        Assertions.assertNotNull(array);
-        Assertions.assertEquals(1, array.length);
-        Assertions.assertEquals("test", array[0]);
+        assertThat(array).isNotNull();
+        assertThat(array.length).isOne();
+        assertThat(array[0]).isEqualTo("test");
     }
 
     @Test
-    void testImplicitlyTypedConverterIsAdaptedCorrectly() {
+    void implicitlyTypedConverterIsAdaptedCorrectly() {
         this.testConverterTypeIsAdaptedCorrectly(
             registry -> registry.addConverter(new SimpleConverter()),
             "1", Integer.class,
@@ -228,7 +234,7 @@ public abstract class ConversionServiceTests {
     }
 
     @Test
-    void testLambdaConverterWithoutExplicitTypesIsRejected() {
+    void lambdaConverterWithoutExplicitTypesIsRejected() {
         ConverterCache converterCache = new GenericConverters();
         ConverterCache defaultValueProviderCache = new GenericConverters();
         ConverterRegistry registry = new StandardConversionService(this.introspector(),
@@ -236,16 +242,13 @@ public abstract class ConversionServiceTests {
             defaultValueProviderCache);
         // Not allowed because the source and target types cannot practically be determined due to
         // type erasure
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> registry.addConverter((Converter<String, Integer>) source -> {
-                //noinspection Convert2MethodRef
-                return Integer.parseInt(source);
-            }));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+            registry.addConverter((Converter<String, Integer>) Integer::parseInt);
+        });
     }
 
     @Test
-    void testLambdaConverterWithExplicitTypesIsAdaptedCorrectly() {
+    void lambdaConverterWithExplicitTypesIsAdaptedCorrectly() {
         this.testConverterTypeIsAdaptedCorrectly(
             registry -> registry.addConverter(String.class,
                 Integer.class,
@@ -256,7 +259,7 @@ public abstract class ConversionServiceTests {
     }
 
     @Test
-    void testExplicitlyTypedConverterIsAdapterCorrectly() {
+    void explicitlyTypedConverterIsAdapterCorrectly() {
         this.testConverterTypeIsAdaptedCorrectly(
             registry -> registry.addConverter(String.class, Integer.class, new SimpleConverter()),
             "1", Integer.class,
@@ -265,7 +268,7 @@ public abstract class ConversionServiceTests {
     }
 
     @Test
-    void testImplicitDefaultValueProviderIsAdaptedCorrectly() {
+    void implicitDefaultValueProviderIsAdaptedCorrectly() {
         // Lambdas are not supported in this context due to the absence of sufficient type hints.
         // Though, using #addDefaultValueProvider(Class, DefaultValueProvider) it would be
         // supported in any practical scenario.
@@ -283,7 +286,7 @@ public abstract class ConversionServiceTests {
     }
 
     @Test
-    void testExplicitDefaultValueProviderIsAdaptedCorrectly() {
+    void explicitDefaultValueProviderIsAdaptedCorrectly() {
         this.testConverterTypeIsAdaptedCorrectly(
             registry -> registry.addDefaultValueProvider(String.class, () -> ""),
             NullAccess.getInstance(), String.class,
@@ -302,8 +305,8 @@ public abstract class ConversionServiceTests {
         ConverterRegistry registry = new StandardConversionService(this.introspector(),
             converterCache,
             defaultValueProviderCache);
-        Assertions.assertTrue(converterCache.converters().isEmpty());
-        Assertions.assertTrue(defaultValueProviderCache.converters().isEmpty());
+        assertThat(converterCache.converters()).isEmpty();
+        assertThat(defaultValueProviderCache.converters()).isEmpty();
 
         registerAction.accept(registry);
 
@@ -312,12 +315,12 @@ public abstract class ConversionServiceTests {
         ConverterCache shouldBePopulated =
             converterType == ConverterType.CONVERTER ? converterCache : defaultValueProviderCache;
 
-        Assertions.assertTrue(shouldBeEmpty.converters().isEmpty());
-        Assertions.assertFalse(shouldBePopulated.converters().isEmpty());
-        Assertions.assertEquals(1, shouldBePopulated.converters().size());
+        assertThat(shouldBeEmpty.converters()).isEmpty();
+        assertThat(shouldBePopulated.converters()).isNotEmpty();
+        assertThat(shouldBePopulated.converters()).hasSize(1);
 
         GenericConverter converter = shouldBePopulated.getConverter(source, targetType);
-        Assertions.assertNotNull(converter);
+        assertThat(converter).isNotNull();
     }
 
     private enum ConverterType {

--- a/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
+++ b/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
@@ -16,19 +16,8 @@
 
 package test.org.dockbox.hartshorn.util.introspect;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
-
+import org.assertj.core.api.Assertions;
 import org.dockbox.hartshorn.util.collections.CollectionUtilities;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import org.dockbox.hartshorn.util.types.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.ParameterizableType;
 import org.dockbox.hartshorn.util.introspect.TypeParametersIntrospector;
@@ -39,7 +28,7 @@ import org.dockbox.hartshorn.util.introspect.view.ParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
+import org.dockbox.hartshorn.util.types.TypeUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -51,6 +40,15 @@ import test.org.dockbox.hartshorn.util.introspect.support.basic.ConcreteTestType
 import test.org.dockbox.hartshorn.util.introspect.support.basic.ParentTestType;
 import test.org.dockbox.hartshorn.util.introspect.support.basic.TestEnumType;
 import test.org.dockbox.hartshorn.util.introspect.support.bridge.BridgeElement;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for the {@link Introspector} interface. Unlike {@link TypeIntrospectionTests}, this class

--- a/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
+++ b/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/IntrospectorTests.java
@@ -24,7 +24,10 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.dockbox.hartshorn.util.collections.CollectionUtilities;
-import org.dockbox.hartshorn.util.types.TypeConversionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.dockbox.hartshorn.util.types.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.ParameterizableType;
@@ -132,95 +135,96 @@ public abstract class IntrospectorTests {
 
     @ParameterizedTest
     @MethodSource("fields")
-    void testFieldValueReturnsValue(String field) throws Throwable {
+    void fieldValueReturnsValue(String field) throws Throwable {
         ConcreteTestType instance = new ConcreteTestType();
         TypeView<ConcreteTestType> type = this.introspector().introspect(instance);
         Option<?> value = type.fields().named(field).get().get(instance);
-        Assertions.assertTrue(value.present());
-        Assertions.assertEquals(field, value.get());
+        assertThat(value.present()).isTrue();
+        assertThat(value.get()).isEqualTo(field);
     }
 
     @ParameterizedTest
     @MethodSource("methods")
-    void testRunMethodReturnsValue(String method) throws Throwable {
+    void runMethodReturnsValue(String method) throws Throwable {
         ConcreteTestType instance = new ConcreteTestType();
         TypeView<ConcreteTestType> type = this.introspector().introspect(instance);
         Option<?> value =
             type.methods().named(method, List.of(String.class)).get().invoke(instance, "value");
-        Assertions.assertTrue(value.present());
-        Assertions.assertEquals("VALUE", value.get());
+        assertThat(value.present()).isTrue();
+        assertThat(value.get()).isEqualTo("VALUE");
     }
 
     @ParameterizedTest
     @MethodSource("assignablePrimitives")
-    void testAssignableFromPrimitives(Class<?> primitive, Class<?> wrapper) {
+    void assignableFromPrimitives(Class<?> primitive, Class<?> wrapper) {
         TypeView<?> pt = this.introspector().introspect(primitive);
         TypeView<?> wt = this.introspector().introspect(wrapper);
-        Assertions.assertTrue(pt.isChildOf(wt.type()));
-        Assertions.assertTrue(wt.isChildOf(pt.type()));
+        assertThat(pt.isChildOf(wt.type())).isTrue();
+        assertThat(wt.isChildOf(pt.type())).isTrue();
     }
 
     @Test
-    void testAssignableFromSuper() {
-        Assertions.assertTrue(this.introspector()
+    void assignableFromSuper() {
+        assertThat(this.introspector()
             .introspect(ConcreteTestType.class)
-            .isChildOf(ParentTestType.class));
+            .isChildOf(ParentTestType.class)).isTrue();
     }
 
     @Test
-    void testAssignableFromSame() {
-        Assertions.assertTrue(this.introspector()
+    void assignableFromSame() {
+        assertThat(this.introspector()
             .introspect(ConcreteTestType.class)
-            .isChildOf(ConcreteTestType.class));
+            .isChildOf(ConcreteTestType.class)).isTrue();
     }
 
     @Test
-    void testAssignableFromChild() {
-        Assertions.assertFalse(this.introspector()
+    void assignableFromChild() {
+        assertThat(this.introspector()
             .introspect(ParentTestType.class)
-            .isChildOf(ConcreteTestType.class));
+            .isChildOf(ConcreteTestType.class)).isFalse();
     }
 
     @Test
-    void testAnnotatedMethodsReturnsAllModifiers() {
+    void annotatedMethodsReturnsAllModifiers() {
         TypeView<ConcreteTestType> type = this.introspector().introspect(ConcreteTestType.class);
         List<MethodView<ConcreteTestType, ?>> methods =
             type.methods().annotatedWith(MultipleElementAnnotation.class);
-        Assertions.assertEquals(3, methods.size());
+        assertThat(methods).hasSize(3);
 
         List<String> names = methods.stream().map(MethodView::name).toList();
-        Assertions.assertTrue(names.contains("publicAnnotatedMethod"));
-        Assertions.assertTrue(names.contains("privateAnnotatedMethod"));
+        assertThat(names)
+                .contains("publicAnnotatedMethod")
+                .contains("privateAnnotatedMethod");
     }
 
     @Test
-    void testStaticFieldsReturnsAllModifiers() {
+    void staticFieldsReturnsAllModifiers() {
         List<FieldView<ConcreteTestType, ?>> fields =
             this.introspector().introspect(ConcreteTestType.class).fields().all().stream()
                 .filter(field -> field.modifiers().isStatic())
                 .toList();
-        Assertions.assertEquals(2, fields.size());
+        assertThat(fields).hasSize(2);
     }
 
     @Test
-    void testHasAnnotationOnMethod() {
+    void hasAnnotationOnMethod() {
         Option<MethodView<ConcreteTestType, ?>> method =
             this.introspector().introspect(ConcreteTestType.class)
                 .methods()
                 .named("publicAnnotatedMethod");
-        Assertions.assertTrue(method.present());
-        Assertions.assertTrue(method.get().annotations().has(MultipleElementAnnotation.class));
+        assertThat(method.present()).isTrue();
+        assertThat(method.get().annotations().has(MultipleElementAnnotation.class)).isTrue();
     }
 
     @Test
-    void testSuperTypesReturnsAllSuperTypesWithoutObject() {
+    void superTypesReturnsAllSuperTypesWithoutObject() {
         TypeView<?> parent = this.introspector().introspect(ConcreteTestType.class).superClass();
-        Assertions.assertFalse(parent.isVoid());
-        Assertions.assertSame(ParentTestType.class, parent.type());
+        assertThat(parent.isVoid()).isFalse();
+        assertThat(parent.type()).isSameAs(ParentTestType.class);
     }
 
     @Test
-    void testMethodsReturnsAllDeclaredAndParentMethods() {
+    void methodsReturnsAllDeclaredAndParentMethods() {
         TypeView<ConcreteTestType> type = this.introspector().introspect(ConcreteTestType.class);
         List<MethodView<ConcreteTestType, ?>> methods = type.methods().all();
         boolean fail = true;
@@ -230,105 +234,105 @@ public abstract class IntrospectorTests {
             }
         }
         if (fail) {
-            Assertions.fail("Parent types were not included");
+            org.assertj.core.api.Assertions.fail("Parent types were not included");
         }
     }
 
     @Test
-    void testTypeContextMethodsDoNotIncludeBridgeMethods() {
+    void typeContextMethodsDoNotIncludeBridgeMethods() {
         TypeView<BridgeElement> bridge = this.introspector().introspect(BridgeElement.class);
         List<MethodView<BridgeElement, ?>> methods = bridge.methods().all();
         for (MethodView<BridgeElement, ?> method : methods) {
             Option<Method> nativeMethod = method.method();
-            Assertions.assertTrue(nativeMethod.present());
-            Assertions.assertFalse(nativeMethod.get().isBridge());
+            assertThat(nativeMethod.present()).isTrue();
+            assertThat(nativeMethod.get().isBridge()).isFalse();
         }
     }
 
     @Test
-    void testTypeContextBridgeMethodsCanBeObtained() {
+    void typeContextBridgeMethodsCanBeObtained() {
         TypeView<BridgeElement> bridge = this.introspector().introspect(BridgeElement.class);
         List<MethodView<BridgeElement, ?>> methods = bridge.methods().bridges();
-        Assertions.assertEquals(1, methods.size());
-        Assertions.assertSame(Object.class, methods.get(0).returnType().type());
-        Assertions.assertTrue(methods.get(0).method().present());
-        Assertions.assertTrue(methods.get(0).method().get().isBridge());
+        assertThat(methods).hasSize(1);
+        assertThat(methods.get(0).returnType().type()).isSameAs(Object.class);
+        assertThat(methods.get(0).method().present()).isTrue();
+        assertThat(methods.get(0).method().get().isBridge()).isTrue();
     }
 
     @Test
-    void testLookupReturnsClassIfPresent() {
+    void lookupReturnsClassIfPresent() {
         TypeView<?> lookup = this.introspector().introspect(ConcreteTestType.class.getName());
-        Assertions.assertNotNull(lookup);
-        Assertions.assertSame(ConcreteTestType.class, lookup.type());
+        assertThat(lookup).isNotNull();
+        assertThat(lookup.type()).isSameAs(ConcreteTestType.class);
     }
 
     @Test
-    void testLookupReturnsVoidIfAbsent() {
+    void lookupReturnsVoidIfAbsent() {
         TypeView<?> lookup =
             this.introspector().introspect("org.dockbox.hartshorn.util.AnotherClass");
-        Assertions.assertTrue(lookup.isVoid());
+        assertThat(lookup.isVoid()).isTrue();
     }
 
     @Test
-    void testHasMethodIsTrueIfMethodExists() {
-        Assertions.assertTrue(this.introspector().introspect(ConcreteTestType.class)
+    void hasMethodIsTrueIfMethodExists() {
+        assertThat(this.introspector().introspect(ConcreteTestType.class)
             .methods()
             .named("publicMethod", String.class)
-            .present());
+            .present()).isTrue();
     }
 
     @Test
-    void testHasMethodIsFalseIfMethodDoesNotExist() {
-        Assertions.assertFalse(this.introspector().introspect(ConcreteTestType.class)
+    void hasMethodIsFalseIfMethodDoesNotExist() {
+        assertThat(this.introspector().introspect(ConcreteTestType.class)
             .methods()
             .named("otherMethod")
-            .present());
+            .present()).isFalse();
     }
 
     @Test
-    void testInstanceHasMethodIsTrueIfMethodExists() {
-        Assertions.assertTrue(this.introspector().introspect(new ConcreteTestType())
+    void instanceHasMethodIsTrueIfMethodExists() {
+        assertThat(this.introspector().introspect(new ConcreteTestType())
             .methods()
             .named("publicMethod", String.class)
-            .present());
+            .present()).isTrue();
     }
 
     @Test
-    void testInstanceHasMethodIsFalseIfMethodDoesNotExist() {
-        Assertions.assertFalse(this.introspector().introspect(new ConcreteTestType())
+    void instanceHasMethodIsFalseIfMethodDoesNotExist() {
+        assertThat(this.introspector().introspect(new ConcreteTestType())
             .methods()
             .named("otherMethod")
-            .present());
+            .present()).isFalse();
     }
 
     @ParameterizedTest
     @MethodSource("nonVoidTypes")
-    void testVoidIsFalseIfTypeIsNotVoid(Class<?> type) {
-        Assertions.assertFalse(this.introspector().introspect(type).isVoid());
+    void voidIsFalseIfTypeIsNotVoid(Class<?> type) {
+        assertThat(this.introspector().introspect(type).isVoid()).isFalse();
     }
 
     @Test
-    void testVoidIsTrueIfTypeIsVoid() {
-        Assertions.assertTrue(this.introspector().introspect(Void.class).isVoid());
+    void voidIsTrueIfTypeIsVoid() {
+        assertThat(this.introspector().introspect(Void.class).isVoid()).isTrue();
     }
 
     @Test
-    void testVoidIsTrueIfTypeIsVoidPrimitive() {
-        Assertions.assertTrue(this.introspector().introspect(void.class).isVoid());
+    void voidIsTrueIfTypeIsVoidPrimitive() {
+        assertThat(this.introspector().introspect(void.class).isVoid()).isTrue();
     }
 
     @ParameterizedTest
     @MethodSource("fields")
-    void testHasFieldReturnsTrue(String field) {
-        Assertions.assertTrue(this.introspector().introspect(ConcreteTestType.class)
+    void hasFieldReturnsTrue(String field) {
+        assertThat(this.introspector().introspect(ConcreteTestType.class)
             .fields()
             .named(field)
-            .present());
+            .present()).isTrue();
     }
 
     @ParameterizedTest
     @MethodSource("fields")
-    void testFieldsConsumesAllFields(String field) {
+    void fieldsConsumesAllFields(String field) {
         boolean activated = false;
         TypeView<ConcreteTestType> type = this.introspector().introspect(ConcreteTestType.class);
         for (FieldView<ConcreteTestType, ?> fieldView : type.fields().all()) {
@@ -336,69 +340,70 @@ public abstract class IntrospectorTests {
                 activated = true;
             }
         }
-        Assertions.assertTrue(activated);
+        assertThat(activated).isTrue();
     }
 
     @Test
-    void testSetFieldUpdatesAccessorField() throws Throwable {
+    void setFieldUpdatesAccessorField() throws Throwable {
         Field fieldRef = ConcreteTestType.class.getDeclaredField("accessorField");
         FieldView<?, ?> field = this.introspector().introspect(fieldRef);
         ConcreteTestType instance = new ConcreteTestType();
         field.set(instance, "newValue");
 
-        Assertions.assertTrue(instance.activatedSetter());
+        assertThat(instance.activatedSetter()).isTrue();
     }
 
     @Test
-    void testSetFieldUpdatesNormalField() throws Throwable {
+    void setFieldUpdatesNormalField() throws Throwable {
         Field fieldRef = ConcreteTestType.class.getDeclaredField("publicField");
         FieldView<?, ?> field = this.introspector().introspect(fieldRef);
         ConcreteTestType instance = new ConcreteTestType();
         field.set(instance, "newValue");
 
-        Assertions.assertEquals("newValue", instance.publicField);
+        assertThat(instance.publicField).isEqualTo("newValue");
     }
 
     @Test
-    void testAnnotatedFieldsIncludesStatic() {
+    void annotatedFieldsIncludesStatic() {
         List<FieldView<ConcreteTestType, ?>> fields =
             this.introspector().introspect(ConcreteTestType.class).fields().annotatedWith(
                 MultipleElementAnnotation.class);
-        Assertions.assertEquals(2, fields.size());
+        assertThat(fields).hasSize(2);
         int statics = 0;
         for (FieldView<ConcreteTestType, ?> field : fields) {
             if (field.modifiers().isStatic()) {
                 statics++;
             }
         }
-        Assertions.assertEquals(1, statics);
+        assertThat(statics).isOne();
     }
 
     @Test
-    void testAnnotatedConstructors() {
+    void annotatedConstructors() {
         TypeView<ConcreteTestType> type = this.introspector().introspect(ConcreteTestType.class);
         List<ConstructorView<ConcreteTestType>> constructors =
             type.constructors().annotatedWith(MultipleElementAnnotation.class);
-        Assertions.assertEquals(1, constructors.size());
+        assertThat(constructors).hasSize(1);
     }
 
     @ParameterizedTest
     @MethodSource("primitiveValues")
-    void testStringToPrimitive(Class<?> type, String value, Object expected)
-        throws TypeConversionException {
+    void stringToPrimitive(Class<?> type, String value, Object expected)
+        throws Exception {
         Object o = TypeUtils.toPrimitive(type, value);
-        Assertions.assertNotNull(o);
-        Assertions.assertEquals(expected, o);
+        assertThat(o)
+                .isNotNull()
+                .isEqualTo(expected);
     }
 
     @Test
-    void testRedefinedAnnotationsTakePriority() {
+    void redefinedAnnotationsTakePriority() {
         TypeView<AnnotatedObject> typeContext =
             this.introspector().introspect(AnnotatedObject.class);
         Option<AnyElementAnnotation> annotation =
             typeContext.annotations().get(AnyElementAnnotation.class);
-        Assertions.assertTrue(annotation.present());
-        Assertions.assertEquals("impl", annotation.get().value());
+        assertThat(annotation.present()).isTrue();
+        assertThat(annotation.get().value()).isEqualTo("impl");
     }
 
     @Test
@@ -413,22 +418,22 @@ public abstract class IntrospectorTests {
 
         TypeView<?> first = parameter.genericType();
 
-        Assertions.assertTrue(first.is(List.class));
-        Assertions.assertEquals(1, first.typeParameters().allInput().count());
+        assertThat(first.is(List.class)).isTrue();
+        assertThat(first.typeParameters().allInput().count()).isOne();
 
         TypeView<?> second = first.typeParameters().atIndex(0)
             .orElseGet(Assertions::fail)
             .resolvedType().orNull();
-        Assertions.assertNotNull(second);
-        Assertions.assertTrue(second.is(List.class));
-        Assertions.assertEquals(1, second.typeParameters().allInput().count());
+        assertThat(second).isNotNull();
+        assertThat(second.is(List.class)).isTrue();
+        assertThat(second.typeParameters().allInput().count()).isOne();
 
         TypeView<?> third = second.typeParameters().atIndex(0)
             .orElseGet(Assertions::fail)
             .resolvedType().orNull();
-        Assertions.assertNotNull(third);
-        Assertions.assertTrue(third.is(String.class));
-        Assertions.assertEquals(0, third.typeParameters().allInput().count());
+        assertThat(third).isNotNull();
+        assertThat(third.is(String.class)).isTrue();
+        assertThat(third.typeParameters().allInput().count()).isZero();
     }
 
     @SuppressWarnings("unused") // Used by genericTypeTests
@@ -440,7 +445,7 @@ public abstract class IntrospectorTests {
     }
 
     @Test
-    void testWildcardsWithUpperBounds() {
+    void wildcardsWithUpperBounds() {
         ParameterView<?> parameter = this.introspector().introspect(this)
             .methods()
             .named("methodWithWildcardUpperbounds", List.class)
@@ -449,78 +454,78 @@ public abstract class IntrospectorTests {
             .at(0)
             .orNull();
 
-        Assertions.assertNotNull(parameter);
+        assertThat(parameter).isNotNull();
         TypeView<?> first = parameter.genericType();
 
-        Assertions.assertTrue(first.is(List.class));
-        Assertions.assertEquals(1, first.typeParameters().allInput().count());
+        assertThat(first.is(List.class)).isTrue();
+        assertThat(first.typeParameters().allInput().count()).isOne();
 
         TypeView<?> second = first.typeParameters().atIndex(0)
             .orElseGet(Assertions::fail)
             .resolvedType().orNull();
-        Assertions.assertNotNull(second);
-        Assertions.assertTrue(second.is(String.class));
-        Assertions.assertFalse(second.isWildcard());
+        assertThat(second).isNotNull();
+        assertThat(second.is(String.class)).isTrue();
+        assertThat(second.isWildcard()).isFalse();
     }
 
     @Test
     void concreteClassIsCorrectlyIdentified() {
         TypeView<ConcreteClass> type = this.introspector().introspect(ConcreteClass.class);
-        Assertions.assertFalse(type.modifiers().isAbstract());
-        Assertions.assertFalse(type.isInterface());
-        Assertions.assertFalse(type.isRecord());
-        Assertions.assertFalse(type.isEnum());
-        Assertions.assertFalse(type.isAnnotation());
+        assertThat(type.modifiers().isAbstract()).isFalse();
+        assertThat(type.isInterface()).isFalse();
+        assertThat(type.isRecord()).isFalse();
+        assertThat(type.isEnum()).isFalse();
+        assertThat(type.isAnnotation()).isFalse();
     }
 
     @Test
     void abstractClassIsCorrectlyIdentified() {
         TypeView<AbstractClass> type = this.introspector().introspect(AbstractClass.class);
-        Assertions.assertTrue(type.modifiers().isAbstract());
-        Assertions.assertFalse(type.isInterface());
-        Assertions.assertFalse(type.isRecord());
-        Assertions.assertFalse(type.isEnum());
-        Assertions.assertFalse(type.isAnnotation());
+        assertThat(type.modifiers().isAbstract()).isTrue();
+        assertThat(type.isInterface()).isFalse();
+        assertThat(type.isRecord()).isFalse();
+        assertThat(type.isEnum()).isFalse();
+        assertThat(type.isAnnotation()).isFalse();
     }
 
     @Test
     void interfaceIsCorrectlyIdentified() {
         TypeView<Interface> type = this.introspector().introspect(Interface.class);
-        Assertions.assertTrue(type.modifiers().isAbstract());
-        Assertions.assertTrue(type.isInterface());
-        Assertions.assertFalse(type.isRecord());
-        Assertions.assertFalse(type.isEnum());
-        Assertions.assertFalse(type.isAnnotation());
+        assertThat(type.modifiers().isAbstract()).isTrue();
+        assertThat(type.isInterface()).isTrue();
+        assertThat(type.isRecord()).isFalse();
+        assertThat(type.isEnum()).isFalse();
+        assertThat(type.isAnnotation()).isFalse();
     }
 
     @Test
     void recordIsCorrectlyIdentified() {
         TypeView<RecordType> type = this.introspector().introspect(RecordType.class);
-        Assertions.assertFalse(type.modifiers().isAbstract());
-        Assertions.assertFalse(type.isInterface());
-        Assertions.assertTrue(type.isRecord());
-        Assertions.assertFalse(type.isEnum());
-        Assertions.assertFalse(type.isAnnotation());
+        assertThat(type.modifiers().isAbstract()).isFalse();
+        assertThat(type.isInterface()).isFalse();
+        assertThat(type.isRecord()).isTrue();
+        assertThat(type.isEnum()).isFalse();
+        assertThat(type.isAnnotation()).isFalse();
     }
 
     @Test
     void enumIsCorrectlyIdentified() {
         TypeView<EnumType> type = this.introspector().introspect(EnumType.class);
-        Assertions.assertFalse(type.modifiers().isAbstract());
-        Assertions.assertFalse(type.isInterface());
-        Assertions.assertFalse(type.isRecord());
-        Assertions.assertTrue(type.isEnum());
-        Assertions.assertFalse(type.isAnnotation());
+        assertThat(type.modifiers().isAbstract()).isFalse();
+        assertThat(type.isInterface()).isFalse();
+        assertThat(type.isRecord()).isFalse();
+        assertThat(type.isEnum()).isTrue();
+        assertThat(type.isAnnotation()).isFalse();
     }
 
     @Test
     void annotationIsCorrectlyIdentified() {
         TypeView<AnnotationType> type = this.introspector().introspect(AnnotationType.class);
-        Assertions.assertTrue(type.modifiers().isAbstract());
-        Assertions.assertTrue(type.isInterface());
-        Assertions.assertFalse(type.isRecord());
-        Assertions.assertFalse(type.isEnum());
-        Assertions.assertTrue(type.isAnnotation());
+        assertThat(type.modifiers().isAbstract()).isTrue();
+        assertThat(type.isInterface()).isTrue();
+        assertThat(type.isRecord()).isFalse();
+        assertThat(type.isEnum()).isFalse();
+        assertThat(type.isAnnotation()).isTrue();
     }
 
     private static class ConcreteClass {
@@ -541,40 +546,40 @@ public abstract class IntrospectorTests {
     }
 
     @Test
-    void testGenericTypeWithWildcardUsesUpperbounds() {
+    void genericTypeWithWildcardUsesUpperbounds() {
         Option<FieldView<IntrospectorTests, ?>> field =
             this.introspector().introspect(this).fields().named("genericType");
-        Assertions.assertTrue(field.present());
+        assertThat(field.present()).isTrue();
 
         TypeParametersIntrospector parametersIntrospector =
             field.get().genericType().typeParameters();
-        Assertions.assertEquals(1, parametersIntrospector.allInput().count());
+        assertThat(parametersIntrospector.allInput().count()).isOne();
 
         TypeParameterView typeParameter = parametersIntrospector.atIndex(0)
             .orElseGet(Assertions::fail);
 
         TypeView<?> parameter = typeParameter
             .resolvedType().orNull();
-        Assertions.assertTrue(parameter.isWildcard());
+        assertThat(parameter.isWildcard()).isTrue();
 
         Set<TypeView<?>> upperBounds = typeParameter.upperBounds();
-        Assertions.assertEquals(1, upperBounds.size());
-        Assertions.assertSame(Object.class, CollectionUtilities.first(upperBounds).type());
+        assertThat(upperBounds).hasSize(1);
+        assertThat(CollectionUtilities.first(upperBounds).type()).isSameAs(Object.class);
     }
 
     @SuppressWarnings("unused") // Used by testGenericTypeWithWildcardUsesUpperbounds
     private final List<?> genericType = new ArrayList<>();
 
     @Test
-    void testParameterizableTypeCanBeIntrospected() {
+    void parameterizableTypeCanBeIntrospected() {
         ParameterizableType argumentType = ParameterizableType.create(String.class);
         ParameterizableType collectionType = ParameterizableType.builder(List.class)
             .parameters(argumentType)
             .build();
 
         TypeView<?> typeView = this.introspector().introspect(collectionType);
-        Assertions.assertTrue(typeView.is(List.class));
-        Assertions.assertEquals(1, typeView.typeParameters().allInput().count());
+        assertThat(typeView.is(List.class)).isTrue();
+        assertThat(typeView.typeParameters().allInput().count()).isOne();
 
         TypeParameterView typeParameterView = typeView.typeParameters().atIndex(0)
             .orElseGet(Assertions::fail);
@@ -582,6 +587,6 @@ public abstract class IntrospectorTests {
         TypeView<?> argumentView = typeParameterView.resolvedType()
             .orElseGet(Assertions::fail);
 
-        Assertions.assertTrue(argumentView.is(String.class));
+        assertThat(argumentView.is(String.class)).isTrue();
     }
 }

--- a/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/TypeIntrospectionTests.java
+++ b/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/TypeIntrospectionTests.java
@@ -24,7 +24,6 @@ import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -38,6 +37,10 @@ import test.org.dockbox.hartshorn.util.introspect.support.typeparameters.Interfa
 
 import java.lang.annotation.Annotation;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 /**
  * Tests to verify {@link Introspector} implementations correctly expose basic type information.
@@ -103,312 +106,278 @@ public abstract class TypeIntrospectionTests {
     protected abstract Introspector introspector();
 
     @Test
-    void testTypesAreCached() {
+    void typesAreCached() {
         TypeView<TypeIntrospectionTests> tc1 = this.introspector()
                 .introspect(TypeIntrospectionTests.class);
         TypeView<TypeIntrospectionTests> tc2 = this.introspector()
                 .introspect(TypeIntrospectionTests.class);
-        Assertions.assertSame(tc1, tc2);
+        assertThat(tc2).isSameAs(tc1);
     }
 
     @Test
-    void testCachedItemsAreNotReusedForDifferentTypes() {
+    void cachedItemsAreNotReusedForDifferentTypes() {
         TypeView<TypeIntrospectionTests> tc1 = this.introspector()
                 .introspect(TypeIntrospectionTests.class);
         TypeView<Object> tc2 = this.introspector().introspect(Object.class);
-        Assertions.assertNotSame(tc1, tc2);
+        assertThat(tc2).isNotSameAs(tc1);
     }
 
     @ParameterizedTest
     @MethodSource("primitives")
-    public void testIsPrimitiveAcceptsPrimitives(Class<?> primitive) {
-        Assertions.assertTrue(this.introspector()
-                .introspect(primitive)
-                .isPrimitive()
-        );
+    public void isPrimitiveAcceptsPrimitives(Class<?> primitive) {
+        assertThat(this.introspector()
+            .introspect(primitive)
+            .isPrimitive()).isTrue();
     }
 
     @ParameterizedTest
     @MethodSource("wrappers")
-    public void testIsPrimitiveRejectsPrimitiveWrappers(Class<?> wrapper) {
-        Assertions.assertFalse(this.introspector()
-                .introspect(wrapper)
-                .isPrimitive()
-        );
+    public void isPrimitiveRejectsPrimitiveWrappers(Class<?> wrapper) {
+        assertThat(this.introspector()
+            .introspect(wrapper)
+            .isPrimitive()).isFalse();
     }
 
     @Test
-    public void testIsVoidAcceptsPrimitiveAndWrapper() {
-        Assertions.assertTrue(this.introspector()
-                .introspect(void.class)
-                .isVoid()
-        );
-        Assertions.assertTrue(this.introspector()
-                .introspect(Void.class)
-                .isVoid()
-        );
+    public void isVoidAcceptsPrimitiveAndWrapper() {
+        assertThat(this.introspector()
+            .introspect(void.class)
+            .isVoid()).isTrue();
+        assertThat(this.introspector()
+            .introspect(Void.class)
+            .isVoid()).isTrue();
     }
 
     @Test
-    public void testIsVoidRejectsNonPrimitiveAndNonWrapper() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(String.class)
-                .isVoid()
-        );
-        Assertions.assertFalse(this.introspector()
-                .introspect(Object.class)
-                .isVoid()
-        );
+    public void isVoidRejectsNonPrimitiveAndNonWrapper() {
+        assertThat(this.introspector()
+            .introspect(String.class)
+            .isVoid()).isFalse();
+        assertThat(this.introspector()
+            .introspect(Object.class)
+            .isVoid()).isFalse();
     }
 
     @Test
-    public void testIsPrimitiveRejectsNonPrimitiveAndNonWrapper() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(String.class)
-                .isPrimitive()
-        );
-        Assertions.assertFalse(this.introspector()
-                .introspect(Object.class)
-                .isPrimitive()
-        );
+    public void isPrimitiveRejectsNonPrimitiveAndNonWrapper() {
+        assertThat(this.introspector()
+            .introspect(String.class)
+            .isPrimitive()).isFalse();
+        assertThat(this.introspector()
+            .introspect(Object.class)
+            .isPrimitive()).isFalse();
     }
 
     @Test
-    public void testIsPrimitiveRejectsVoidWrapper() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Void.class)
-                .isPrimitive()
-        );
+    public void isPrimitiveRejectsVoidWrapper() {
+        assertThat(this.introspector()
+            .introspect(Void.class)
+            .isPrimitive()).isFalse();
     }
 
     @Test
-    public void testIsPrimitiveAcceptsVoidPrimitive() {
-        Assertions.assertTrue(this.introspector()
-                .introspect(void.class)
-                .isPrimitive()
-        );
+    public void isPrimitiveAcceptsVoidPrimitive() {
+        assertThat(this.introspector()
+            .introspect(void.class)
+            .isPrimitive()).isTrue();
     }
 
     @Test
-    public void testAnonymousTypesAreAnonymous() {
+    public void anonymousTypesAreAnonymous() {
         TypeView<Object> anonymous = this.introspector().introspect(new Object() {
         });
-        Assertions.assertTrue(anonymous.isAnonymous());
+        assertThat(anonymous.isAnonymous()).isTrue();
     }
 
     @Test
-    public void testNonAnonymousTypesAreNotAnonymous() {
+    public void nonAnonymousTypesAreNotAnonymous() {
         TypeView<Object> anonymous = this.introspector().introspect(Object.class);
-        Assertions.assertFalse(anonymous.isAnonymous());
+        assertThat(anonymous.isAnonymous()).isFalse();
     }
 
     @Test
-    void testAnonymousWrappersReturnCorrectType() {
+    void anonymousWrappersReturnCorrectType() {
         TypeView<Object> anonymous = this.introspector().introspect(new Object() {
         });
-        Assertions.assertNotEquals(Object.class, anonymous.type());
+        assertThat(anonymous.type()).isNotEqualTo(Object.class);
     }
 
     @Test
-    public void testEnumsAreEnum() {
-        Assertions.assertTrue(this.introspector()
-                .introspect(TestEnumType.class)
-                .isEnum()
-        );
+    public void enumsAreEnum() {
+        assertThat(this.introspector()
+            .introspect(TestEnumType.class)
+            .isEnum()).isTrue();
     }
 
     @Test
-    public void testNonEnumsAreNotEnum() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Object.class)
-                .isEnum()
-        );
+    public void nonEnumsAreNotEnum() {
+        assertThat(this.introspector()
+            .introspect(Object.class)
+            .isEnum()).isFalse();
     }
 
     @Test
-    public void testEnumsAreNotAnonymous() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(TestEnumType.class)
-                .isAnonymous()
-        );
+    public void enumsAreNotAnonymous() {
+        assertThat(this.introspector()
+            .introspect(TestEnumType.class)
+            .isAnonymous()).isFalse();
     }
 
     @Test
     public void enumConstantsCanBeObtained() {
         TypeView<TestEnumType> enumContext = this.introspector().introspect(TestEnumType.class);
-        Assertions.assertEquals(TestEnumType.values().length, enumContext.enumConstants().size());
+        assertThat(enumContext.enumConstants()).hasSameSizeAs(TestEnumType.values());
     }
 
     @Test
-    public void testAnnotationsAreAnnotations() {
-        Assertions.assertTrue(this.introspector()
-                .introspect(TypeOnlyAnnotation.class)
-                .isAnnotation()
-        );
+    public void annotationsAreAnnotations() {
+        assertThat(this.introspector()
+            .introspect(TypeOnlyAnnotation.class)
+            .isAnnotation()).isTrue();
     }
 
     @Test
-    public void testNonAnnotationsAreNotAnnotations() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Object.class)
-                .isAnnotation()
-        );
+    public void nonAnnotationsAreNotAnnotations() {
+        assertThat(this.introspector()
+            .introspect(Object.class)
+            .isAnnotation()).isFalse();
     }
 
     @Test
-    public void testAnnotationsAreNotAnonymous() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Annotation.class)
-                .isAnonymous()
-        );
+    public void annotationsAreNotAnonymous() {
+        assertThat(this.introspector()
+            .introspect(Annotation.class)
+            .isAnonymous()).isFalse();
     }
 
     @Test
-    public void testAnnotationsAreNotEnum() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Annotation.class)
-                .isEnum()
-        );
+    public void annotationsAreNotEnum() {
+        assertThat(this.introspector()
+            .introspect(Annotation.class)
+            .isEnum()).isFalse();
     }
 
     @Test
-    public void testAnnotationsAreNotPrimitive() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Annotation.class)
-                .isPrimitive()
-        );
+    public void annotationsAreNotPrimitive() {
+        assertThat(this.introspector()
+            .introspect(Annotation.class)
+            .isPrimitive()).isFalse();
     }
 
     @Test
-    public void testAnnotationsAreNotVoid() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Annotation.class)
-                .isVoid()
-        );
+    public void annotationsAreNotVoid() {
+        assertThat(this.introspector()
+            .introspect(Annotation.class)
+            .isVoid()).isFalse();
     }
 
     @Test
-    public void testAnnotationsAreNotArray() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Annotation.class)
-                .isArray()
-        );
+    public void annotationsAreNotArray() {
+        assertThat(this.introspector()
+            .introspect(Annotation.class)
+            .isArray()).isFalse();
     }
 
     @Test
-    void testArraysAreArrays() {
-        Assertions.assertTrue(this.introspector()
-                .introspect(Object[].class)
-                .isArray()
-        );
+    void arraysAreArrays() {
+        assertThat(this.introspector()
+            .introspect(Object[].class)
+            .isArray()).isTrue();
     }
 
     @Test
-    void testArraysAreNotAnonymous() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Object[].class)
-                .isAnonymous()
-        );
+    void arraysAreNotAnonymous() {
+        assertThat(this.introspector()
+            .introspect(Object[].class)
+            .isAnonymous()).isFalse();
     }
 
     @Test
-    void testArraysAreNotEnum() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Object[].class)
-                .isEnum()
-        );
+    void arraysAreNotEnum() {
+        assertThat(this.introspector()
+            .introspect(Object[].class)
+            .isEnum()).isFalse();
     }
 
     @Test
-    void testArraysAreNotPrimitive() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Object[].class)
-                .isPrimitive()
-        );
+    void arraysAreNotPrimitive() {
+        assertThat(this.introspector()
+            .introspect(Object[].class)
+            .isPrimitive()).isFalse();
     }
 
     @Test
-    void testArraysAreNotVoid() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Object[].class)
-                .isVoid()
-        );
+    void arraysAreNotVoid() {
+        assertThat(this.introspector()
+            .introspect(Object[].class)
+            .isVoid()).isFalse();
     }
 
     @Test
-    void testArraysAreNotAnnotation() {
-        Assertions.assertFalse(this.introspector()
-                .introspect(Object[].class)
-                .isAnnotation()
-        );
+    void arraysAreNotAnnotation() {
+        assertThat(this.introspector()
+            .introspect(Object[].class)
+            .isAnnotation()).isFalse();
     }
 
     @ParameterizedTest
     @MethodSource("primitiveDefaults")
-    void testPrimitiveDefaults(Class<?> primitive, Object defaultValue) {
-        Assertions.assertEquals(defaultValue, this.introspector()
-                .introspect(primitive)
-                .defaultOrNull()
-        );
+    void primitiveDefaults(Class<?> primitive, Object defaultValue) {
+        assertThat(this.introspector()
+            .introspect(primitive)
+            .defaultOrNull()).isEqualTo(defaultValue);
     }
 
     @Test
-    void testObjectDefaultsToNull() {
-        Assertions.assertNull(this.introspector()
-                .introspect(Object.class)
-                .defaultOrNull()
-        );
+    void objectDefaultsToNull() {
+        assertThat(this.introspector()
+            .introspect(Object.class)
+            .defaultOrNull()).isNull();
     }
 
     @Test
-    void testAnnotationDefaultsToNull() {
-        Assertions.assertNull(this.introspector()
-                .introspect(TypeOnlyAnnotation.class)
-                .defaultOrNull()
-        );
+    void annotationDefaultsToNull() {
+        assertThat(this.introspector()
+            .introspect(TypeOnlyAnnotation.class)
+            .defaultOrNull()).isNull();
     }
 
     @Test
-    void testEnumDefaultsToNull() {
-        Assertions.assertNull(this.introspector()
-                .introspect(TestEnumType.class)
-                .defaultOrNull()
-        );
+    void enumDefaultsToNull() {
+        assertThat(this.introspector()
+            .introspect(TestEnumType.class)
+            .defaultOrNull()).isNull();
     }
 
     @Test
-    void testArrayDefaultsToNull() {
-        Assertions.assertNull(this.introspector()
-                .introspect(Object[].class)
-                .defaultOrNull()
-        );
+    void arrayDefaultsToNull() {
+        assertThat(this.introspector()
+            .introspect(Object[].class)
+            .defaultOrNull()).isNull();
     }
 
     @ParameterizedTest
     @MethodSource("wrapperDefaults")
-    void testWrapperDefaults(Class<?> wrapper, Object defaultValue) {
-        Assertions.assertEquals(defaultValue, this.introspector()
-                .introspect(wrapper)
-                .defaultOrNull()
+    void wrapperDefaults(Class<?> wrapper, Object defaultValue) {
+        assertThat(this.introspector()
+            .introspect(wrapper)
+            .defaultOrNull()).isEqualTo(defaultValue);
+    }
+
+    @Test
+    void interfacesAreObtainable() {
+        assertThat(this.introspector()
+            .introspect(ImplementationWithTypeParameter.class)
+            .interfaces()).hasSize(1);
+        assertThat(this.introspector()
+            .introspect(ImplementationWithTypeParameter.class)
+            .interfaces()).first().isEqualTo(this.introspector()
+                .introspect(InterfaceWithTypeParameter.class)
         );
     }
 
     @Test
-    void testInterfacesAreObtainable() {
-        Assertions.assertEquals(1, this.introspector()
-                .introspect(ImplementationWithTypeParameter.class)
-                .interfaces()
-                .size()
-        );
-        Assertions.assertEquals(
-                this.introspector().introspect(InterfaceWithTypeParameter.class),
-                this.introspector().introspect(ImplementationWithTypeParameter.class)
-                        .interfaces().getFirst()
-        );
-    }
-
-    @Test
-    void testTypeParametersWithoutSourceAreFromSuperclass() {
+    void typeParametersWithoutSourceAreFromSuperclass() {
         TypeView<ImplementationWithTypeParameter> type = this.introspector()
                 .introspect(ImplementationWithTypeParameter.class);
         assertTypeParameterForType(type, AbstractTypeWithTypeParameter.class, Integer.class);
@@ -421,81 +390,81 @@ public abstract class TypeIntrospectionTests {
             Class<?> expectedClass
     ) {
         TypeParameterList typeParameters = type.typeParameters().outputFor(forClass);
-        Assertions.assertEquals(1, typeParameters.count());
+        assertThat(typeParameters.count()).isOne();
 
         TypeParameterView typeParameterView = typeParameters.atIndex(0).get();
         Option<TypeView<?>> upperBound = typeParameterView.resolvedType();
-        Assertions.assertTrue(upperBound.present());
-        Assertions.assertSame(expectedClass, upperBound.get().type());
+        assertThat(upperBound.present()).isTrue();
+        assertThat(upperBound.get().type()).isSameAs(expectedClass);
     }
 
     @Test
-    void testAnnotatedTypeHasAnnotations() {
+    void annotatedTypeHasAnnotations() {
         TypeView<AnnotatedElement> type = this.introspector().introspect(AnnotatedElement.class);
-        Assertions.assertEquals(1, type.annotations().count());
-        Assertions.assertSame(
-                TypeOnlyAnnotation.class,
-                CollectionUtilities.first(type.annotations().all()).annotationType()
-        );
+        assertThat(type.annotations().count()).isOne();
+        assertThat(CollectionUtilities.first(type.annotations().all()).annotationType())
+                .isSameAs(TypeOnlyAnnotation.class);
     }
 
     @Test
-    void testAnnotatedTypeCanGetAnnotationFromAnnotation() {
-        Assertions.assertTrue(this.introspector().introspect(AnnotatedElement.class)
-                .annotations()
-                .has(TypeOnlyAnnotation.class));
+    void annotatedTypeCanGetAnnotationFromAnnotation() {
+        assertThat(this.introspector().introspect(AnnotatedElement.class)
+            .annotations()
+            .has(TypeOnlyAnnotation.class)).isTrue();
     }
 
     @Test
-    void testTypeViewCanReflect() {
-        Assertions.assertDoesNotThrow(() -> this.introspector().introspect(TypeView.class));
+    void typeViewCanReflect() {
+        assertThatCode(() -> this.introspector().introspect(TypeView.class))
+                .doesNotThrowAnyException();
     }
 
     @Test
-    void testStaticMethodCanInvokeStatic() throws Throwable {
+    void staticMethodCanInvokeStatic() throws Throwable {
         Option<MethodView<TypeIntrospectionTests, ?>> test = this.introspector().introspect(this)
                 .methods()
                 .named("testStatic");
-        Assertions.assertTrue(test.present());
+        assertThat(test.present()).isTrue();
         MethodView<TypeIntrospectionTests, ?> methodContext = test.get();
-        Assertions.assertTrue(methodContext.modifiers().isStatic());
+        assertThat(methodContext.modifiers().isStatic()).isTrue();
         Option<?> result = methodContext.invokeStatic();
         // Void methods return empty option
-        Assertions.assertTrue(result.absent());
+        assertThat(result.absent()).isTrue();
     }
 
     public static void testStatic() {
     }
 
     @Test
-    void testNonStaticMethodCannotInvokeStatic() {
+    void nonStaticMethodCannotInvokeStatic() {
         Option<MethodView<TypeIntrospectionTests, ?>> test = this.introspector().introspect(this)
                 .methods()
                 .named("testNonStatic");
-        Assertions.assertTrue(test.present());
+        assertThat(test.present()).isTrue();
         MethodView<TypeIntrospectionTests, ?> methodContext = test.get();
-        Assertions.assertFalse(methodContext.modifiers().isStatic());
-        Assertions.assertThrows(IllegalIntrospectionException.class, methodContext::invokeStatic);
+        assertThat(methodContext.modifiers().isStatic()).isFalse();
+        assertThatExceptionOfType(IllegalIntrospectionException.class)
+                .isThrownBy(methodContext::invokeStatic);
     }
 
     public void testNonStatic() {
     }
 
     @Test
-    void testMethodOnTypeLookupCanResolveWithChangedReturnType() {
+    void methodOnTypeLookupCanResolveWithChangedReturnType() {
         Option<MethodView<TypeWithOverrideMethodDeclaration, ?>> method = this.introspector()
                 .introspect(TypeWithOverrideMethodDeclaration.class)
                 .methods()
                 .named("methodWithArguments", String.class, Integer.class);
-        Assertions.assertTrue(method.present());
+        assertThat(method.present()).isTrue();
 
         MethodView<TypeWithOverrideMethodDeclaration, ?> methodView = method.get();
         Option<MethodView<TypeWithMethodDeclaration, ?>> onParent = methodView
                 .onType(TypeWithMethodDeclaration.class);
-        Assertions.assertTrue(onParent.present());
+        assertThat(onParent.present()).isTrue();
 
         MethodView<TypeWithMethodDeclaration, ?> parentMethodView = onParent.get();
-        Assertions.assertEquals(Number.class, parentMethodView.returnType().type());
+        assertThat(parentMethodView.returnType().type()).isEqualTo(Number.class);
     }
 
     static class TypeWithMethodDeclaration {

--- a/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/TypeParameterIntrospectionTests.java
+++ b/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/TypeParameterIntrospectionTests.java
@@ -25,7 +25,6 @@ import org.dockbox.hartshorn.util.introspect.TypeParametersIntrospector;
 import org.dockbox.hartshorn.util.introspect.view.TypeParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
@@ -36,6 +35,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for introspecting type parameters.
@@ -59,19 +60,19 @@ public abstract class TypeParameterIntrospectionTests {
     }
 
     @Test
-    public void testVariableGenericTypeWithSingleUpperbound() {
+    public void variableGenericTypeWithSingleUpperbound() {
         TypeView<TypeWithSingleTypeBound> typeView =
             this.introspector().introspect(TypeWithSingleTypeBound.class);
-        Assertions.assertSame(TypeWithSingleTypeBound.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(TypeWithSingleTypeBound.class);
 
         this.testVariableWithExpectedBounds(typeView, Number.class);
     }
 
     @Test
-    public void testVariableGenericTypeWithMultipleUpperbound() {
+    public void variableGenericTypeWithMultipleUpperbound() {
         TypeView<TypeWithMultipleTypeBounds> typeView =
             this.introspector().introspect(TypeWithMultipleTypeBounds.class);
-        Assertions.assertSame(TypeWithMultipleTypeBounds.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(TypeWithMultipleTypeBounds.class);
 
         this.testVariableWithExpectedBounds(typeView,
             Number.class,
@@ -80,27 +81,27 @@ public abstract class TypeParameterIntrospectionTests {
     }
 
     @Test
-    void testVariableGenericTypeWithoutExplicitUpperbounds() {
+    void variableGenericTypeWithoutExplicitUpperbounds() {
         TypeView<TypeWithoutTypeBounds> typeView =
             this.introspector().introspect(TypeWithoutTypeBounds.class);
-        Assertions.assertSame(TypeWithoutTypeBounds.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(TypeWithoutTypeBounds.class);
 
         this.testVariableWithExpectedBounds(typeView, Object.class);
     }
 
     private void testVariableWithExpectedBounds(TypeView<?> type, Class<?>... expectedBounds) {
         List<TypeParameterView> inputTypes = type.typeParameters().allInput().asList();
-        Assertions.assertEquals(1, inputTypes.size());
+        assertThat(inputTypes).hasSize(1);
 
         TypeParameterView parameterView = inputTypes.get(0);
-        Assertions.assertTrue(parameterView.isBounded());
-        Assertions.assertTrue(parameterView.isVariable());
+        assertThat(parameterView.isBounded()).isTrue();
+        assertThat(parameterView.isVariable()).isTrue();
 
         Set<TypeView<?>> upperBounds = parameterView.upperBounds();
-        Assertions.assertEquals(expectedBounds.length, upperBounds.size());
+        assertThat(upperBounds).hasSameSizeAs(expectedBounds);
         for (Class<?> expectedBound : expectedBounds) {
-            Assertions.assertTrue(upperBounds.stream()
-                .anyMatch(typeView -> typeView.type().equals(expectedBound)));
+            assertThat(upperBounds.stream()
+                .anyMatch(typeView -> typeView.type().equals(expectedBound))).isTrue();
         }
     }
 
@@ -111,58 +112,58 @@ public abstract class TypeParameterIntrospectionTests {
     }
 
     @Test
-    void testOutputParameterWithConcreteValue() {
+    void outputParameterWithConcreteValue() {
         TypeView<IntegerPredicate> typeView =
             this.introspector().introspect(IntegerPredicate.class);
-        Assertions.assertSame(IntegerPredicate.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(IntegerPredicate.class);
 
         List<TypeParameterView> outputTypes = typeView.typeParameters().allOutput().asList();
-        Assertions.assertEquals(1, outputTypes.size());
+        assertThat(outputTypes).hasSize(1);
 
         TypeParameterView parameterView = outputTypes.get(0);
-        Assertions.assertFalse(parameterView.isVariable());
+        assertThat(parameterView.isVariable()).isFalse();
 
         TypeView<?> resolvedType = parameterView.resolvedType().get();
-        Assertions.assertSame(Integer.class, resolvedType.type());
+        assertThat(resolvedType.type()).isSameAs(Integer.class);
     }
 
     @Test
-    void testOutputParameterWithVariableValue() {
+    void outputParameterWithVariableValue() {
         TypeView<NumberPredicate> typeView = this.introspector().introspect(NumberPredicate.class);
-        Assertions.assertSame(NumberPredicate.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(NumberPredicate.class);
 
         List<TypeParameterView> outputTypes = typeView.typeParameters().allOutput().asList();
-        Assertions.assertEquals(1, outputTypes.size());
+        assertThat(outputTypes).hasSize(1);
 
         TypeParameterView parameterView = outputTypes.get(0);
-        Assertions.assertTrue(parameterView.isVariable());
-        Assertions.assertTrue(parameterView.resolvedType().absent());
-        Assertions.assertTrue(parameterView.isBounded());
+        assertThat(parameterView.isVariable()).isTrue();
+        assertThat(parameterView.resolvedType().absent()).isTrue();
+        assertThat(parameterView.isBounded()).isTrue();
 
         Set<TypeView<?>> upperBounds = parameterView.upperBounds();
-        Assertions.assertEquals(1, upperBounds.size());
-        Assertions.assertSame(Number.class, CollectionUtilities.first(upperBounds).type());
+        assertThat(upperBounds).hasSize(1);
+        assertThat(CollectionUtilities.first(upperBounds).type()).isSameAs(Number.class);
     }
 
     @Test
-    void testInputRepresentingOutputVariable() {
+    void inputRepresentingOutputVariable() {
         TypeView<NumberPredicate> typeView = this.introspector().introspect(NumberPredicate.class);
-        Assertions.assertSame(NumberPredicate.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(NumberPredicate.class);
 
         List<TypeParameterView> inputTypes = typeView.typeParameters().allInput().asList();
-        Assertions.assertEquals(1, inputTypes.size());
+        assertThat(inputTypes).hasSize(1);
 
         TypeParameterView parameterView = inputTypes.get(0);
-        Assertions.assertTrue(parameterView.isVariable());
-        Assertions.assertTrue(parameterView.resolvedType().absent());
-        Assertions.assertTrue(parameterView.isBounded());
+        assertThat(parameterView.isVariable()).isTrue();
+        assertThat(parameterView.resolvedType().absent()).isTrue();
+        assertThat(parameterView.isBounded()).isTrue();
 
         Set<TypeParameterView> represents = parameterView.represents();
-        Assertions.assertEquals(1, represents.size());
+        assertThat(represents).hasSize(1);
 
         TypeParameterView representing = CollectionUtilities.first(represents);
-        Assertions.assertTrue(representing.isVariable());
-        Assertions.assertSame(Predicate.class, representing.consumedBy().type());
+        assertThat(representing.isVariable()).isTrue();
+        assertThat(representing.consumedBy().type()).isSameAs(Predicate.class);
     }
 
     private interface NumberFunctionAndPredicate<U extends Number>
@@ -170,84 +171,85 @@ public abstract class TypeParameterIntrospectionTests {
     }
 
     @Test
-    void testInputRepresentingMultipleOutputVariables() {
+    void inputRepresentingMultipleOutputVariables() {
         TypeView<NumberFunctionAndPredicate> typeView =
             this.introspector().introspect(NumberFunctionAndPredicate.class);
-        Assertions.assertSame(NumberFunctionAndPredicate.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(NumberFunctionAndPredicate.class);
 
         List<TypeParameterView> inputTypes = typeView.typeParameters().allInput().asList();
-        Assertions.assertEquals(1, inputTypes.size());
+        assertThat(inputTypes).hasSize(1);
 
         TypeParameterView parameterView = inputTypes.get(0);
-        Assertions.assertTrue(parameterView.isVariable());
-        Assertions.assertTrue(parameterView.resolvedType().absent());
-        Assertions.assertTrue(parameterView.isBounded());
+        assertThat(parameterView.isVariable()).isTrue();
+        assertThat(parameterView.resolvedType().absent()).isTrue();
+        assertThat(parameterView.isBounded()).isTrue();
 
         Set<TypeParameterView> represents = parameterView.represents();
-        Assertions.assertEquals(3, represents.size());
+        assertThat(represents).hasSize(3);
 
         Map<Class<?>, List<TypeParameterView>> representationsByType = represents.stream()
             .collect(Collectors.groupingBy(typeParameterView -> typeParameterView.consumedBy()
                 .type()));
-        Assertions.assertTrue(representationsByType.containsKey(Function.class));
-        Assertions.assertTrue(representationsByType.containsKey(Predicate.class));
+        assertThat(representationsByType)
+                .containsKey(Function.class)
+                .containsKey(Predicate.class);
 
         List<TypeParameterView> functionRepresentations = representationsByType.get(Function.class);
-        Assertions.assertEquals(2, functionRepresentations.size());
-        Assertions.assertTrue(functionRepresentations.stream()
-            .allMatch(TypeParameterView::isVariable));
+        assertThat(functionRepresentations).hasSize(2);
+        assertThat(functionRepresentations.stream()
+            .allMatch(TypeParameterView::isVariable)).isTrue();
 
         List<TypeParameterView> predicateRepresentations =
             representationsByType.get(Predicate.class);
-        Assertions.assertEquals(1, predicateRepresentations.size());
+        assertThat(predicateRepresentations).hasSize(1);
     }
 
     @Test
-    void testOutputToInputReferencesCorrectDeclarations() {
+    void outputToInputReferencesCorrectDeclarations() {
         TypeView<NumberPredicate> typeView = this.introspector().introspect(NumberPredicate.class);
-        Assertions.assertSame(NumberPredicate.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(NumberPredicate.class);
 
         List<TypeParameterView> outputParameters = typeView.typeParameters().allOutput().asList();
-        Assertions.assertEquals(1, outputParameters.size());
+        assertThat(outputParameters).hasSize(1);
 
         TypeParameterView outputParameter = outputParameters.get(0);
-        Assertions.assertTrue(outputParameter.isVariable());
-        Assertions.assertSame(NumberPredicate.class, outputParameter.declaredBy().type());
-        Assertions.assertEquals("U", outputParameter.name());
+        assertThat(outputParameter.isVariable()).isTrue();
+        assertThat(outputParameter.declaredBy().type()).isSameAs(NumberPredicate.class);
+        assertThat(outputParameter.name()).isEqualTo("U");
 
         TypeParameterView inputParameter = outputParameter.asInputParameter();
-        Assertions.assertTrue(inputParameter.isVariable());
-        Assertions.assertSame(Predicate.class, inputParameter.declaredBy().type());
-        Assertions.assertEquals("T", inputParameter.name());
+        assertThat(inputParameter.isVariable()).isTrue();
+        assertThat(inputParameter.declaredBy().type()).isSameAs(Predicate.class);
+        assertThat(inputParameter.name()).isEqualTo("T");
     }
 
     @Test
-    void testInputToInputReturnsSelf() {
+    void inputToInputReturnsSelf() {
         TypeView<NumberPredicate> typeView = this.introspector().introspect(NumberPredicate.class);
-        Assertions.assertSame(NumberPredicate.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(NumberPredicate.class);
 
         List<TypeParameterView> inputParameters = typeView.typeParameters().allInput().asList();
-        Assertions.assertEquals(1, inputParameters.size());
+        assertThat(inputParameters).hasSize(1);
 
         TypeParameterView inputParameter = inputParameters.get(0);
-        Assertions.assertTrue(inputParameter.isVariable());
-        Assertions.assertSame(NumberPredicate.class, inputParameter.declaredBy().type());
-        Assertions.assertEquals("U", inputParameter.name());
+        assertThat(inputParameter.isVariable()).isTrue();
+        assertThat(inputParameter.declaredBy().type()).isSameAs(NumberPredicate.class);
+        assertThat(inputParameter.name()).isEqualTo("U");
 
         TypeParameterView asInputParameter = inputParameter.asInputParameter();
-        Assertions.assertSame(inputParameter, asInputParameter);
+        assertThat(asInputParameter).isSameAs(inputParameter);
     }
 
     private interface XYtoYXFunction<X, Y> extends Function<Y, X> {
     }
 
     @Test
-    void testInputToOutputCorrectlyUpdatesIndex() {
+    void inputToOutputCorrectlyUpdatesIndex() {
         TypeView<XYtoYXFunction> typeView = this.introspector().introspect(XYtoYXFunction.class);
-        Assertions.assertSame(XYtoYXFunction.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(XYtoYXFunction.class);
 
         List<TypeParameterView> inputParameters = typeView.typeParameters().allInput().asList();
-        Assertions.assertEquals(2, inputParameters.size());
+        assertThat(inputParameters).hasSize(2);
 
         assertParameterAtIndexReferencesParameterAtIndex(typeView, 0, 1);
         assertParameterAtIndexReferencesParameterAtIndex(typeView, 1, 0);
@@ -259,133 +261,133 @@ public abstract class TypeParameterIntrospectionTests {
         int outputIndex
     ) {
         Option<TypeParameterView> parameter = typeView.typeParameters().atIndex(inputIndex);
-        Assertions.assertTrue(parameter.present());
+        assertThat(parameter.present()).isTrue();
         TypeParameterView parameterView = parameter.get();
-        Assertions.assertEquals(inputIndex, parameterView.index());
+        assertThat(parameterView.index()).isEqualTo(inputIndex);
 
         Set<TypeParameterView> parameterRepresents = parameterView.represents();
-        Assertions.assertEquals(1, parameterRepresents.size());
+        assertThat(parameterRepresents).hasSize(1);
 
         TypeParameterView parameterRepresentsView = CollectionUtilities.first(parameterRepresents);
-        Assertions.assertEquals(outputIndex, parameterRepresentsView.index());
+        assertThat(parameterRepresentsView.index()).isEqualTo(outputIndex);
     }
 
     @Test
-    void testInputIsInput() {
+    void inputIsInput() {
         TypeView<NumberPredicate> typeView = this.introspector().introspect(NumberPredicate.class);
-        Assertions.assertSame(NumberPredicate.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(NumberPredicate.class);
 
         List<TypeParameterView> inputParameters = typeView.typeParameters().allInput().asList();
-        Assertions.assertEquals(1, inputParameters.size());
+        assertThat(inputParameters).hasSize(1);
 
         TypeParameterView inputParameter = inputParameters.get(0);
-        Assertions.assertTrue(inputParameter.isInputParameter());
-        Assertions.assertFalse(inputParameter.isOutputParameter());
+        assertThat(inputParameter.isInputParameter()).isTrue();
+        assertThat(inputParameter.isOutputParameter()).isFalse();
     }
 
     @Test
-    void testOutputIsOutput() {
+    void outputIsOutput() {
         TypeView<NumberPredicate> typeView = this.introspector().introspect(NumberPredicate.class);
-        Assertions.assertSame(NumberPredicate.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(NumberPredicate.class);
 
         List<TypeParameterView> outputParameters = typeView.typeParameters().allOutput().asList();
-        Assertions.assertEquals(1, outputParameters.size());
+        assertThat(outputParameters).hasSize(1);
 
         TypeParameterView outputParameter = outputParameters.get(0);
-        Assertions.assertTrue(outputParameter.isOutputParameter());
-        Assertions.assertFalse(outputParameter.isInputParameter());
+        assertThat(outputParameter.isOutputParameter()).isTrue();
+        assertThat(outputParameter.isInputParameter()).isFalse();
     }
 
     @Test
-    void testResolveForSelfWithExplicitParameters() {
+    void resolveForSelfWithExplicitParameters() {
         TypeView<Collection<String>> typeView = this.introspector().introspect(new GenericType<>() {
         });
-        Assertions.assertSame(Collection.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(Collection.class);
 
         TypeParametersIntrospector typeParameters = typeView.typeParameters();
         List<TypeParameterView> collectionParameters =
             typeParameters.inputFor(Collection.class).asList();
-        Assertions.assertEquals(1, collectionParameters.size());
+        assertThat(collectionParameters).hasSize(1);
 
         TypeParameterView collectionParameter = collectionParameters.get(0);
-        Assertions.assertFalse(collectionParameter.isVariable()); // Should not be 'E'
-        Assertions.assertSame(String.class, collectionParameter.resolvedType().get().type());
+        assertThat(collectionParameter.isVariable()).isFalse(); // Should not be 'E'
+        assertThat(collectionParameter.resolvedType().get().type()).isSameAs(String.class);
     }
 
     @Test
-    void testResolveForDirectParentWithExplicitParameters() {
+    void resolveForDirectParentWithExplicitParameters() {
         TypeView<Collection<String>> typeView = this.introspector().introspect(new GenericType<>() {
         });
-        Assertions.assertSame(Collection.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(Collection.class);
 
         TypeParametersIntrospector typeParameters = typeView.typeParameters();
         List<TypeParameterView> collectionParameters =
             typeParameters.inputFor(Iterable.class).asList();
-        Assertions.assertEquals(1, collectionParameters.size());
+        assertThat(collectionParameters).hasSize(1);
 
         TypeParameterView collectionParameter = collectionParameters.get(0);
-        Assertions.assertFalse(collectionParameter.isVariable()); // Should not be 'E'
-        Assertions.assertSame(String.class, collectionParameter.resolvedType().get().type());
+        assertThat(collectionParameter.isVariable()).isFalse(); // Should not be 'E'
+        assertThat(collectionParameter.resolvedType().get().type()).isSameAs(String.class);
     }
 
     @Test
-    void testResolveForIndirectParentWithExplicitParameters() {
+    void resolveForIndirectParentWithExplicitParameters() {
         TypeView<LinkedList<String>> typeView = this.introspector().introspect(new GenericType<>() {
         });
-        Assertions.assertSame(LinkedList.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(LinkedList.class);
 
         TypeParametersIntrospector typeParameters = typeView.typeParameters();
         List<TypeParameterView> collectionParameters =
             typeParameters.inputFor(Iterable.class).asList();
-        Assertions.assertEquals(1, collectionParameters.size());
+        assertThat(collectionParameters).hasSize(1);
 
         TypeParameterView collectionParameter = collectionParameters.get(0);
-        Assertions.assertFalse(collectionParameter.isVariable()); // Should not be 'E'
-        Assertions.assertSame(String.class, collectionParameter.resolvedType().get().type());
+        assertThat(collectionParameter.isVariable()).isFalse(); // Should not be 'E'
+        assertThat(collectionParameter.resolvedType().get().type()).isSameAs(String.class);
     }
 
     @Test
-    void testOutputAsMapResolvesAllToParent() {
+    void outputAsMapResolvesAllToParent() {
         TypeView<NumberFunctionAndPredicate> typeView =
             this.introspector().introspect(NumberFunctionAndPredicate.class);
-        Assertions.assertSame(NumberFunctionAndPredicate.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(NumberFunctionAndPredicate.class);
 
         TypeParametersIntrospector typeParameters = typeView.typeParameters();
         TypeParameterList outputParameters = typeParameters.allOutput();
         BiMultiMap<TypeParameterView, TypeParameterView> multiMap = outputParameters.asMap();
         // Should be 1:1 mappings, so the size should be the same
-        Assertions.assertEquals(outputParameters.count(), multiMap.size());
+        assertThat(multiMap.size()).isEqualTo(outputParameters.count());
 
         Set<TypeParameterView> keys = multiMap.keySet();
-        Assertions.assertEquals(outputParameters.count(), keys.size());
+        assertThat(keys).hasSize(outputParameters.count());
 
         Collection<TypeParameterView> values = multiMap.allValues();
         // Output parameters should only map to the input parameters of their target types
-        Assertions.assertEquals(outputParameters.count(), values.size());
+        assertThat(values).hasSize(outputParameters.count());
     }
 
     @Test
-    void testInputAsMapResolvesAllToOutput() {
+    void inputAsMapResolvesAllToOutput() {
         TypeView<NumberFunctionAndPredicate> typeView =
             this.introspector().introspect(NumberFunctionAndPredicate.class);
-        Assertions.assertSame(NumberFunctionAndPredicate.class, typeView.type());
+        assertThat(typeView.type()).isSameAs(NumberFunctionAndPredicate.class);
 
         TypeParametersIntrospector typeParameters = typeView.typeParameters();
         TypeParameterList inputParameters = typeParameters.allInput();
 
         BiMultiMap<TypeParameterView, TypeParameterView> multiMap = inputParameters.asMap();
         Set<TypeParameterView> keys = multiMap.keySet();
-        // Note: unlike output parameters, I -> O mappings are not 1:1, but are 1:n (where n is the
-        // number of output parameters), so the size of the map will be different, but the keys
-        // should be the same
-        Assertions.assertEquals(inputParameters.count(), keys.size());
-
-        Assertions.assertEquals(1, keys.size());
+        assertThat(keys)
+                // Note: unlike output parameters, I -> O mappings are not 1:1, but are 1:n (where
+                // n is the number of output parameters), so the size of the map will be different,
+                // but the keys should be the same
+                .hasSize(inputParameters.count())
+                .hasSize(1);
         Collection<TypeParameterView> values = multiMap.get(CollectionUtilities.first(keys));
         TypeParameterList outputParameters = typeParameters.allOutput();
-        Assertions.assertEquals(outputParameters.count(), values.size());
+        assertThat(values).hasSize(outputParameters.count());
 
         List<TypeParameterView> outputParametersList = outputParameters.asList();
-        Assertions.assertTrue(values.containsAll(outputParametersList));
+        assertThat(values).containsAll(outputParametersList);
     }
 }

--- a/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/support/basic/ConcreteTestType.java
+++ b/hartshorn-introspect-test-fixtures/src/main/java/test/org/dockbox/hartshorn/util/introspect/support/basic/ConcreteTestType.java
@@ -19,7 +19,8 @@ package test.org.dockbox.hartshorn.util.introspect.support.basic;
 import java.util.Locale;
 
 import org.dockbox.hartshorn.util.introspect.annotations.Property;
-import org.junit.jupiter.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import test.org.dockbox.hartshorn.util.introspect.support.annotations.MultipleElementAnnotation;
 
 /**
@@ -78,12 +79,12 @@ public class ConcreteTestType extends ParentTestType {
     }
 
     public String publicMethod(String argument) {
-        Assertions.assertEquals("value", argument);
+        assertThat(argument).isEqualTo("value");
         return argument.toUpperCase(Locale.ROOT);
     }
 
     public String privateMethod(String argument) {
-        Assertions.assertEquals("value", argument);
+        assertThat(argument).isEqualTo("value");
         return argument.toUpperCase(Locale.ROOT);
     }
 

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/AnnotationLookupTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/AnnotationLookupTests.java
@@ -18,14 +18,16 @@ package test.org.dockbox.hartshorn.introspect;
 
 import org.dockbox.hartshorn.util.introspect.annotations.AnnotationLookup;
 import org.dockbox.hartshorn.util.introspect.annotations.VirtualHierarchyAnnotationLookup;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import test.org.dockbox.hartshorn.introspect.annotations.Base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 import test.org.dockbox.hartshorn.introspect.annotations.HttpMethod;
 import test.org.dockbox.hartshorn.introspect.annotations.Intercept;
 import test.org.dockbox.hartshorn.introspect.annotations.InterceptType;
@@ -44,7 +46,7 @@ import test.org.dockbox.hartshorn.introspect.components.TestClassWithSameBaseTyp
 import test.org.dockbox.hartshorn.introspect.components.TestClassWithSocketJS;
 import test.org.dockbox.hartshorn.introspect.components.TestClassWithSub;
 
-public class AnnotationLookupTests {
+class AnnotationLookupTests {
 
     /**
      * Default implementation of {@link AnnotationLookup}, provided as a method to allow overriding
@@ -57,116 +59,86 @@ public class AnnotationLookupTests {
     }
 
     @Test
-    public void testBaseAnnotationOnSub() {
-        Assertions.assertEquals("Sub",
-            this.annotationLookup().find(TestClassWithSub.class, Base.class).value());
+    void baseAnnotationOnSub() {
+        assertThat(this.annotationLookup().find(TestClassWithSub.class, Base.class).value()).isEqualTo("Sub");
     }
 
     @Test
-    public void testBaseAnnotationOnBase() {
-        Assertions.assertEquals("Base",
-            this.annotationLookup().find(TestClassWithBase.class, Base.class).value());
+    void baseAnnotationOnBase() {
+        assertThat(this.annotationLookup().find(TestClassWithBase.class, Base.class).value()).isEqualTo("Base");
     }
 
     @Test
-    public void testBaseAnnotationOnMid() {
-        Assertions.assertEquals("Mid",
-            this.annotationLookup().find(TestClassWithMid.class, Base.class).value());
+    void baseAnnotationOnMid() {
+        assertThat(this.annotationLookup().find(TestClassWithMid.class, Base.class).value()).isEqualTo("Mid");
     }
 
     @Test
-    public void testRouteAnnotationOnRouteClass() {
-        Assertions.assertEquals(HttpMethod.POST,
-            this.annotationLookup().find(TestClassWithRoute.class, Route.class).method());
-        Assertions.assertEquals("test",
-            this.annotationLookup().find(TestClassWithRoute.class, Route.class).path());
+    void routeAnnotationOnRouteClass() {
+        assertThat(this.annotationLookup().find(TestClassWithRoute.class, Route.class).method()).isEqualTo(HttpMethod.POST);
+        assertThat(this.annotationLookup().find(TestClassWithRoute.class, Route.class).path()).isEqualTo("test");
     }
 
     @Test
-    public void testRouteAnnotationOnGetExtendedClass() {
-        Assertions.assertEquals(HttpMethod.GET,
-            this.annotationLookup().find(TestClassWithGet.class, Route.class).method());
-        Assertions.assertEquals("get",
-            this.annotationLookup().find(TestClassWithGet.class, Route.class).path());
+    void routeAnnotationOnGetExtendedClass() {
+        assertThat(this.annotationLookup().find(TestClassWithGet.class, Route.class).method()).isEqualTo(HttpMethod.GET);
+        assertThat(this.annotationLookup().find(TestClassWithGet.class, Route.class).path()).isEqualTo("get");
     }
 
     @Test
-    public void testRouteAnnotationOnPostExtendedClass() {
-        Assertions.assertEquals(HttpMethod.POST,
-            this.annotationLookup().find(TestClassWithPost.class, Route.class).method());
-        Assertions.assertEquals("post",
-            this.annotationLookup().find(TestClassWithPost.class, Route.class).path());
+    void routeAnnotationOnPostExtendedClass() {
+        assertThat(this.annotationLookup().find(TestClassWithPost.class, Route.class).method()).isEqualTo(HttpMethod.POST);
+        assertThat(this.annotationLookup().find(TestClassWithPost.class, Route.class).path()).isEqualTo("post");
     }
 
     @Test
-    public void testRouteAnnotationOnSocketExtendedClass() {
-        Assertions.assertEquals("socketjs",
-            this.annotationLookup().find(TestClassWithSocketJS.class, Route.class).path());
+    void routeAnnotationOnSocketExtendedClass() {
+        assertThat(this.annotationLookup().find(TestClassWithSocketJS.class, Route.class).path()).isEqualTo("socketjs");
     }
 
     @Test
-    public void testInterceptedRouteAnnotations() {
-        Assertions.assertEquals("intercept",
-            this.annotationLookup().find(TestClassWithIntercept.class, Intercept.class).path());
-        Assertions.assertEquals("intercept",
-            this.annotationLookup().find(TestClassWithIntercept.class, Route.class).path());
-        Assertions.assertEquals(HttpMethod.POST,
-            this.annotationLookup().find(TestClassWithIntercept.class, Intercept.class).method());
-        Assertions.assertEquals(HttpMethod.POST,
-            this.annotationLookup().find(TestClassWithIntercept.class, Route.class).method());
-        Assertions.assertEquals(InterceptType.AFTER_SUCCESS,
-            this.annotationLookup().find(TestClassWithIntercept.class, Intercept.class).type());
+    void interceptedRouteAnnotations() {
+        assertThat(this.annotationLookup().find(TestClassWithIntercept.class, Intercept.class).path()).isEqualTo("intercept");
+        assertThat(this.annotationLookup().find(TestClassWithIntercept.class, Route.class).path()).isEqualTo("intercept");
+        assertThat(this.annotationLookup().find(TestClassWithIntercept.class, Intercept.class).method()).isEqualTo(HttpMethod.POST);
+        assertThat(this.annotationLookup().find(TestClassWithIntercept.class, Route.class).method()).isEqualTo(HttpMethod.POST);
+        assertThat(this.annotationLookup().find(TestClassWithIntercept.class, Intercept.class).type()).isEqualTo(InterceptType.AFTER_SUCCESS);
     }
 
     @Test
-    public void testDoubleInterceptedRouteAnnotations() {
-        Assertions.assertEquals("prehandler",
-            this.annotationLookup().find(TestClassWithPreHandler.class, Intercept.class).path());
-        Assertions.assertEquals("prehandler",
-            this.annotationLookup().find(TestClassWithPreHandler.class, Route.class).path());
-        Assertions.assertEquals(HttpMethod.GET,
-            this.annotationLookup().find(TestClassWithPreHandler.class, Intercept.class).method());
-        Assertions.assertEquals(HttpMethod.GET,
-            this.annotationLookup().find(TestClassWithPreHandler.class, Route.class).method());
-        Assertions.assertEquals(InterceptType.PRE_HANDLER,
-            this.annotationLookup().find(TestClassWithPreHandler.class, Intercept.class).type());
+    void doubleInterceptedRouteAnnotations() {
+        assertThat(this.annotationLookup().find(TestClassWithPreHandler.class, Intercept.class).path()).isEqualTo("prehandler");
+        assertThat(this.annotationLookup().find(TestClassWithPreHandler.class, Route.class).path()).isEqualTo("prehandler");
+        assertThat(this.annotationLookup().find(TestClassWithPreHandler.class, Intercept.class).method()).isEqualTo(HttpMethod.GET);
+        assertThat(this.annotationLookup().find(TestClassWithPreHandler.class, Route.class).method()).isEqualTo(HttpMethod.GET);
+        assertThat(this.annotationLookup().find(TestClassWithPreHandler.class, Intercept.class).type()).isEqualTo(InterceptType.PRE_HANDLER);
     }
 
     @Test
-    public void testDoubleInheritedAndDefaultedRouteAnnotation() {
-        Assertions.assertEquals("aftersuccess",
-            this.annotationLookup().find(TestClassWithAfterSuccess.class, Intercept.class).path());
-        Assertions.assertEquals("aftersuccess",
-            this.annotationLookup().find(TestClassWithAfterSuccess.class, Route.class).path());
-        Assertions.assertEquals(HttpMethod.POST,
-            this.annotationLookup()
-                .find(TestClassWithAfterSuccess.class, Intercept.class)
-                .method());
-        Assertions.assertEquals(HttpMethod.POST,
-            this.annotationLookup().find(TestClassWithAfterSuccess.class, Route.class).method());
-        Assertions.assertEquals(InterceptType.AFTER_SUCCESS,
-            this.annotationLookup().find(TestClassWithAfterSuccess.class, Intercept.class).type());
+    void doubleInheritedAndDefaultedRouteAnnotation() {
+        assertThat(this.annotationLookup().find(TestClassWithAfterSuccess.class, Intercept.class).path()).isEqualTo("aftersuccess");
+        assertThat(this.annotationLookup().find(TestClassWithAfterSuccess.class, Route.class).path()).isEqualTo("aftersuccess");
+        assertThat(this.annotationLookup()
+            .find(TestClassWithAfterSuccess.class, Intercept.class)
+            .method()).isEqualTo(HttpMethod.POST);
+        assertThat(this.annotationLookup().find(TestClassWithAfterSuccess.class, Route.class).method()).isEqualTo(HttpMethod.POST);
+        assertThat(this.annotationLookup().find(TestClassWithAfterSuccess.class, Intercept.class).type()).isEqualTo(InterceptType.AFTER_SUCCESS);
     }
 
     @Test
-    public void reportErrorWhenMultipleAnnotationsWithSameBaseTypeFound() {
-        Exception exception = Assertions.assertThrows(Exception.class,
-            () -> this.annotationLookup().find(TestClassWithSameBaseType.class, Base.class));
-        Assertions.assertTrue(exception.getMessage()
-            .contains("Found more than one annotation on class"));
+    void reportErrorWhenMultipleAnnotationsWithSameBaseTypeFound() {
+        Exception exception = assertThatExceptionOfType(Exception.class).isThrownBy(() -> this.annotationLookup().find(TestClassWithSameBaseType.class, Base.class)).actual();
+        assertThat(exception.getMessage()).contains("Found more than one annotation on class");
 
         this.annotationLookup().find(TestClassWithSameBaseType.class, Sub.class);
     }
 
     @Test
-    public void jointAnnotationsAreStrictlyOrdered() {
+    void jointAnnotationsAreStrictlyOrdered() {
         List<Route> routes =
             this.annotationLookup().findAll(TestClassWithJointAnnotation2.class, Route.class);
-        Assertions.assertEquals(Arrays.asList(HttpMethod.POST, HttpMethod.GET),
-            routes.stream().map(Route::method).collect(Collectors.toList()));
-        Assertions.assertEquals(Arrays.asList("abc", ""),
-            routes.stream().map(Route::path).collect(Collectors.toList()));
-        Assertions.assertEquals(Arrays.asList("", "jointRegex"),
-            routes.stream().map(Route::regex).collect(Collectors.toList()));
+        assertThat(routes.stream().map(Route::method)).containsExactlyElementsOf(Arrays.asList(HttpMethod.POST, HttpMethod.GET));
+        assertThat(routes.stream().map(Route::path)).containsExactlyElementsOf(Arrays.asList("abc", ""));
+        assertThat(routes.stream().map(Route::regex)).containsExactlyElementsOf(Arrays.asList("", "jointRegex"));
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/ClassPathScannerTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/ClassPathScannerTests.java
@@ -17,8 +17,6 @@
 package test.org.dockbox.hartshorn.introspect;
 
 import org.dockbox.hartshorn.util.introspect.scan.classpath.ClassPathScanner;
-import org.dockbox.hartshorn.util.introspect.scan.classpath.ClassPathWalkingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.org.dockbox.hartshorn.introspect.types.ScanAnnotation;
 import test.org.dockbox.hartshorn.introspect.types.ScanClass;
@@ -28,17 +26,19 @@ import test.org.dockbox.hartshorn.introspect.types.ScanEnum;
 import test.org.dockbox.hartshorn.introspect.types.ScanInterface;
 import test.org.dockbox.hartshorn.introspect.types.ScanRecord;
 
-import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ClassPathScannerTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+class ClassPathScannerTests {
 
     @Test
-    void testCanScanWithPackageFilter() throws ClassPathWalkingException {
+    void canScanWithPackageFilter() throws Exception {
         ClassPathScanner scanner = ClassPathScanner.create()
             .includeDefaultClassPath()
             .filterPrefix("test.org.dockbox.hartshorn.introspect.types");
@@ -46,29 +46,29 @@ public class ClassPathScannerTests {
         Set<String> classes = new HashSet<>();
         scanner.scan(resource -> classes.add(resource.resourceName()));
 
-        Assertions.assertEquals(7, classes.size()); // 7 classes in the test package
-
-        Assertions.assertTrue(classes.contains(ScanAnnotation.class.getCanonicalName()));
-        Assertions.assertTrue(classes.contains(ScanClass.class.getCanonicalName()));
-        // Inner classes' canonical name is OuterClass.InnerClass, while the resource name (which is also compatible with Class.forName) is OuterClass$InnerClass
-        Assertions.assertTrue(classes.contains(this.resourceNameFromCanonicalName(
-            NonStaticInnerClass.class.getCanonicalName())));
-        Assertions.assertTrue(classes.contains(this.resourceNameFromCanonicalName(StaticInnerClass.class.getCanonicalName())));
-        Assertions.assertTrue(classes.contains(ScanEnum.class.getCanonicalName()));
-        Assertions.assertTrue(classes.contains(ScanInterface.class.getCanonicalName()));
-        Assertions.assertTrue(classes.contains(ScanRecord.class.getCanonicalName()));
+        assertThat(classes)
+                .hasSize(7)
+                // 7 classes in the test package
+                .contains(ScanAnnotation.class.getCanonicalName())
+                .contains(ScanClass.class.getCanonicalName())
+                // Inner classes' canonical name is OuterClass.InnerClass, while the resource name (which is also compatible with Class.forName) is OuterClass$InnerClass
+                .contains(this.resourceNameFromCanonicalName(
+            NonStaticInnerClass.class.getCanonicalName()))
+                .contains(this.resourceNameFromCanonicalName(StaticInnerClass.class.getCanonicalName()))
+                .contains(ScanEnum.class.getCanonicalName())
+                .contains(ScanInterface.class.getCanonicalName())
+                .contains(ScanRecord.class.getCanonicalName());
     }
 
     @Test
-    void testCanScanWithEncodedCharacters() throws IOException, ClassPathWalkingException {
+    void canScanWithEncodedCharacters() throws Exception {
         // Note that we use an empty directory here, so scanning will yield no results, but won't throw an exception either.
         Path dummyFolder = Files.createTempDirectory("dummy folder");
         dummyFolder.toFile().deleteOnExit();
         URL url = dummyFolder.toUri().toURL();
 
-        ClassPathScanner scanner =
-            Assertions.assertDoesNotThrow(() -> ClassPathScanner.create().addUrlForScanning(url));
-        scanner.scan(resource -> Assertions.fail("Should not have found any resources"));
+        ClassPathScanner scanner = ClassPathScanner.create().addUrlForScanning(url);
+        scanner.scan(resource -> fail("Should not have found any resources"));
     }
 
     private String resourceNameFromCanonicalName(String canonicalName) {

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/GenericConvertersTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/GenericConvertersTests.java
@@ -23,27 +23,31 @@ import org.dockbox.hartshorn.util.introspect.convert.ConverterCache;
 import org.dockbox.hartshorn.util.introspect.convert.ConvertibleTypePair;
 import org.dockbox.hartshorn.util.introspect.convert.GenericConverter;
 import org.dockbox.hartshorn.util.introspect.convert.GenericConverters;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-public class GenericConvertersTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class GenericConvertersTests {
 
     @Test
-    void testGenericConverterWithSingleTypePair() {
+    void genericConverterWithSingleTypePair() {
         GenericConverter converter =
             new SimpleGenericConverter(Set.of(ConvertibleTypePair.of(Object.class, String.class)));
         ConverterCache converters = new GenericConverters();
         converters.addConverter(converter);
 
         GenericConverter locatedConverter = converters.getConverter(new Object(), String.class);
-        Assertions.assertNotNull(locatedConverter);
-        Assertions.assertSame(converter, locatedConverter);
+        assertThat(locatedConverter)
+                .isNotNull()
+                .isSameAs(converter);
     }
 
     @Test
-    void testGenericConverterWithMultipleTypePairs() {
+    void genericConverterWithMultipleTypePairs() {
         GenericConverter converter = new SimpleGenericConverter(Set.of(
             ConvertibleTypePair.of(Object.class, String.class),
             ConvertibleTypePair.of(Object.class, Integer.class)
@@ -53,17 +57,19 @@ public class GenericConvertersTests {
 
         GenericConverter locatedStringConverter =
             converters.getConverter(new Object(), String.class);
-        Assertions.assertNotNull(locatedStringConverter);
-        Assertions.assertSame(converter, locatedStringConverter);
+        assertThat(locatedStringConverter)
+                .isNotNull()
+                .isSameAs(converter);
 
         GenericConverter locatedIntegerConverter =
             converters.getConverter(new Object(), Integer.class);
-        Assertions.assertNotNull(locatedIntegerConverter);
-        Assertions.assertSame(converter, locatedIntegerConverter);
+        assertThat(locatedIntegerConverter)
+                .isNotNull()
+                .isSameAs(converter);
     }
 
     @Test
-    void testGenericConverterWithMultipleTypePairsAndMultipleConverters() {
+    void genericConverterWithMultipleTypePairsAndMultipleConverters() {
         GenericConverter converter1 = new SimpleGenericConverter(Set.of(
             ConvertibleTypePair.of(Object.class, String.class),
             ConvertibleTypePair.of(Object.class, Integer.class)
@@ -79,11 +85,12 @@ public class GenericConvertersTests {
         converters.addConverter(converter1);
         converters.addConverter(converter2);
 
-        Assertions.assertThrows(AmbiguousConverterException.class,
-            () -> converters.getConverter(new Object(), String.class));
-        Assertions.assertThrows(AmbiguousConverterException.class,
-            () -> converters.getConverter(new Object(), Integer.class));
-        Assertions.assertDoesNotThrow(() -> converters.getConverter(new Object(), Long.class));
+        assertThatExceptionOfType(AmbiguousConverterException.class)
+                .isThrownBy(() -> converters.getConverter(new Object(), String.class));
+        assertThatExceptionOfType(AmbiguousConverterException.class)
+                .isThrownBy(() -> converters.getConverter(new Object(), Integer.class));
+        assertThatCode(() -> converters.getConverter(new Object(), Long.class))
+                .doesNotThrowAnyException();
     }
 
     private record SimpleGenericConverter(Set<ConvertibleTypePair> convertibleTypes)

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/ParameterLoaderTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/ParameterLoaderTests.java
@@ -24,26 +24,27 @@ import org.dockbox.hartshorn.util.introspect.util.RuleBasedParameterLoader;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.ParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.LinkedList;
 import java.util.List;
 
-public class ParameterLoaderTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ParameterLoaderTests {
 
     @Test
-    void testRuleBasedParameterLoadersCannotHaveDuplicateRules() {
+    void ruleBasedParameterLoadersCannotHaveDuplicateRules() {
         RuleBasedParameterLoader<?> parameterLoader = RuleBasedParameterLoader.createDefault();
         ParameterLoaderRule<ParameterLoaderContext> stringRule = new StringParameterRule();
         parameterLoader.add(stringRule);
         parameterLoader.add(stringRule);
-        Assertions.assertEquals(1, parameterLoader.rules().size());
+        assertThat(parameterLoader.rules()).hasSize(1);
     }
 
     @Test
-    void testRuleBasedParameterLoaderReturnsCorrectObjectsOrDefault() {
+    void ruleBasedParameterLoaderReturnsCorrectObjectsOrDefault() {
         RuleBasedParameterLoader<?> parameterLoader = RuleBasedParameterLoader.createDefault();
         parameterLoader.add(new StringParameterRule());
 
@@ -85,10 +86,9 @@ public class ParameterLoaderTests {
             new ParameterLoaderContext(methodContext, new Object());
         List<Object> objects = parameterLoader.loadArguments(loaderContext);
 
-        Assertions.assertNotNull(objects);
-        Assertions.assertEquals(2, objects.size());
-        Assertions.assertEquals("JUnit", objects.get(0));
-        Assertions.assertEquals(0,
-            objects.get(1)); // Default value for 'int', instead of the value being null
+        assertThat(objects)
+                .hasSize(2);
+        assertThat(objects.get(0)).isEqualTo("JUnit");
+        assertThat(objects.get(1)).isEqualTo(0); // Default value for 'int', instead of the value being null
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/TypeCollectorTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/TypeCollectorTests.java
@@ -16,20 +16,14 @@
 
 package test.org.dockbox.hartshorn.introspect;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.dockbox.hartshorn.util.introspect.scan.AggregateTypeReferenceCollector;
 import org.dockbox.hartshorn.util.introspect.scan.CachedTypeReferenceCollector;
 import org.dockbox.hartshorn.util.introspect.scan.ClassReferenceLoadException;
 import org.dockbox.hartshorn.util.introspect.scan.PredefinedSetTypeReferenceCollector;
-import org.dockbox.hartshorn.util.introspect.scan.TypeCollectionException;
 import org.dockbox.hartshorn.util.introspect.scan.TypeReference;
 import org.dockbox.hartshorn.util.introspect.scan.TypeReferenceCollector;
 import org.dockbox.hartshorn.util.introspect.scan.classpath.ClassPathScannerTypeReferenceCollector;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import test.org.dockbox.hartshorn.introspect.types.ScanAnnotation;
 import test.org.dockbox.hartshorn.introspect.types.ScanClass;
 import test.org.dockbox.hartshorn.introspect.types.ScanClass.NonStaticInnerClass;
@@ -38,37 +32,44 @@ import test.org.dockbox.hartshorn.introspect.types.ScanEnum;
 import test.org.dockbox.hartshorn.introspect.types.ScanInterface;
 import test.org.dockbox.hartshorn.introspect.types.ScanRecord;
 
-public class TypeCollectorTests {
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+class TypeCollectorTests {
 
     @Test
-    void testClassPathScannerTypeCollector() throws TypeCollectionException {
+    void classPathScannerTypeCollector() throws Exception {
         TypeReferenceCollector collector =
             new ClassPathScannerTypeReferenceCollector("test.org.dockbox.hartshorn.introspect.types");
         Set<TypeReference> typeReferences = collector.collect();
 
-        Assertions.assertEquals(7, typeReferences.size());
+        assertThat(typeReferences).hasSize(7);
 
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        Set<? extends Class<?>> types = typeReferences.stream().map(typeReference -> {
+        Set<Class<?>> types = typeReferences.stream().map(typeReference -> {
             try {
                 return typeReference.getOrLoad(classLoader);
             }
             catch (ClassReferenceLoadException e) {
-                return Assertions.fail(e);
+                return fail(e);
             }
         }).collect(Collectors.toSet());
 
-        Assertions.assertTrue(types.contains(ScanAnnotation.class));
-        Assertions.assertTrue(types.contains(ScanClass.class));
-        Assertions.assertTrue(types.contains(NonStaticInnerClass.class));
-        Assertions.assertTrue(types.contains(StaticInnerClass.class));
-        Assertions.assertTrue(types.contains(ScanEnum.class));
-        Assertions.assertTrue(types.contains(ScanInterface.class));
-        Assertions.assertTrue(types.contains(ScanRecord.class));
+        assertThat(types)
+                .contains(ScanAnnotation.class)
+                .contains(ScanClass.class)
+                .contains(NonStaticInnerClass.class)
+                .contains(StaticInnerClass.class)
+                .contains(ScanEnum.class)
+                .contains(ScanInterface.class)
+                .contains(ScanRecord.class);
     }
 
     @Test
-    void testCachedTypeCollector() throws TypeCollectionException {
+    void cachedTypeCollector() throws Exception {
         TypeReferenceCollector collector =
             new ClassPathScannerTypeReferenceCollector("test.org.dockbox.hartshorn.introspect.types");
         TypeReferenceCollector cachedCollector = new CachedTypeReferenceCollector(collector);
@@ -76,11 +77,11 @@ public class TypeCollectorTests {
         Set<TypeReference> typeReferencesA = cachedCollector.collect();
         Set<TypeReference> typeReferencesB = cachedCollector.collect();
 
-        Assertions.assertSame(typeReferencesA, typeReferencesB);
+        assertThat(typeReferencesB).isSameAs(typeReferencesA);
     }
 
     @Test
-    void testAggregateTypeCollector() throws TypeCollectionException {
+    void aggregateTypeCollector() throws Exception {
         PredefinedSetTypeReferenceCollector enumCollector =
             PredefinedSetTypeReferenceCollector.of(ScanEnum.class);
         PredefinedSetTypeReferenceCollector classCollector =
@@ -92,20 +93,21 @@ public class TypeCollectorTests {
             new AggregateTypeReferenceCollector(enumCollector, classCollector, interfaceCollector);
         Set<TypeReference> typeReferences = collector.collect();
 
-        Assertions.assertEquals(3, typeReferences.size());
+        assertThat(typeReferences).hasSize(3);
 
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        Set<? extends Class<?>> types = typeReferences.stream().map(typeReference -> {
+        Set<Class<?>> types = typeReferences.stream().map(typeReference -> {
             try {
                 return typeReference.getOrLoad(classLoader);
             }
             catch (ClassReferenceLoadException e) {
-                return Assertions.fail(e);
+                return fail(e);
             }
         }).collect(Collectors.toSet());
 
-        Assertions.assertTrue(types.contains(ScanEnum.class));
-        Assertions.assertTrue(types.contains(ScanClass.class));
-        Assertions.assertTrue(types.contains(ScanInterface.class));
+        assertThat(types)
+                .contains(ScanEnum.class)
+                .contains(ScanClass.class)
+                .contains(ScanInterface.class);
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/WildcardIntrospectorTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/WildcardIntrospectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,30 +20,32 @@ import org.dockbox.hartshorn.util.introspect.AccessModifier;
 import org.dockbox.hartshorn.util.introspect.TypeConstructorsIntrospector;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.introspect.view.wildcard.WildcardTypeView;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class WildcardIntrospectorTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class WildcardIntrospectorTests {
 
     @Test
-    void testWildcardIsParentChildAndEqual() {
+    void wildcardIsParentChildAndEqual() {
         TypeView<Object> view = new WildcardTypeView();
 
-        Assertions.assertTrue(view.isParentOf(Object.class));
-        Assertions.assertTrue(view.is(Object.class));
-        Assertions.assertFalse(view.isChildOf(Object.class));
+        assertThat(view.isParentOf(Object.class)).isTrue();
+        assertThat(view.is(Object.class)).isTrue();
+        assertThat(view.isChildOf(Object.class)).isFalse();
 
-        Assertions.assertTrue(view.isParentOf(String.class));
-        Assertions.assertTrue(view.is(String.class));
-        Assertions.assertFalse(view.isChildOf(String.class));
+        assertThat(view.isParentOf(String.class)).isTrue();
+        assertThat(view.is(String.class)).isTrue();
+        assertThat(view.isChildOf(String.class)).isFalse();
 
-        Assertions.assertTrue(view.isParentOf(WildcardIntrospectorTests.class));
-        Assertions.assertTrue(view.is(WildcardIntrospectorTests.class));
-        Assertions.assertFalse(view.isChildOf(WildcardIntrospectorTests.class));
+        assertThat(view.isParentOf(WildcardIntrospectorTests.class)).isTrue();
+        assertThat(view.is(WildcardIntrospectorTests.class)).isTrue();
+        assertThat(view.isChildOf(WildcardIntrospectorTests.class)).isFalse();
     }
 
     @Test
-    void testNameAndQualifiedNameAreNonValidClassNameCharacter() {
+    void nameAndQualifiedNameAreNonValidClassNameCharacter() {
         TypeView<Object> view = new WildcardTypeView();
 
         // Expected to be '*', but not enforced. This is just a test to ensure that the name and qualified
@@ -51,95 +53,95 @@ public class WildcardIntrospectorTests {
         String regex = "[a-zA-Z_$][a-zA-Z\\d_$]*";
 
         boolean isUsableClassName = view.name().matches(regex);
-        Assertions.assertFalse(isUsableClassName);
+        assertThat(isUsableClassName).isFalse();
 
         boolean isUsableQualifiedClassName = view.qualifiedName().matches(regex);
-        Assertions.assertFalse(isUsableQualifiedClassName);
+        assertThat(isUsableQualifiedClassName).isFalse();
     }
 
     @Test
-    void testWildcardHasNoElementType() {
+    void wildcardHasNoElementType() {
         TypeView<Object> view = new WildcardTypeView();
-        Assertions.assertFalse(view.elementType().present());
+        assertThat(view.elementType().present()).isFalse();
     }
 
     @Test
-    void testWildcardHasEnumConstants() {
+    void wildcardHasEnumConstants() {
         TypeView<Object> view = new WildcardTypeView();
-        Assertions.assertTrue(view.enumConstants().isEmpty());
+        assertThat(view.enumConstants()).isEmpty();
     }
 
     @Test
-    void testWildcardHasNullDefault() {
+    void wildcardHasNullDefault() {
         TypeView<Object> view = new WildcardTypeView();
-        Assertions.assertNull(view.defaultOrNull());
+        assertThat(view.defaultOrNull()).isNull();
     }
 
     @Test
-    void testWildcardCastsAnyObject() {
+    void wildcardCastsAnyObject() {
         TypeView<Object> view = new WildcardTypeView();
-        Assertions.assertDoesNotThrow(() -> view.cast(new Object()));
-        Assertions.assertDoesNotThrow(() -> view.cast(this));
-        Assertions.assertDoesNotThrow(() -> view.cast("test"));
+        assertThatCode(() -> view.cast(new Object())).doesNotThrowAnyException();
+        assertThatCode(() -> view.cast(this)).doesNotThrowAnyException();
+        assertThatCode(() -> view.cast("test")).doesNotThrowAnyException();
     }
 
     @Test
-    void testWildcardHasNoModifiers() {
+    void wildcardHasNoModifiers() {
         TypeView<Object> view = new WildcardTypeView();
         for (AccessModifier modifier : AccessModifier.values()) {
-            Assertions.assertFalse(view.modifiers().has(modifier));
+            assertThat(view.modifiers().has(modifier)).isFalse();
         }
     }
 
     @Test
-    void testWildcardIsWildcard() {
+    void wildcardIsWildcard() {
         TypeView<Object> view = new WildcardTypeView();
-        Assertions.assertTrue(view.isWildcard());
+        assertThat(view.isWildcard()).isTrue();
     }
 
     @Test
-    void testWildcardConstructors() {
+    void wildcardConstructors() {
         TypeView<Object> view = new WildcardTypeView();
         TypeConstructorsIntrospector<Object> constructors = view.constructors();
-        Assertions.assertEquals(0, constructors.count());
-        Assertions.assertTrue(constructors.all().isEmpty());
-        Assertions.assertTrue(constructors.defaultConstructor().absent());
+        assertThat(constructors.count()).isZero();
+        assertThat(constructors.all()).isEmpty();
+        assertThat(constructors.defaultConstructor().absent()).isTrue();
     }
 
     @Test
-    void testWildcardHasNoFields() {
+    void wildcardHasNoFields() {
         TypeView<Object> view = new WildcardTypeView();
-        Assertions.assertTrue(view.fields().all().isEmpty());
+        assertThat(view.fields().all()).isEmpty();
     }
 
     @Test
-    void testWildcardHasNoMethods() {
+    void wildcardHasNoMethods() {
         TypeView<Object> view = new WildcardTypeView();
-        Assertions.assertTrue(view.methods().all().isEmpty());
+        assertThat(view.methods().all()).isEmpty();
     }
 
     @Test
-    void testWildcardIsOwnSuperClass() {
+    void wildcardIsOwnSuperClass() {
         TypeView<Object> view = new WildcardTypeView();
-        Assertions.assertSame(view, view.superClass());
+        assertThat(view.superClass()).isSameAs(view);
     }
 
     @Test
-    void testWildcardIsNoExplicitType() {
+    void wildcardIsNoExplicitType() {
         TypeView<Object> view = new WildcardTypeView();
-        Assertions.assertFalse(view.isVoid());
-        Assertions.assertFalse(view.isAnonymous());
-        Assertions.assertFalse(view.isPrimitive());
-        Assertions.assertFalse(view.isEnum());
-        Assertions.assertFalse(view.isAnnotation());
-        Assertions.assertFalse(view.isInterface());
-        Assertions.assertFalse(view.isRecord());
+        assertThat(view.isVoid()).isFalse();
+        assertThat(view.isAnonymous()).isFalse();
+        assertThat(view.isPrimitive()).isFalse();
+        assertThat(view.isEnum()).isFalse();
+        assertThat(view.isAnnotation()).isFalse();
+        assertThat(view.isInterface()).isFalse();
+        assertThat(view.isRecord()).isFalse();
     }
 
     @Test
-    void testWildcardPackageIsEmpty() {
+    void wildcardPackageIsEmpty() {
         TypeView<Object> view = new WildcardTypeView();
-        Assertions.assertEquals("", view.packageInfo().name());
-        Assertions.assertEquals("", view.packageInfo().qualifiedName());
+        assertThat(view.packageInfo().name()).isEmpty();
+        assertThat(view.packageInfo().qualifiedName()).isEmpty();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ArrayToCollectionConverterFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ArrayToCollectionConverterFactoryTests.java
@@ -21,19 +21,20 @@ import java.util.Collection;
 import java.util.List;
 
 import org.dockbox.hartshorn.util.collections.CollectionUtilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.dockbox.hartshorn.util.types.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.ConverterFactory;
 import org.dockbox.hartshorn.util.introspect.convert.support.ArrayToCollectionConverterFactory;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("rawtypes")
-public class ArrayToCollectionConverterFactoryTests {
+class ArrayToCollectionConverterFactoryTests {
 
     @Test
-    void testFactoryCreatesConverterForConcreteCollectionTarget() {
+    void factoryCreatesConverterForConcreteCollectionTarget() {
         Introspector introspector = ConverterIntrospectionHelper.createIntrospectorForCollection(
             ArrayList.class,
             ArrayList::new);
@@ -41,32 +42,32 @@ public class ArrayToCollectionConverterFactoryTests {
         ConverterFactory<Object[], Collection<?>> factory =
             new ArrayToCollectionConverterFactory(introspector);
         Converter<Object[], ArrayList> converter = factory.create(ArrayList.class);
-        Assertions.assertNotNull(converter);
+        assertThat(converter).isNotNull();
 
         List<?> list = converter.convert(new Object[] {"test"});
-        Assertions.assertNotNull(list);
-        Assertions.assertEquals(1, list.size());
-        Assertions.assertEquals("test", list.get(0));
+        assertThat(list)
+                .hasSize(1);
+        assertThat(list.get(0)).isEqualTo("test");
     }
 
     @Test
-    void testFactoryCreatesConverterForInterfaceCollectionTarget() {
+    void factoryCreatesConverterForInterfaceCollectionTarget() {
         Converter<Object[], Collection<String>> converter = createConverter();
-        Assertions.assertNotNull(converter);
+        assertThat(converter).isNotNull();
 
         Collection<String> list = converter.convert(new Object[] {"test"});
-        Assertions.assertNotNull(list);
-        Assertions.assertEquals(1, list.size());
-        Assertions.assertEquals("test", CollectionUtilities.first(list));
+        assertThat(list)
+                .hasSize(1);
+        assertThat(CollectionUtilities.first(list)).isEqualTo("test");
     }
 
     @Test
-    void testFactoryCreatesEmptyCollectionIfArrayEmpty() {
+    void factoryCreatesEmptyCollectionIfArrayEmpty() {
         Converter<Object[], Collection<String>> converter = createConverter();
 
         Collection list = converter.convert(new Object[0]);
-        Assertions.assertNotNull(list);
-        Assertions.assertEquals(0, list.size());
+        assertThat(list).isNotNull();
+        assertThat(list).isEmpty();
     }
 
     private static Converter<Object[], Collection<String>> createConverter() {
@@ -77,7 +78,7 @@ public class ArrayToCollectionConverterFactoryTests {
 
         Converter<Object[], Collection<String>> converter =
             TypeUtils.unchecked(factory.create(Collection.class), Converter.class);
-        Assertions.assertNotNull(converter);
+        assertThat(converter).isNotNull();
 
         return converter;
     }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ArrayToObjectConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ArrayToObjectConverterTests.java
@@ -22,39 +22,41 @@ import org.dockbox.hartshorn.util.introspect.convert.StandardConversionService;
 import org.dockbox.hartshorn.util.introspect.convert.support.ArrayToObjectConverter;
 import org.dockbox.hartshorn.util.introspect.convert.support.StringToNumberConverterFactory;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class ArrayToObjectConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArrayToObjectConverterTests {
 
     @Test
-    void testArrayConvertsToObjectIfLengthIsOne() {
+    void arrayConvertsToObjectIfLengthIsOne() {
         GenericConverter converter = new ArrayToObjectConverter(null);
         Object[] array = {"test"};
         Object result = converter.convert(array, Object[].class, Object.class);
-        Assertions.assertNotNull(result);
-        Assertions.assertEquals("test", result);
+        assertThat(result)
+                .isNotNull()
+                .isEqualTo("test");
     }
 
     @Test
-    void testArrayDoesNotConvertIfLengthIsZero() {
+    void arrayDoesNotConvertIfLengthIsZero() {
         GenericConverter converter = new ArrayToObjectConverter(null);
         Object[] array = {};
         Object result = converter.convert(array, Object[].class, Object.class);
-        Assertions.assertNull(result);
+        assertThat(result).isNull();
     }
 
     @Test
-    void testArrayDoesNotConvertIfLengthIsMoreThanOne() {
+    void arrayDoesNotConvertIfLengthIsMoreThanOne() {
         GenericConverter converter = new ArrayToObjectConverter(null);
         Object[] array = {"test", "test"};
         Object result = converter.convert(array, Object[].class, Object.class);
-        Assertions.assertNull(result);
+        assertThat(result).isNull();
     }
 
     @Test
-    void testArrayElementIsConvertedIfComponentTypeDoesNotMatch() {
+    void arrayElementIsConvertedIfComponentTypeDoesNotMatch() {
         TypeView<Integer> integerTypeView = Mockito.mock(TypeView.class);
         Mockito.when(integerTypeView.type()).thenReturn(Integer.class);
         Mockito.when(integerTypeView.cast(Mockito.any()))
@@ -73,7 +75,8 @@ public class ArrayToObjectConverterTests {
         Object[] array = {"1"};
         // Use Object[].class as the source type, so we can test that the element type is used, instead of the array component type
         Object result = converter.convert(array, Object[].class, Integer.class);
-        Assertions.assertNotNull(result);
-        Assertions.assertEquals(1, result);
+        assertThat(result)
+                .isNotNull()
+                .isEqualTo(1);
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionDefaultValueProviderFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionDefaultValueProviderFactoryTests.java
@@ -20,7 +20,6 @@ import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.convert.DefaultValueProvider;
 import org.dockbox.hartshorn.util.introspect.convert.DefaultValueProviderFactory;
 import org.dockbox.hartshorn.util.introspect.convert.support.CollectionDefaultValueProviderFactory;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.beans.beancontext.BeanContext;
@@ -28,82 +27,90 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.function.Supplier;
 
-public class CollectionDefaultValueProviderFactoryTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CollectionDefaultValueProviderFactoryTests {
+
     @Test
-    void testConcreteListCanBeProvided() {
+    void concreteListCanBeProvided() {
         DefaultValueProvider<ArrayList> provider = createProvider(ArrayList.class, ArrayList::new);
 
         List<?> list = provider.defaultValue();
-        Assertions.assertNotNull(list);
-        Assertions.assertTrue(list instanceof ArrayList<?>);
-        Assertions.assertEquals(0, list.size());
+        assertThat(list)
+                .isInstanceOf(ArrayList.class)
+                .isEmpty();
     }
 
     @Test
-    void testConcreteSetCanBeProvided() {
+    void concreteSetCanBeProvided() {
         DefaultValueProvider<HashSet> provider = createProvider(HashSet.class, HashSet::new);
 
         Set<?> set = provider.defaultValue();
-        Assertions.assertNotNull(set);
-        Assertions.assertEquals(0, set.spliterator().getExactSizeIfKnown());
+        assertThat(set).isEmpty();
     }
 
     @Test
-    void testInterfaceListCanBeProvided() {
+    void interfaceListCanBeProvided() {
         DefaultValueProvider<List> provider = createProvider(List.class);
 
         List<?> list = provider.defaultValue();
-        Assertions.assertNotNull(list);
-        Assertions.assertEquals(0, list.size());
+        assertThat(list)
+                .isInstanceOf(ArrayList.class)
+                .isEmpty();
     }
 
     @Test
-    void testInterfaceCollectionCanBeProvided() {
+    void interfaceCollectionCanBeProvided() {
         DefaultValueProvider<Collection> provider = createProvider(Collection.class);
 
         Collection<?> collection = provider.defaultValue();
-        Assertions.assertNotNull(collection);
-        Assertions.assertEquals(0, collection.size());
+        assertThat(collection)
+                .isInstanceOf(ArrayList.class)
+                .isEmpty();
     }
 
     @Test
-    void testInterfaceSetCanBeProvided() {
+    void interfaceSetCanBeProvided() {
         DefaultValueProvider<Set> provider = createProvider(Set.class);
 
         Set<?> set = provider.defaultValue();
-        Assertions.assertNotNull(set);
-        Assertions.assertEquals(0, set.spliterator().getExactSizeIfKnown());
+        assertThat(set)
+                .isInstanceOf(HashSet.class)
+                .isEmpty();
     }
 
     @Test
-    void testInterfaceQueueCanBeProvided() {
+    void interfaceQueueCanBeProvided() {
         DefaultValueProvider<Queue> provider = createProvider(Queue.class);
 
         Queue<?> queue = provider.defaultValue();
-        Assertions.assertNotNull(queue);
-        Assertions.assertEquals(0, queue.size());
+        assertThat(queue)
+                .isInstanceOf(LinkedList.class)
+                .isEmpty();
     }
 
     @Test
-    void testInterfaceDequeCanBeProvided() {
+    void interfaceDequeCanBeProvided() {
         DefaultValueProvider<Deque> provider = createProvider(Deque.class);
 
         Deque<?> deque = provider.defaultValue();
-        Assertions.assertNotNull(deque);
-        Assertions.assertEquals(0, deque.size());
+        assertThat(deque)
+                .isInstanceOf(LinkedList.class)
+                .isEmpty();
     }
 
     @Test
-    void testUnsupportedCollectionTypeCannotBeProvided() {
+    void unsupportedCollectionTypeCannotBeProvided() {
         DefaultValueProvider<BeanContext> provider = createProvider(BeanContext.class);
 
         Collection<?> collection = provider.defaultValue();
-        Assertions.assertNull(collection);
+        assertThat(collection).isNull();
     }
 
     private static <T extends Collection<?>> DefaultValueProvider<T> createProvider(Class<T> type) {
@@ -111,16 +118,17 @@ public class CollectionDefaultValueProviderFactoryTests {
     }
 
     private static <T extends Collection<?>> DefaultValueProvider<T> createProvider(
-        Class<T> type,
-        Supplier<T> supplier
+            Class<T> type,
+            Supplier<T> supplier
     ) {
         Introspector introspector =
-            ConverterIntrospectionHelper.createIntrospectorForCollection(type, supplier);
+                ConverterIntrospectionHelper.createIntrospectorForCollection(type, supplier);
         DefaultValueProviderFactory<Collection<?>> factory =
-            new CollectionDefaultValueProviderFactory(introspector).withDefaults();
+                new CollectionDefaultValueProviderFactory(introspector).withDefaults();
 
         DefaultValueProvider<T> provider = factory.create(type);
-        Assertions.assertNotNull(provider);
+        assertThat(provider)
+                .isNotNull();
 
         return provider;
     }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionFactoryTests.java
@@ -32,77 +32,79 @@ import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
 import org.dockbox.hartshorn.util.introspect.Introspector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 import org.dockbox.hartshorn.util.introspect.convert.support.collections.CollectionFactory;
 import org.dockbox.hartshorn.util.introspect.convert.support.collections.SimpleCollectionFactory;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked")
-public class CollectionFactoryTests {
+class CollectionFactoryTests {
 
     @Test
-    public void testCreateCollectionWithArrayList() {
+    void createCollectionWithArrayList() {
         List<Integer> list =
             this.createDefaultFactory().createCollection(List.class, Integer.class);
-        Assertions.assertInstanceOf(ArrayList.class, list);
-        Assertions.assertEquals(list.size(), 0);
+        assertThat(list).isInstanceOf(ArrayList.class);
+        assertThat(list).isEmpty();
     }
 
     @Test
-    public void testCreateCollectionWithHashSet() {
+    void createCollectionWithHashSet() {
         Set<String> set = this.createDefaultFactory().createCollection(Set.class, String.class);
-        Assertions.assertInstanceOf(HashSet.class, set);
-        Assertions.assertEquals(set.size(), 0);
+        assertThat(set).isInstanceOf(HashSet.class);
+        assertThat(set).isEmpty();
     }
 
     @Test
-    public void testCreateCollectionWithTreeSet() {
+    void createCollectionWithTreeSet() {
         SortedSet<Double> sortedSet =
             this.createDefaultFactory().createCollection(SortedSet.class, Double.class);
-        Assertions.assertInstanceOf(TreeSet.class, sortedSet);
-        Assertions.assertEquals(sortedSet.size(), 0);
+        assertThat(sortedSet).isInstanceOf(TreeSet.class);
+        assertThat(sortedSet).isEmpty();
     }
 
     @Test
-    public void testCreateCollectionWithLinkedList() {
+    void createCollectionWithLinkedList() {
         Queue<Boolean> queue =
             this.createDefaultFactory().createCollection(Queue.class, Boolean.class);
-        Assertions.assertInstanceOf(LinkedList.class, queue);
-        Assertions.assertEquals(queue.size(), 0);
+        assertThat(queue).isInstanceOf(LinkedList.class);
+        assertThat(queue).isEmpty();
     }
 
     @Test
-    public void testCreateCollectionWithEnumSet() {
+    void createCollectionWithEnumSet() {
         CollectionFactory factory = this.createFactory(EnumSet.class, () -> null);
         EnumSet<Color> enumSet = factory.createCollection(EnumSet.class, Color.class, 2);
-        Assertions.assertInstanceOf(EnumSet.class, enumSet);
-        Assertions.assertEquals(enumSet.size(), 0);
+        assertThat(enumSet).isInstanceOf(EnumSet.class);
+        assertThat(enumSet).isEmpty();
     }
 
     @Test
-    public void testInitialCapacityIsConfigured() {
+    void initialCapacityIsConfigured() {
         int initialCapacity = 23;
         CollectionFactory factory = this.createFactory(Vector.class, Vector::new, Vector::new);
         Vector<String> enumSet =
             factory.createCollection(Vector.class, String.class, initialCapacity);
-        Assertions.assertInstanceOf(Vector.class, enumSet);
-        Assertions.assertEquals(enumSet.size(), 0);
-        Assertions.assertEquals(enumSet.capacity(), initialCapacity);
+        assertThat(enumSet).isInstanceOf(Vector.class);
+        assertThat(enumSet).isEmpty();
+        assertThat(initialCapacity).isEqualTo(enumSet.capacity());
     }
 
     @Test
-    public void testCreateCollectionWithUnsupportedInterface() {
+    void createCollectionWithUnsupportedInterface() {
         CollectionFactory factory = this.createFactory(BeanContext.class, () -> null);
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> factory.createCollection(BeanContext.class, Integer.class, 0));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> factory.createCollection(BeanContext.class, Integer.class, 0));
     }
 
     @Test
-    public void testCreateCollectionWithConcreteImplementation() {
+    void createCollectionWithConcreteImplementation() {
         CollectionFactory factory = this.createFactory(LinkedList.class, LinkedList::new);
         List<Integer> list = factory.createCollection(LinkedList.class, Integer.class, 0);
-        Assertions.assertInstanceOf(LinkedList.class, list);
-        Assertions.assertEquals(list.size(), 0);
+        assertThat(list).isInstanceOf(LinkedList.class);
+        assertThat(list).isEmpty();
     }
 
     private <T extends Collection<?>> CollectionFactory createFactory(

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionToArrayConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionToArrayConverterTests.java
@@ -17,44 +17,43 @@
 package test.org.dockbox.hartshorn.introspect.convert;
 
 import org.dockbox.hartshorn.util.introspect.convert.support.CollectionToArrayConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class CollectionToArrayConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CollectionToArrayConverterTests {
 
     @Test
-    void testConversionKeepsOrderAndElements() {
+    void conversionKeepsOrderAndElements() {
         List<Object> list = List.of("test", 1, 2.0, true, new Object());
 
-        Object converted =
-            new CollectionToArrayConverter().convert(list, List.class, Object[].class);
-        Assertions.assertNotNull(converted);
+        Object converted = new CollectionToArrayConverter()
+                .convert(list, List.class, Object[].class);
+        assertThat(converted).isInstanceOf(Object[].class);
 
-        Assertions.assertTrue(converted instanceof Object[]);
         Object[] array = (Object[]) converted;
 
-        Assertions.assertEquals(list.size(), array.length);
+        assertThat(array.length).isEqualTo(list.size());
         for (int i = 0; i < list.size(); i++) {
-            Assertions.assertSame(list.get(i), array[i]);
+            assertThat(array[i]).isSameAs(list.get(i));
         }
     }
 
     @Test
-    void testComponentTypeIsRetained() {
+    void componentTypeIsRetained() {
         List<String> list = List.of("test", "test2", "test3");
 
-        Object converted =
-            new CollectionToArrayConverter().convert(list, List.class, String[].class);
-        Assertions.assertNotNull(converted);
+        Object converted = new CollectionToArrayConverter()
+                .convert(list, List.class, String[].class);
+        assertThat(converted).isInstanceOf(String[].class);
 
-        Assertions.assertTrue(converted instanceof String[]);
         String[] array = (String[]) converted;
 
-        Assertions.assertEquals(list.size(), array.length);
+        assertThat(array.length).isEqualTo(list.size());
         for (int i = 0; i < list.size(); i++) {
-            Assertions.assertEquals(list.get(i), array[i]);
+            assertThat(array[i]).isEqualTo(list.get(i));
         }
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionToCollectionConverterFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionToCollectionConverterFactoryTests.java
@@ -19,7 +19,6 @@ package test.org.dockbox.hartshorn.introspect.convert;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.support.CollectionToCollectionConverterFactory;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -31,7 +30,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-public class CollectionToCollectionConverterFactoryTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CollectionToCollectionConverterFactoryTests {
 
     @Test
     void convertHashSetToArrayList() {
@@ -45,9 +46,10 @@ public class CollectionToCollectionConverterFactoryTests {
             new CollectionToCollectionConverterFactory(introspector).create(ArrayList.class);
         List<Integer> output = converter.convert(input);
 
-        Assertions.assertTrue(output instanceof ArrayList);
-        Assertions.assertEquals(expectedOutput.size(), output.size());
-        Assertions.assertTrue(output.containsAll(expectedOutput));
+        assertThat(output)
+                .isInstanceOf(ArrayList.class)
+                .hasSameSizeAs(expectedOutput)
+                .containsAll(expectedOutput);
     }
 
     @Test
@@ -62,9 +64,10 @@ public class CollectionToCollectionConverterFactoryTests {
             new CollectionToCollectionConverterFactory(introspector).create(LinkedList.class);
         List<String> output = converter.convert(input);
 
-        Assertions.assertTrue(output instanceof LinkedList);
-        Assertions.assertEquals(expectedOutput.size(), output.size());
-        Assertions.assertTrue(output.containsAll(expectedOutput));
+        assertThat(output)
+                .isInstanceOf(LinkedList.class)
+                .hasSameSizeAs(expectedOutput)
+                .containsAll(expectedOutput);
     }
 
     @Test
@@ -79,14 +82,15 @@ public class CollectionToCollectionConverterFactoryTests {
             new CollectionToCollectionConverterFactory(introspector).create(LinkedHashSet.class);
         Set<?> output = converter.convert(input);
 
-        Assertions.assertTrue(output instanceof LinkedHashSet);
-        Assertions.assertEquals(expectedOutput.size(), output.size());
+        assertThat(output)
+                .isInstanceOf(LinkedHashSet.class)
+                .hasSameSizeAs(expectedOutput);
 
         // Assert order is preserved
         List<?> outputList = new ArrayList<>(output);
         List<?> expectedOutputList = new ArrayList<>(expectedOutput);
         for (int i = 0; i < outputList.size(); i++) {
-            Assertions.assertEquals(expectedOutputList.get(i), outputList.get(i));
+            assertThat(outputList.get(i)).isEqualTo(expectedOutputList.get(i));
         }
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionToObjectConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/CollectionToObjectConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,43 +18,45 @@ package test.org.dockbox.hartshorn.introspect.convert;
 
 import org.dockbox.hartshorn.util.introspect.convert.ConditionalConverter;
 import org.dockbox.hartshorn.util.introspect.convert.support.CollectionToObjectConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Set;
 
-public class CollectionToObjectConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CollectionToObjectConverterTests {
 
     @Test
-    void testSingleElementCollectionOfTargetTypeCanConvert() {
+    void singleElementCollectionOfTargetTypeCanConvert() {
         Set<String> collection = Collections.singleton("test");
         CollectionToObjectConverter converter = new CollectionToObjectConverter();
-        Assertions.assertTrue(converter.canConvert(collection, String.class));
+        assertThat(converter.canConvert(collection, String.class)).isTrue();
 
         Object converted = converter.convert(collection, Set.class, String.class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals("test", converted);
+        assertThat(converted)
+                .isNotNull()
+                .isEqualTo("test");
     }
 
     @Test
-    void testSingleElementCollectionOfDifferentTypeCannotConvert() {
+    void singleElementCollectionOfDifferentTypeCannotConvert() {
         Set<Integer> collection = Collections.singleton(1);
         ConditionalConverter converter = new CollectionToObjectConverter();
-        Assertions.assertFalse(converter.canConvert(collection, String.class));
+        assertThat(converter.canConvert(collection, String.class)).isFalse();
     }
 
     @Test
-    void testEmptyCollectionCannotConvert() {
+    void emptyCollectionCannotConvert() {
         Set<String> collection = Collections.emptySet();
         ConditionalConverter converter = new CollectionToObjectConverter();
-        Assertions.assertFalse(converter.canConvert(collection, String.class));
+        assertThat(converter.canConvert(collection, String.class)).isFalse();
     }
 
     @Test
-    void testMultiElementCollectionCannotConvert() {
+    void multiElementCollectionCannotConvert() {
         Set<String> collection = Set.of("test", "test2");
         ConditionalConverter converter = new CollectionToObjectConverter();
-        Assertions.assertFalse(converter.canConvert(collection, String.class));
+        assertThat(converter.canConvert(collection, String.class)).isFalse();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConverterIntrospectionHelper.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConverterIntrospectionHelper.java
@@ -16,12 +16,6 @@
 
 package test.org.dockbox.hartshorn.introspect.convert;
 
-import java.lang.reflect.Constructor;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.IntFunction;
-import java.util.function.Supplier;
-
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.SimpleTypeParameterList;
 import org.dockbox.hartshorn.util.introspect.TypeConstructorsIntrospector;
@@ -29,8 +23,17 @@ import org.dockbox.hartshorn.util.introspect.TypeParametersIntrospector;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ConverterIntrospectionHelper {
 
@@ -40,7 +43,7 @@ public class ConverterIntrospectionHelper {
     ) {
         return createIntrospectorForCollection(type,
             supplier,
-            capacity -> Assertions.fail("Unexpected call to capacity constructor"));
+                _ -> fail("Unexpected call to capacity constructor"));
     }
 
     public static <T extends Collection<?>> Introspector createIntrospectorForCollection(
@@ -74,16 +77,14 @@ public class ConverterIntrospectionHelper {
     ) {
         try {
             Constructor<T> defaultConstructor = type.getConstructor();
-            Assertions.assertNotNull(defaultConstructor);
+            assertThat(defaultConstructor).isNotNull();
 
             ConstructorView<T> constructorView = Mockito.mock(ConstructorView.class);
             Mockito.when(constructorView.constructor()).thenReturn(Option.of(defaultConstructor));
-            try {
-                Mockito.when(constructorView.create()).thenAnswer(invocation -> supplier.get());
-            }
-            catch (Throwable throwable) {
-                Assertions.fail("On-going stub yielded an unexpected exception", throwable);
-            }
+            assertThatCode(() -> {
+                Mockito.when(constructorView.create()).thenAnswer(_ -> supplier.get());
+            }).withFailMessage("On-going stub yielded an unexpected exception")
+                    .doesNotThrowAnyException();
 
             Mockito.when(constructors.defaultConstructor()).thenReturn(Option.of(constructorView));
         }
@@ -99,17 +100,15 @@ public class ConverterIntrospectionHelper {
     ) {
         try {
             Constructor<T> capacityConstructor = type.getConstructor(int.class);
-            Assertions.assertNotNull(capacityConstructor);
+            assertThat(capacityConstructor).isNotNull();
 
             ConstructorView<T> constructorView = Mockito.mock(ConstructorView.class);
             Mockito.when(constructorView.constructor()).thenReturn(Option.of(capacityConstructor));
-            try {
+            assertThatCode(() -> {
                 Mockito.when(constructorView.create(Mockito.anyInt()))
                     .thenAnswer(invocation -> supplier.apply((int) invocation.getArguments()[0]));
-            }
-            catch (Throwable throwable) {
-                Assertions.fail("On-going stub yielded an unexpected exception", throwable);
-            }
+            }).withFailMessage("On-going stub yielded an unexpected exception")
+                    .doesNotThrowAnyException();
 
             Mockito.when(constructors.withParameters(int.class))
                 .thenReturn(Option.of(constructorView));

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConverterTests.java
@@ -17,19 +17,20 @@
 package test.org.dockbox.hartshorn.introspect.convert;
 
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConverterTests {
 
     @Test
-    void testConverterChainingFollowsCorrectOrder() {
+    void converterChainingFollowsCorrectOrder() {
         Converter<String, Byte> converter = ((Converter<String, Double>) Double::parseDouble)
             .andThen(Double::longValue)
             .andThen(Long::intValue)
             .andThen(Integer::byteValue);
 
         byte result = converter.convert("1.0");
-        Assertions.assertEquals((byte) 1, result);
+        assertThat(result).isOne();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConvertibleTypePairTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ConvertibleTypePairTests.java
@@ -18,34 +18,38 @@ package test.org.dockbox.hartshorn.introspect.convert;
 
 import org.dockbox.hartshorn.util.introspect.convert.ConvertibleTypePair;
 import org.dockbox.hartshorn.util.introspect.convert.Null;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class ConvertibleTypePairTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class ConvertibleTypePairTests {
 
     @Test
-    void testNullTargetTypeIsRejected() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> ConvertibleTypePair.of(String.class, null));
+    void nullTargetTypeIsRejected() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ConvertibleTypePair.of(String.class, null));
     }
 
     @Test
-    void testNonNullTypesAreAccepted() {
-        Assertions.assertDoesNotThrow(() -> ConvertibleTypePair.of(String.class, String.class));
+    void nonNullTypesAreAccepted() {
+        assertThatCode(() -> ConvertibleTypePair.of(String.class, String.class))
+                .doesNotThrowAnyException();
     }
 
     @Test
-    void testNullSourceTypeIsNullableType() {
+    void nullSourceTypeIsNullableType() {
         // Separate test, as annotations cannot supply null values
-        this.testSourceTypeIsNullableType(null);
+        this.sourceTypeIsNullableType(null);
     }
 
     @ParameterizedTest
     @ValueSource(classes = {void.class, Void.class})
-    void testSourceTypeIsNullableType(Class<?> type) {
+    void sourceTypeIsNullableType(Class<?> type) {
         ConvertibleTypePair typePair = ConvertibleTypePair.of(type, String.class);
-        Assertions.assertSame(Null.TYPE, typePair.sourceType());
+        assertThat(typePair.sourceType()).isSameAs(Null.TYPE);
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToArrayConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToArrayConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,129 +18,130 @@ package test.org.dockbox.hartshorn.introspect.convert;
 
 import org.dockbox.hartshorn.util.introspect.convert.GenericConverter;
 import org.dockbox.hartshorn.util.introspect.convert.support.ObjectToArrayConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ObjectToArrayConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObjectToArrayConverterTests {
 
     @Test
-    void testNonNullElementCanBeConverted() {
+    void nonNullElementCanBeConverted() {
         String element = "test";
         GenericConverter converter = new ObjectToArrayConverter();
         Object converted = converter.convert(element, Object.class, Object[].class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Object[]);
-        Assertions.assertEquals(1, ((Object[]) converted).length);
-        Assertions.assertEquals(element, ((Object[]) converted)[0]);
+        assertThat(converted).isNotNull();
+        assertThat((converted instanceof Object[])).isTrue();
+        assertThat(((Object[]) converted).length).isOne();
+        assertThat(((Object[]) converted)[0]).isEqualTo(element);
     }
 
     @Test
-    void testElementTypeIsRetained() {
+    void elementTypeIsRetained() {
         String element = "test";
         GenericConverter converter = new ObjectToArrayConverter();
         Object converted = converter.convert(element, String.class, String[].class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof String[]);
-        Assertions.assertEquals(1, ((String[]) converted).length);
-        Assertions.assertEquals(element, ((String[]) converted)[0]);
+        assertThat(converted).isNotNull();
+        assertThat((converted instanceof String[])).isTrue();
+        assertThat(((String[]) converted).length).isOne();
+        assertThat(((String[]) converted)[0]).isEqualTo(element);
     }
 
     @Test
-    void testNullElementCanBeConverted() {
+    void nullElementCanBeConverted() {
         Object element = null;
         GenericConverter converter = new ObjectToArrayConverter();
         Object converted = converter.convert(element, Object.class, Object[].class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Object[]);
-        Assertions.assertEquals(1, ((Object[]) converted).length);
-        Assertions.assertNull(((Object[]) converted)[0]);
+        assertThat(converted).isNotNull();
+        assertThat((converted instanceof Object[])).isTrue();
+        assertThat(((Object[]) converted).length).isOne();
+        assertThat(((Object[]) converted)[0]).isNull();
     }
 
     @Test
-    void testPrimitiveIntCanBeConverted() {
+    void primitiveIntCanBeConverted() {
         int element = 1;
         GenericConverter converter = new ObjectToArrayConverter();
         Object converted = converter.convert(element, int.class, int[].class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof int[]);
-        Assertions.assertEquals(1, ((int[]) converted).length);
-        Assertions.assertEquals(element, ((int[]) converted)[0]);
+        assertThat(converted).isNotNull();
+        assertThat((converted instanceof int[])).isTrue();
+        assertThat(((int[]) converted).length).isOne();
+        assertThat(((int[]) converted)[0]).isEqualTo(element);
     }
 
     @Test
-    void testPrimitiveLongCanBeConverted() {
+    void primitiveLongCanBeConverted() {
         long element = 1L;
         GenericConverter converter = new ObjectToArrayConverter();
         Object converted = converter.convert(element, long.class, long[].class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof long[]);
-        Assertions.assertEquals(1, ((long[]) converted).length);
-        Assertions.assertEquals(element, ((long[]) converted)[0]);
+        assertThat(converted).isNotNull();
+        assertThat((converted instanceof long[])).isTrue();
+        assertThat(((long[]) converted).length).isOne();
+        assertThat(((long[]) converted)[0]).isEqualTo(element);
     }
 
     @Test
-    void testPrimitiveShortCanBeConverted() {
+    void primitiveShortCanBeConverted() {
         short element = 1;
         GenericConverter converter = new ObjectToArrayConverter();
         Object converted = converter.convert(element, short.class, short[].class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof short[]);
-        Assertions.assertEquals(1, ((short[]) converted).length);
-        Assertions.assertEquals(element, ((short[]) converted)[0]);
+        assertThat(converted).isNotNull();
+        assertThat((converted instanceof short[])).isTrue();
+        assertThat(((short[]) converted).length).isOne();
+        assertThat(((short[]) converted)[0]).isEqualTo(element);
     }
 
     @Test
-    void testPrimitiveByteCanBeConverted() {
+    void primitiveByteCanBeConverted() {
         byte element = 1;
         GenericConverter converter = new ObjectToArrayConverter();
         Object converted = converter.convert(element, byte.class, byte[].class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof byte[]);
-        Assertions.assertEquals(1, ((byte[]) converted).length);
-        Assertions.assertEquals(element, ((byte[]) converted)[0]);
+        assertThat(converted).isNotNull();
+        assertThat((converted instanceof byte[])).isTrue();
+        assertThat(((byte[]) converted).length).isOne();
+        assertThat(((byte[]) converted)[0]).isEqualTo(element);
     }
 
     @Test
-    void testPrimitiveFloatCanBeConverted() {
+    void primitiveFloatCanBeConverted() {
         float element = 1.0F;
         GenericConverter converter = new ObjectToArrayConverter();
         Object converted = converter.convert(element, float.class, float[].class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof float[]);
-        Assertions.assertEquals(1, ((float[]) converted).length);
-        Assertions.assertEquals(element, ((float[]) converted)[0]);
+        assertThat(converted).isNotNull();
+        assertThat((converted instanceof float[])).isTrue();
+        assertThat(((float[]) converted).length).isOne();
+        assertThat(((float[]) converted)[0]).isEqualTo(element);
     }
 
     @Test
-    void testPrimitiveDoubleCanBeConverted() {
+    void primitiveDoubleCanBeConverted() {
         double element = 1.0D;
         GenericConverter converter = new ObjectToArrayConverter();
         Object converted = converter.convert(element, double.class, double[].class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof double[]);
-        Assertions.assertEquals(1, ((double[]) converted).length);
-        Assertions.assertEquals(element, ((double[]) converted)[0]);
+        assertThat(converted).isNotNull();
+        assertThat((converted instanceof double[])).isTrue();
+        assertThat(((double[]) converted).length).isOne();
+        assertThat(((double[]) converted)[0]).isEqualTo(element);
     }
 
     @Test
-    void testPrimitiveCharCanBeConverted() {
+    void primitiveCharCanBeConverted() {
         char element = 'a';
         GenericConverter converter = new ObjectToArrayConverter();
         Object converted = converter.convert(element, char.class, char[].class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof char[]);
-        Assertions.assertEquals(1, ((char[]) converted).length);
-        Assertions.assertEquals(element, ((char[]) converted)[0]);
+        assertThat(converted).isNotNull();
+        assertThat((converted instanceof char[])).isTrue();
+        assertThat(((char[]) converted).length).isOne();
+        assertThat(((char[]) converted)[0]).isEqualTo(element);
     }
 
     @Test
-    void testPrimitiveBooleanCanBeConverted() {
+    void primitiveBooleanCanBeConverted() {
         boolean element = true;
         GenericConverter converter = new ObjectToArrayConverter();
         Object converted = converter.convert(element, boolean.class, boolean[].class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof boolean[]);
-        Assertions.assertEquals(1, ((boolean[]) converted).length);
-        Assertions.assertEquals(element, ((boolean[]) converted)[0]);
+        assertThat(converted).isNotNull();
+        assertThat((converted instanceof boolean[])).isTrue();
+        assertThat(((boolean[]) converted).length).isOne();
+        assertThat(((boolean[]) converted)[0]).isEqualTo(element);
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToCollectionConverterFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToCollectionConverterFactoryTests.java
@@ -16,41 +16,44 @@
 
 package test.org.dockbox.hartshorn.introspect.convert;
 
-import java.util.Collection;
-import java.util.Set;
-
-import org.dockbox.hartshorn.util.collections.CollectionUtilities;
-import org.dockbox.hartshorn.util.types.TypeUtils;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.ConverterFactory;
 import org.dockbox.hartshorn.util.introspect.convert.support.ObjectToCollectionConverterFactory;
-import org.junit.jupiter.api.Assertions;
+import org.dockbox.hartshorn.util.types.TypeUtils;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("rawtypes")
-public class ObjectToCollectionConverterFactoryTests {
+import java.util.Collection;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObjectToCollectionConverterFactoryTests {
 
     @Test
-    void testNonNullElementCanBeConverted() {
+    void nonNullElementCanBeConverted() {
         String element = "test";
         Converter<Object, Set<String>> converter = createConverter();
         Object converted = converter.convert(element);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Set);
-        Assertions.assertEquals(1, ((Collection) converted).size());
-        Assertions.assertEquals(element, CollectionUtilities.first((Iterable) converted));
+        assertThat(converted).isInstanceOf(Set.class)
+                .asInstanceOf(InstanceOfAssertFactories.set(String.class))
+                .hasSize(1)
+                .first()
+                .isEqualTo(element);
     }
 
     @Test
-    void testPrimitiveCanBeConverted() {
+    void primitiveCanBeConverted() {
         int element = 1;
         Converter<Object, Set<String>> converter = createConverter();
         Object converted = converter.convert(element);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Set);
-        Assertions.assertEquals(1, ((Collection) converted).size());
-        Assertions.assertEquals(element, CollectionUtilities.first((Iterable) converted));
+        assertThat(converted)
+                .isInstanceOf(Set.class)
+                .asInstanceOf(InstanceOfAssertFactories.set(int.class))
+                .hasSize(1)
+                .first()
+                .isEqualTo(element);
     }
 
     private static Converter<Object, Set<String>> createConverter() {

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToOptionConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToOptionConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,33 +16,36 @@
 
 package test.org.dockbox.hartshorn.introspect.convert;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.support.ObjectToOptionConverter;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @SuppressWarnings("rawtypes")
-public class ObjectToOptionConverterTests {
+class ObjectToOptionConverterTests {
 
     @Test
-    void testNonNullElementConvertsToPresentOption() {
+    void nonNullElementConvertsToPresentOption() {
         String element = "test";
         Converter<Object, Option<?>> converter = new ObjectToOptionConverter();
         Object converted = converter.convert(element);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Option);
-        Assertions.assertTrue(((Option) converted).present());
-        Assertions.assertEquals(element, ((Option) converted).get());
+        assertThat(converted)
+                .asInstanceOf(InstanceOfAssertFactories.type(Option.class))
+                .matches(Option::present)
+                .extracting(Option::get)
+                .isEqualTo(element);
     }
 
     @Test
-    void testNullElementConvertsToEmptyOption() {
+    void nullElementConvertsToEmptyOption() {
         Object element = null;
         Converter<Object, Option<?>> converter = new ObjectToOptionConverter();
         Object converted = converter.convert(element);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Option);
-        Assertions.assertFalse(((Option) converted).present());
+        assertThat(converted)
+                .asInstanceOf(InstanceOfAssertFactories.type(Option.class))
+                .matches(Option::absent);
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToOptionalConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToOptionalConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,34 +16,34 @@
 
 package test.org.dockbox.hartshorn.introspect.convert;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.support.ObjectToOptionalConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @SuppressWarnings("rawtypes")
-public class ObjectToOptionalConverterTests {
+class ObjectToOptionalConverterTests {
 
     @Test
-    void testNonNullElementConvertsToPresentOptional() {
+    void nonNullElementConvertsToPresentOptional() {
         String element = "test";
         Converter<Object, Optional<?>> converter = new ObjectToOptionalConverter();
         Object converted = converter.convert(element);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Optional);
-        Assertions.assertTrue(((Optional) converted).isPresent());
-        Assertions.assertEquals(element, ((Optional) converted).get());
+        assertThat(converted)
+            .asInstanceOf(InstanceOfAssertFactories.optional(String.class)).hasValue(element);
     }
 
     @Test
-    void testNullElementConvertsToEmptyOptional() {
+    void nullElementConvertsToEmptyOptional() {
         Object element = null;
         Converter<Object, Optional<?>> converter = new ObjectToOptionalConverter();
         Object converted = converter.convert(element);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Optional);
-        Assertions.assertFalse(((Optional) converted).isPresent());
+        assertThat(converted)
+                .asInstanceOf(InstanceOfAssertFactories.optional(String.class))
+                .isEmpty();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToStringConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToStringConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,49 +18,42 @@ package test.org.dockbox.hartshorn.introspect.convert;
 
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.support.ObjectToStringConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ObjectToStringConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObjectToStringConverterTests {
 
     @Test
-    void testNullCanBeConverted() {
+    void nullCanBeConverted() {
         Object element = null;
         Converter<Object, String> converter = new ObjectToStringConverter();
         Object converted = converter.convert(element);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof String);
-        Assertions.assertEquals("null", converted);
+        assertThat(converted).isEqualTo("null");
     }
 
     @Test
-    void testStringElementCanBeConvertedAndNotEscaped() {
+    void stringElementCanBeConvertedAndNotEscaped() {
         String element = "test";
         Converter<Object, String> converter = new ObjectToStringConverter();
         Object converted = converter.convert(element);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof String);
-        Assertions.assertEquals(element, converted);
+        assertThat(converted).isEqualTo(element);
     }
 
     @Test
-    void testNonNullElementCanBeConverted() {
+    void nonNullElementCanBeConverted() {
         Object element = new Object();
         Converter<Object, String> converter = new ObjectToStringConverter();
         Object converted = converter.convert(element);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof String);
-        Assertions.assertEquals(element.toString(), converted);
+        assertThat(converted).isEqualTo(element.toString());
     }
 
     @Test
-    void testToStringIsUsedForObjects() {
+    void toStringIsUsedForObjects() {
         Object element = new TestClass("test");
         Converter<Object, String> converter = new ObjectToStringConverter();
         Object converted = converter.convert(element);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof String);
-        Assertions.assertEquals("{toStringResult:test}", converted);
+        assertThat(converted).isEqualTo("{toStringResult:test}");
     }
 
     private record TestClass(String test) {

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToVoidConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/ObjectToVoidConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,40 +19,41 @@ package test.org.dockbox.hartshorn.introspect.convert;
 import org.dockbox.hartshorn.util.introspect.convert.ConditionalConverter;
 import org.dockbox.hartshorn.util.introspect.convert.GenericConverter;
 import org.dockbox.hartshorn.util.introspect.convert.support.ObjectToVoidConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ObjectToVoidConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObjectToVoidConverterTests {
 
     @Test
-    void testCanConvertPrimitive() {
+    void canConvertPrimitive() {
         ConditionalConverter converter = new ObjectToVoidConverter();
-        Assertions.assertTrue(converter.canConvert(null, void.class));
+        assertThat(converter.canConvert(null, void.class)).isTrue();
     }
 
     @Test
-    void testCanConvertPrimitiveWrapper() {
+    void canConvertPrimitiveWrapper() {
         ConditionalConverter converter = new ObjectToVoidConverter();
-        Assertions.assertTrue(converter.canConvert(null, Void.class));
+        assertThat(converter.canConvert(null, Void.class)).isTrue();
     }
 
     @Test
-    void testCanConvertPrimitiveType() {
+    void canConvertPrimitiveType() {
         ConditionalConverter converter = new ObjectToVoidConverter();
-        Assertions.assertTrue(converter.canConvert(null, Void.TYPE));
+        assertThat(converter.canConvert(null, Void.TYPE)).isTrue();
     }
 
     @Test
-    void testVoidIsAlwaysNull() {
+    void voidIsAlwaysNull() {
         GenericConverter converter = new ObjectToVoidConverter();
 
-        Assertions.assertNull(converter.convert(null, Object.class, void.class));
-        Assertions.assertNull(converter.convert("test", Object.class, void.class));
+        assertThat(converter.convert(null, Object.class, void.class)).isNull();
+        assertThat(converter.convert("test", Object.class, void.class)).isNull();
 
-        Assertions.assertNull(converter.convert(null, Object.class, Void.class));
-        Assertions.assertNull(converter.convert("test", Object.class, Void.class));
+        assertThat(converter.convert(null, Object.class, Void.class)).isNull();
+        assertThat(converter.convert("test", Object.class, Void.class)).isNull();
 
-        Assertions.assertNull(converter.convert(null, Object.class, Void.TYPE));
-        Assertions.assertNull(converter.convert("test", Object.class, Void.TYPE));
+        assertThat(converter.convert(null, Object.class, Void.TYPE)).isNull();
+        assertThat(converter.convert("test", Object.class, Void.TYPE)).isNull();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionToCollectionConverterFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionToCollectionConverterFactoryTests.java
@@ -20,37 +20,39 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.dockbox.hartshorn.util.collections.CollectionUtilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.dockbox.hartshorn.util.types.TypeUtils;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.ConverterFactory;
 import org.dockbox.hartshorn.util.introspect.convert.support.OptionToCollectionConverterFactory;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class OptionToCollectionConverterFactoryTests {
+class OptionToCollectionConverterFactoryTests {
 
     @Test
-    void testEmptyOptionalConvertsToEmptyCollection() {
+    void emptyOptionalConvertsToEmptyCollection() {
         Converter<Option<?>, ArrayList<String>> converter = createConverter();
         Option<String> option = Option.empty();
 
         Collection<?> converted = converter.convert(option);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted.isEmpty());
+        assertThat(converted).isNotNull();
+        assertThat(converted).isEmpty();
     }
 
     @Test
-    void testPresentOptionalConvertsToCollectionWithElement() {
+    void presentOptionalConvertsToCollectionWithElement() {
         Converter<Option<?>, ArrayList<String>> converter = createConverter();
         Option<String> option = Option.of("test");
 
         Collection<?> converted = converter.convert(option);
-        Assertions.assertNotNull(converted);
-        Assertions.assertFalse(converted.isEmpty());
-        Assertions.assertEquals(1, converted.size());
-        Assertions.assertEquals("test", CollectionUtilities.first(converted));
+        assertThat(converted)
+                .isNotEmpty()
+                .hasSize(1);
+        assertThat(CollectionUtilities.first(converted)).isEqualTo("test");
     }
 
     @SuppressWarnings("NonApiType")

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionToObjectConverterFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionToObjectConverterFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,27 +20,29 @@ import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.ConverterFactory;
 import org.dockbox.hartshorn.util.introspect.convert.support.OptionToObjectConverterFactory;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class OptionToObjectConverterFactoryTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OptionToObjectConverterFactoryTests {
 
     @Test
-    void testPresentOptionConvertsToObject() {
+    void presentOptionConvertsToObject() {
         ConverterFactory<Option<?>, Object> factory = new OptionToObjectConverterFactory();
         Converter<Option<?>, String> converter = factory.create(String.class);
         Option<String> option = Option.of("test");
         String converted = converter.convert(option);
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals("test", converted);
+        assertThat(converted)
+                .isNotNull()
+                .isEqualTo("test");
     }
 
     @Test
-    void testEmptyOptionConvertsToNull() {
+    void emptyOptionConvertsToNull() {
         ConverterFactory<Option<?>, Object> factory = new OptionToObjectConverterFactory();
         Converter<Option<?>, String> converter = factory.create(String.class);
         Option<String> option = Option.empty();
         String converted = converter.convert(option);
-        Assertions.assertNull(converted);
+        assertThat(converted).isNull();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionToOptionalConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionToOptionalConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,31 +16,29 @@
 
 package test.org.dockbox.hartshorn.introspect.convert;
 
-import java.util.Optional;
-
 import org.dockbox.hartshorn.util.introspect.convert.support.OptionToOptionalConverter;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class OptionToOptionalConverterTests {
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OptionToOptionalConverterTests {
 
     @Test
-    void testPresentOptionConvertsToPresentOptional() {
+    void presentOptionConvertsToPresentOptional() {
         OptionToOptionalConverter converter = new OptionToOptionalConverter();
         Option<String> option = Option.of("test");
-        Optional<?> optional = converter.convert(option);
-        Assertions.assertNotNull(optional);
-        Assertions.assertTrue(optional.isPresent());
-        Assertions.assertEquals("test", optional.get());
+        Optional<String> optional = (Optional<String>) converter.convert(option);
+        assertThat(optional).hasValue("test");
     }
 
     @Test
-    void testEmptyOptionConvertsToEmptyOptional() {
+    void emptyOptionConvertsToEmptyOptional() {
         OptionToOptionalConverter converter = new OptionToOptionalConverter();
         Option<String> option = Option.empty();
         Optional<?> optional = converter.convert(option);
-        Assertions.assertNotNull(optional);
-        Assertions.assertFalse(optional.isPresent());
+        assertThat(optional).isEmpty();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionalToCollectionConverterFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionalToCollectionConverterFactoryTests.java
@@ -21,35 +21,37 @@ import java.util.Collection;
 import java.util.Optional;
 
 import org.dockbox.hartshorn.util.collections.CollectionUtilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.ConverterFactory;
 import org.dockbox.hartshorn.util.introspect.convert.support.OptionalToCollectionConverterFactory;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class OptionalToCollectionConverterFactoryTests {
+class OptionalToCollectionConverterFactoryTests {
 
     @Test
-    void testEmptyOptionalConvertsToEmptyCollection() {
+    void emptyOptionalConvertsToEmptyCollection() {
         Converter<Optional<?>, ArrayList> converter = createConverter();
         Optional<String> option = Optional.empty();
 
         Collection<?> converted = converter.convert(option);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted.isEmpty());
+        assertThat(converted).isNotNull();
+        assertThat(converted).isEmpty();
     }
 
     @Test
-    void testPresentOptionalConvertsToCollectionWithElement() {
+    void presentOptionalConvertsToCollectionWithElement() {
         Converter<Optional<?>, ArrayList> converter = createConverter();
         Optional<String> option = Optional.of("test");
 
         Collection<?> converted = converter.convert(option);
-        Assertions.assertNotNull(converted);
-        Assertions.assertFalse(converted.isEmpty());
-        Assertions.assertEquals(1, converted.size());
-        Assertions.assertEquals("test", CollectionUtilities.first(converted));
+        assertThat(converted)
+                .isNotEmpty()
+                .hasSize(1);
+        assertThat(CollectionUtilities.first(converted)).isEqualTo("test");
     }
 
     @SuppressWarnings("NonApiType")

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionalToObjectConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionalToObjectConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,27 +18,29 @@ package test.org.dockbox.hartshorn.introspect.convert;
 
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.support.OptionalToObjectConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-public class OptionalToObjectConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OptionalToObjectConverterTests {
 
     @Test
-    void testPresentOptionalConvertsToObject() {
+    void presentOptionalConvertsToObject() {
         Converter<Optional<?>, Object> converter = new OptionalToObjectConverter();
         Optional<String> option = Optional.of("test");
         Object converted = converter.convert(option);
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals("test", converted);
+        assertThat(converted)
+                .isNotNull()
+                .isEqualTo("test");
     }
 
     @Test
-    void testEmptyOptionalConvertsToNull() {
+    void emptyOptionalConvertsToNull() {
         Converter<Optional<?>, Object> converter = new OptionalToObjectConverter();
         Optional<String> option = Optional.empty();
         Object converted = converter.convert(option);
-        Assertions.assertNull(converted);
+        assertThat(converted).isNull();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionalToOptionConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/OptionalToOptionConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,29 +19,30 @@ package test.org.dockbox.hartshorn.introspect.convert;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.support.OptionalToOptionConverter;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-public class OptionalToOptionConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OptionalToOptionConverterTests {
 
     @Test
-    void testPresentOptionalConvertsToPresentOption() {
+    void presentOptionalConvertsToPresentOption() {
         Converter<Optional<?>, Option<?>> converter = new OptionalToOptionConverter();
         Optional<String> option = Optional.of("test");
         Option<?> converted = converter.convert(option);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted.present());
-        Assertions.assertEquals("test", converted.get());
+        assertThat(converted).isNotNull();
+        assertThat(converted.present()).isTrue();
+        assertThat(converted.get()).isEqualTo("test");
     }
 
     @Test
-    void testEmptyOptionalConvertsToEmptyOption() {
+    void emptyOptionalConvertsToEmptyOption() {
         Converter<Optional<?>, Option<?>> converter = new OptionalToOptionConverter();
         Optional<String> option = Optional.empty();
         Option<?> converted = converter.convert(option);
-        Assertions.assertNotNull(converted);
-        Assertions.assertFalse(converted.present());
+        assertThat(converted).isNotNull();
+        assertThat(converted.present()).isFalse();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/PrimitiveWrapperConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/PrimitiveWrapperConverterTests.java
@@ -16,157 +16,159 @@
 
 package test.org.dockbox.hartshorn.introspect.convert;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.util.introspect.convert.GenericConverter;
 import org.dockbox.hartshorn.util.introspect.convert.support.PrimitiveWrapperConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class PrimitiveWrapperConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PrimitiveWrapperConverterTests {
 
     @Test
-    void testIntToWrapperCanConvert() {
+    void intToWrapperCanConvert() {
         GenericConverter converter = new PrimitiveWrapperConverter();
         Object converted = converter.convert(1, int.class, Integer.class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Integer);
-        Assertions.assertEquals(1, converted);
+        assertThat(converted)
+                .asInstanceOf(InstanceOfAssertFactories.INTEGER)
+                .isOne();
     }
 
     @Test
-    void testLongToWrapperCanConvert() {
+    void longToWrapperCanConvert() {
         GenericConverter converter = new PrimitiveWrapperConverter();
         Object converted = converter.convert(1L, long.class, Long.class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Long);
-        Assertions.assertEquals(1L, converted);
+        assertThat(converted)
+                .asInstanceOf(InstanceOfAssertFactories.LONG)
+                .isOne();
     }
 
     @Test
-    void testDoubleToWrapperCanConvert() {
+    void doubleToWrapperCanConvert() {
         GenericConverter converter = new PrimitiveWrapperConverter();
         Object converted = converter.convert(1.0D, double.class, Double.class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Double);
-        Assertions.assertEquals(1.0D, converted);
+        assertThat(converted)
+                .asInstanceOf(InstanceOfAssertFactories.DOUBLE)
+                .isOne();
     }
 
     @Test
-    void testFloatToWrapperCanConvert() {
+    void floatToWrapperCanConvert() {
         GenericConverter converter = new PrimitiveWrapperConverter();
         Object converted = converter.convert(1.0F, float.class, Float.class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Float);
-        Assertions.assertEquals(1.0F, converted);
+        assertThat(converted)
+                .asInstanceOf(InstanceOfAssertFactories.FLOAT)
+                .isOne();
     }
 
     @Test
-    void testShortToWrapperCanConvert() {
+    void shortToWrapperCanConvert() {
         GenericConverter converter = new PrimitiveWrapperConverter();
         Object converted = converter.convert((short) 1, short.class, Short.class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Short);
-        Assertions.assertEquals((short) 1, converted);
+        assertThat(converted)
+                .asInstanceOf(InstanceOfAssertFactories.SHORT)
+                .isOne();
     }
 
     @Test
-    void testByteToWrapperCanConvert() {
+    void byteToWrapperCanConvert() {
         GenericConverter converter = new PrimitiveWrapperConverter();
         Object converted = converter.convert((byte) 1, byte.class, Byte.class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Byte);
-        Assertions.assertEquals((byte) 1, converted);
+        assertThat(converted)
+                .asInstanceOf(InstanceOfAssertFactories.BYTE)
+                .isOne();
     }
 
     @Test
-    void testBooleanToWrapperCanConvert() {
+    void booleanToWrapperCanConvert() {
         GenericConverter converter = new PrimitiveWrapperConverter();
         Object converted = converter.convert(true, boolean.class, Boolean.class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Boolean);
-        Assertions.assertEquals(true, converted);
+        assertThat(converted)
+                .asInstanceOf(InstanceOfAssertFactories.BOOLEAN)
+                .isTrue();
     }
 
     @Test
-    void testCharToWrapperCanConvert() {
+    void charToWrapperCanConvert() {
         GenericConverter converter = new PrimitiveWrapperConverter();
         Object converted = converter.convert('a', char.class, Character.class);
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted instanceof Character);
-        Assertions.assertEquals('a', converted);
+        assertThat(converted)
+                .asInstanceOf(InstanceOfAssertFactories.CHARACTER)
+                .isEqualTo('a');
     }
 
     @Test
-    void testWrapperToIntCanConvert() {
+    void wrapperToIntCanConvert() {
         PrimitiveWrapperConverter converter = new PrimitiveWrapperConverter();
-        Assertions.assertTrue(converter.canConvert(Integer.valueOf(1), int.class));
+        assertThat(converter.canConvert(Integer.valueOf(1), int.class)).isTrue();
 
         int converted = (int) converter.convert(Integer.valueOf(1), Integer.class, int.class);
-        Assertions.assertEquals(1, converted);
+        assertThat(converted).isOne();
     }
 
     @Test
-    void testWrapperToLongCanConvert() {
+    void wrapperToLongCanConvert() {
         PrimitiveWrapperConverter converter = new PrimitiveWrapperConverter();
-        Assertions.assertTrue(converter.canConvert(Long.valueOf(1L), long.class));
+        assertThat(converter.canConvert(Long.valueOf(1L), long.class)).isTrue();
 
         long converted = (long) converter.convert(Long.valueOf(1L), Long.class, long.class);
-        Assertions.assertEquals(1L, converted);
+        assertThat(converted).isOne();
     }
 
     @Test
-    void testWrapperToDoubleCanConvert() {
+    void wrapperToDoubleCanConvert() {
         PrimitiveWrapperConverter converter = new PrimitiveWrapperConverter();
-        Assertions.assertTrue(converter.canConvert(Double.valueOf(1.0D), double.class));
+        assertThat(converter.canConvert(Double.valueOf(1.0D), double.class)).isTrue();
 
         double converted =
             (double) converter.convert(Double.valueOf(1.0D), Double.class, double.class);
-        Assertions.assertEquals(1.0D, converted);
+        assertThat(converted).isOne();
     }
 
     @Test
-    void testWrapperToFloatCanConvert() {
+    void wrapperToFloatCanConvert() {
         PrimitiveWrapperConverter converter = new PrimitiveWrapperConverter();
-        Assertions.assertTrue(converter.canConvert(Float.valueOf(1.0F), float.class));
+        assertThat(converter.canConvert(Float.valueOf(1.0F), float.class)).isTrue();
 
         float converted = (float) converter.convert(Float.valueOf(1.0F), Float.class, float.class);
-        Assertions.assertEquals(1.0F, converted);
+        assertThat(converted).isOne();
     }
 
     @Test
-    void testWrapperToShortCanConvert() {
+    void wrapperToShortCanConvert() {
         PrimitiveWrapperConverter converter = new PrimitiveWrapperConverter();
-        Assertions.assertTrue(converter.canConvert(Short.valueOf((short) 1), short.class));
+        assertThat(converter.canConvert(Short.valueOf((short) 1), short.class)).isTrue();
 
         short converted =
             (short) converter.convert(Short.valueOf((short) 1), Short.class, short.class);
-        Assertions.assertEquals((short) 1, converted);
+        assertThat(converted).isOne();
     }
 
     @Test
-    void testWrapperToByteCanConvert() {
+    void wrapperToByteCanConvert() {
         PrimitiveWrapperConverter converter = new PrimitiveWrapperConverter();
-        Assertions.assertTrue(converter.canConvert(Byte.valueOf((byte) 1), byte.class));
+        assertThat(converter.canConvert(Byte.valueOf((byte) 1), byte.class)).isTrue();
 
         byte converted = (byte) converter.convert(Byte.valueOf((byte) 1), Byte.class, byte.class);
-        Assertions.assertEquals((byte) 1, converted);
+        assertThat(converted).isOne();
     }
 
     @Test
-    void testWrapperToBooleanCanConvert() {
+    void wrapperToBooleanCanConvert() {
         PrimitiveWrapperConverter converter = new PrimitiveWrapperConverter();
-        Assertions.assertTrue(converter.canConvert(Boolean.TRUE, boolean.class));
+        assertThat(converter.canConvert(Boolean.TRUE, boolean.class)).isTrue();
 
         boolean converted = (boolean) converter.convert(Boolean.TRUE, Boolean.class, boolean.class);
-        Assertions.assertTrue(converted);
+        assertThat(converted).isTrue();
     }
 
     @Test
-    void testWrapperToCharCanConvert() {
+    void wrapperToCharCanConvert() {
         PrimitiveWrapperConverter converter = new PrimitiveWrapperConverter();
-        Assertions.assertTrue(converter.canConvert(Character.valueOf('a'), char.class));
+        assertThat(converter.canConvert(Character.valueOf('a'), char.class)).isTrue();
 
         char converted =
             (char) converter.convert(Character.valueOf('a'), Character.class, char.class);
-        Assertions.assertEquals('a', converted);
+        assertThat(converted).isEqualTo('a');
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToBooleanConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToBooleanConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,32 +17,33 @@
 package test.org.dockbox.hartshorn.introspect.convert;
 
 import org.dockbox.hartshorn.util.introspect.convert.support.StringToBooleanConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class StringToBooleanConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StringToBooleanConverterTests {
 
     @Test
-    void testTrueCanConvert() {
+    void trueCanConvert() {
         StringToBooleanConverter converter = new StringToBooleanConverter();
         Boolean converted = converter.convert("true");
-        Assertions.assertNotNull(converted);
-        Assertions.assertTrue(converted);
+        assertThat(converted)
+                .isTrue();
     }
 
     @Test
-    void testFalseCanConvert() {
+    void falseCanConvert() {
         StringToBooleanConverter converter = new StringToBooleanConverter();
         Boolean converted = converter.convert("false");
-        Assertions.assertNotNull(converted);
-        Assertions.assertFalse(converted);
+        assertThat(converted)
+                .isFalse();
     }
 
     @Test
-    void testNonDefinedValuesConvertToFalse() {
+    void nonDefinedValuesConvertToFalse() {
         StringToBooleanConverter converter = new StringToBooleanConverter();
         Boolean converted = converter.convert("test");
-        Assertions.assertNotNull(converted);
-        Assertions.assertFalse(converted);
+        assertThat(converted)
+                .isFalse();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToCharacterConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToCharacterConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,30 +17,32 @@
 package test.org.dockbox.hartshorn.introspect.convert;
 
 import org.dockbox.hartshorn.util.introspect.convert.support.StringToCharacterConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class StringToCharacterConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StringToCharacterConverterTests {
 
     @Test
-    void testCanConvertLengthOne() {
+    void canConvertLengthOne() {
         StringToCharacterConverter converter = new StringToCharacterConverter();
         Character character = converter.convert("a");
-        Assertions.assertNotNull(character);
-        Assertions.assertEquals('a', character);
+        assertThat(character)
+                .isNotNull()
+                .isEqualTo('a');
     }
 
     @Test
-    void testCanNotConvertLengthZero() {
+    void canNotConvertLengthZero() {
         StringToCharacterConverter converter = new StringToCharacterConverter();
         Character character = converter.convert("");
-        Assertions.assertNull(character);
+        assertThat(character).isNull();
     }
 
     @Test
-    void testNullConvertsToNull() {
+    void nullConvertsToNull() {
         StringToCharacterConverter converter = new StringToCharacterConverter();
         Character character = converter.convert(null);
-        Assertions.assertNull(character);
+        assertThat(character).isNull();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToEnumConverterFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToEnumConverterFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,31 +19,33 @@ package test.org.dockbox.hartshorn.introspect.convert;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.ConverterFactory;
 import org.dockbox.hartshorn.util.introspect.convert.support.StringToEnumConverterFactory;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class StringToEnumConverterFactoryTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StringToEnumConverterFactoryTests {
 
     @Test
-    void testMatchingNameCanConvert() {
+    void matchingNameCanConvert() {
         Converter<String, Color> converter = createConverter();
         Color red = converter.convert("RED");
-        Assertions.assertNotNull(red);
-        Assertions.assertSame(Color.RED, red);
+        assertThat(red)
+                .isNotNull()
+                .isSameAs(Color.RED);
     }
 
     @Test
-    void testMatchingNameIgnoreCaseCanNotConvert() {
+    void matchingNameIgnoreCaseCanNotConvert() {
         Converter<String, Color> converter = createConverter();
         Color red = converter.convert("red");
-        Assertions.assertNull(red);
+        assertThat(red).isNull();
     }
 
     @Test
-    void testNonMatchingNameCanNotConvert() {
+    void nonMatchingNameCanNotConvert() {
         Converter<String, Color> converter = createConverter();
         Color yellow = converter.convert("YELLOW");
-        Assertions.assertNull(yellow);
+        assertThat(yellow).isNull();
     }
 
     private static Converter<String, Color> createConverter() {

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToNumberConverterFactoryTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToNumberConverterFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,272 +19,297 @@ package test.org.dockbox.hartshorn.introspect.convert;
 import org.dockbox.hartshorn.util.introspect.convert.Converter;
 import org.dockbox.hartshorn.util.introspect.convert.ConverterFactory;
 import org.dockbox.hartshorn.util.introspect.convert.support.StringToNumberConverterFactory;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class StringToNumberConverterFactoryTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StringToNumberConverterFactoryTests {
 
     @Test
-    void testValidStringToInteger() {
+    void validStringToInteger() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Integer> converter = factory.create(Integer.class);
         Integer converted = converter.convert("1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testValidStringToLong() {
+    void validStringToLong() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Long> converter = factory.create(Long.class);
         Long converted = converter.convert("1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1L, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testValidStringToFloat() {
+    void validStringToFloat() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Float> converter = factory.create(Float.class);
         Float converted = converter.convert("1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1.0F, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testValidStringToDouble() {
+    void validStringToDouble() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Double> converter = factory.create(Double.class);
         Double converted = converter.convert("1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1.0D, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testValidStringToShort() {
+    void validStringToShort() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Short> converter = factory.create(Short.class);
         Short converted = converter.convert("1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals((short) 1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testValidStringToByte() {
+    void validStringToByte() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Byte> converter = factory.create(Byte.class);
         Byte converted = converter.convert("1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals((byte) 1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testNegativeStringToInteger() {
+    void negativeStringToInteger() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Integer> converter = factory.create(Integer.class);
         Integer converted = converter.convert("-1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(-1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isEqualTo(-1);
     }
 
     @Test
-    void testNegativeStringToLong() {
+    void negativeStringToLong() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Long> converter = factory.create(Long.class);
         Long converted = converter.convert("-1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(-1L, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isEqualTo(-1L);
     }
 
     @Test
-    void testNegativeStringToFloat() {
+    void negativeStringToFloat() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Float> converter = factory.create(Float.class);
         Float converted = converter.convert("-1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(-1.0F, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isEqualTo(-1.0F);
     }
 
     @Test
-    void testNegativeStringToDouble() {
+    void negativeStringToDouble() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Double> converter = factory.create(Double.class);
         Double converted = converter.convert("-1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(-1.0D, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isEqualTo(-1.0D);
     }
 
     @Test
-    void testNegativeStringToShort() {
+    void negativeStringToShort() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Short> converter = factory.create(Short.class);
         Short converted = converter.convert("-1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals((short) -1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isEqualTo((short) -1);
     }
 
     @Test
-    void testNegativeStringToByte() {
+    void negativeStringToByte() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Byte> converter = factory.create(Byte.class);
         Byte converted = converter.convert("-1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals((byte) -1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isEqualTo((byte) -1);
     }
 
     @Test
-    void testInvalidStringToInteger() {
+    void invalidStringToInteger() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Integer> converter = factory.create(Integer.class);
         Integer converted = converter.convert("a");
-        Assertions.assertNull(converted);
+        assertThat(converted).isNull();
     }
 
     @Test
-    void testInvalidStringToLong() {
+    void invalidStringToLong() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Long> converter = factory.create(Long.class);
         Long converted = converter.convert("a");
-        Assertions.assertNull(converted);
+        assertThat(converted).isNull();
     }
 
     @Test
-    void testInvalidStringToFloat() {
+    void invalidStringToFloat() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Float> converter = factory.create(Float.class);
         Float converted = converter.convert("a");
-        Assertions.assertNull(converted);
+        assertThat(converted).isNull();
     }
 
     @Test
-    void testInvalidStringToDouble() {
+    void invalidStringToDouble() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Double> converter = factory.create(Double.class);
         Double converted = converter.convert("a");
-        Assertions.assertNull(converted);
+        assertThat(converted).isNull();
     }
 
     @Test
-    void testInvalidStringToShort() {
+    void invalidStringToShort() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Short> converter = factory.create(Short.class);
         Short converted = converter.convert("a");
-        Assertions.assertNull(converted);
+        assertThat(converted).isNull();
     }
 
     @Test
-    void testInvalidStringToByte() {
+    void invalidStringToByte() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Byte> converter = factory.create(Byte.class);
         Byte converted = converter.convert("a");
-        Assertions.assertNull(converted);
+        assertThat(converted).isNull();
     }
 
     @Test
-    void testHexadecimalStringToInteger() {
+    void hexadecimalStringToInteger() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Integer> converter = factory.create(Integer.class);
         Integer converted = converter.convert("0x1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testHexadecimalStringToLong() {
+    void hexadecimalStringToLong() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Long> converter = factory.create(Long.class);
         Long converted = converter.convert("0x1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1L, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testHexadecimalStringToFloat() {
+    void hexadecimalStringToFloat() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Float> converter = factory.create(Float.class);
         Float converted = converter.convert("0x1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1.0F, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testHexadecimalStringToDouble() {
+    void hexadecimalStringToDouble() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Double> converter = factory.create(Double.class);
         Double converted = converter.convert("0x1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1.0D, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testHexadecimalStringToShort() {
+    void hexadecimalStringToShort() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Short> converter = factory.create(Short.class);
         Short converted = converter.convert("0x1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals((short) 1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testHexadecimalStringToByte() {
+    void hexadecimalStringToByte() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Byte> converter = factory.create(Byte.class);
         Byte converted = converter.convert("0x1");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals((byte) 1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testOctalStringToInteger() {
+    void octalStringToInteger() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Integer> converter = factory.create(Integer.class);
         Integer converted = converter.convert("01");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testOctalStringToLong() {
+    void octalStringToLong() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Long> converter = factory.create(Long.class);
         Long converted = converter.convert("01");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1L, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testOctalStringToFloat() {
+    void octalStringToFloat() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Float> converter = factory.create(Float.class);
         Float converted = converter.convert("01");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1.0F, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testOctalStringToDouble() {
+    void octalStringToDouble() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Double> converter = factory.create(Double.class);
         Double converted = converter.convert("01");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals(1.0D, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testOctalStringToShort() {
+    void octalStringToShort() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Short> converter = factory.create(Short.class);
         Short converted = converter.convert("01");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals((short) 1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 
     @Test
-    void testOctalStringToByte() {
+    void octalStringToByte() {
         ConverterFactory<String, Number> factory = new StringToNumberConverterFactory();
         Converter<String, Byte> converter = factory.create(Byte.class);
         Byte converted = converter.convert("01");
-        Assertions.assertNotNull(converted);
-        Assertions.assertEquals((byte) 1, converted);
+        assertThat(converted)
+                .isNotNull()
+                .isOne();
     }
 }

--- a/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToUUIDConverterTests.java
+++ b/hartshorn-introspect/src/test/java/test/org/dockbox/hartshorn/introspect/convert/StringToUUIDConverterTests.java
@@ -17,40 +17,41 @@
 package test.org.dockbox.hartshorn.introspect.convert;
 
 import org.dockbox.hartshorn.util.introspect.convert.support.StringToUUIDConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class StringToUUIDConverterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StringToUUIDConverterTests {
 
     @Test
-    void testValidUUIDFormatCanConvert() {
+    void validUUIDFormatCanConvert() {
         StringToUUIDConverter converter = new StringToUUIDConverter();
         UUID uuid = converter.convert("123e4567-e89b-12d3-a456-426655440000");
-        Assertions.assertNotNull(uuid);
-        Assertions.assertEquals("123e4567-e89b-12d3-a456-426655440000", uuid.toString());
+        assertThat(uuid)
+                .hasToString("123e4567-e89b-12d3-a456-426655440000");
     }
 
     @Test
-    void testShortUUIDCanConvert() {
+    void shortUUIDCanConvert() {
         StringToUUIDConverter converter = new StringToUUIDConverter();
         UUID uuid = converter.convert("1-2-3-4-5");
-        Assertions.assertNotNull(uuid);
-        Assertions.assertEquals("00000001-0002-0003-0004-000000000005", uuid.toString());
+        assertThat(uuid)
+                .hasToString("00000001-0002-0003-0004-000000000005");
     }
 
     @Test
-    void testInvalidUUIDFormatCannotConvert() {
+    void invalidUUIDFormatCannotConvert() {
         StringToUUIDConverter converter = new StringToUUIDConverter();
         UUID uuid = converter.convert("-123e4567-e89b-12d3-a456-426655440000");
-        Assertions.assertNull(uuid);
+        assertThat(uuid).isNull();
     }
 
     @Test
-    void testNullIsNotParsed() {
+    void nullIsNotParsed() {
         StringToUUIDConverter converter = new StringToUUIDConverter();
         UUID uuid = converter.convert(null);
-        Assertions.assertNull(uuid);
+        assertThat(uuid).isNull();
     }
 }

--- a/hartshorn-launchpad/pom.xml
+++ b/hartshorn-launchpad/pom.xml
@@ -20,7 +20,7 @@
     TODO: Remove once coverage target of 80% is reached.
      In meantime, increase coverage target whenever possible (to avoid regression).
     -->
-    <coverage.target>71%</coverage.target>
+    <coverage.target>70%</coverage.target>
   </properties>
 
   <dependencies>

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/ApplicationReentryPolicy.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/ApplicationReentryPolicy.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.launchpad;
 
 /**

--- a/hartshorn-launchpad/src/test/java/test/org/dockbox/hartshorn/launchpad/ApplicationBatchingTest.java
+++ b/hartshorn-launchpad/src/test/java/test/org/dockbox/hartshorn/launchpad/ApplicationBatchingTest.java
@@ -23,52 +23,58 @@ import org.dockbox.hartshorn.launchpad.environment.ConfigurableApplicationEnviro
 import org.dockbox.hartshorn.launchpad.launch.StandardApplicationContextFactory;
 import org.dockbox.hartshorn.properties.ValueProperty;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Execution(ExecutionMode.CONCURRENT)
-public class ApplicationBatchingTest {
+class ApplicationBatchingTest {
 
     /**
-     * Test that multiple applications can be created and be active at the same time without interfering with each other.
+     * Test that multiple applications can be created and be active at the same time without
+     * interfering with each other.
      */
     @Disabled("Only for manual testing")
     @RepeatedTest(1)
-    void testApplicationContextBatching(RepetitionInfo repetitionInfo) {
+    void applicationContextBatching(RepetitionInfo repetitionInfo) {
         int currentRepetition = repetitionInfo.getCurrentRepetition();
-        ApplicationContext applicationContext = Assertions.assertDoesNotThrow(() ->
-                HartshornApplication.create(ApplicationBatchingTest.class, builder -> {
+        ApplicationContext applicationContext = HartshornApplication.create(
+                ApplicationBatchingTest.class,
+                builder -> {
                     builder.applicationName("ApplicationBatchingTest-" + currentRepetition);
                     builder.arguments("iteration=" + currentRepetition);
-                    builder.applicationContextFactory(StandardApplicationContextFactory.create(constructor -> {
+                    builder.applicationContextFactory(StandardApplicationContextFactory.create(
+                            constructor -> {
                                 constructor.includeBasePackages(false);
-                                constructor.standaloneComponents(components -> components.add(SimpleComponent.class));
-                                constructor.environment(
-                                        ConfigurableApplicationEnvironment.create(environment -> {
+                                constructor.standaloneComponents(components -> {
+                                    components.add(SimpleComponent.class);
+                                });
+                                constructor.environment(ConfigurableApplicationEnvironment.create(
+                                        environment -> {
                                             environment.enableBatchMode();
                                             environment.disableBanner();
                                         })
                                 );
                             })
                     );
-                }));
+                });
 
-        Assertions.assertNotNull(applicationContext);
+        assertThat(applicationContext).isNotNull();
         Option<ValueProperty> iterationProperty = applicationContext.environment()
                 .propertyRegistry()
                 .get("iteration");
-        Assertions.assertTrue(iterationProperty.present());
+        assertThat(iterationProperty.present()).isTrue();
         Option<String> iterationValue = iterationProperty.get().value();
-        Assertions.assertTrue(iterationValue.present());
-        Assertions.assertEquals(String.valueOf(currentRepetition), iterationValue.get());
+        assertThat(iterationValue.present()).isTrue();
+        assertThat(iterationValue.get()).isEqualTo(String.valueOf(currentRepetition));
 
         SimpleComponent component = applicationContext.get(SimpleComponent.class);
-        Assertions.assertNotNull(component);
-        Assertions.assertSame(applicationContext, component.applicationContext());
+        assertThat(component).isNotNull();
+        assertThat(component.applicationContext()).isSameAs(applicationContext);
     }
 
     public record SimpleComponent(ApplicationContext applicationContext) {

--- a/hartshorn-launchpad/src/test/java/test/org/dockbox/hartshorn/launchpad/ApplicationConfigurerTests.java
+++ b/hartshorn-launchpad/src/test/java/test/org/dockbox/hartshorn/launchpad/ApplicationConfigurerTests.java
@@ -17,6 +17,7 @@
 package test.org.dockbox.hartshorn.launchpad;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.inject.InjectionCapableApplication;
 import org.dockbox.hartshorn.inject.LoggingExceptionHandler;
 import org.dockbox.hartshorn.inject.annotations.Component;
@@ -49,13 +50,10 @@ import org.slf4j.LoggerFactory;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
-public class ApplicationConfigurerTests {
+class ApplicationConfigurerTests {
 
     private static ApplicationContext createApplication(Customizer<HartshornApplicationConfigurer> customizer) {
         return HartshornApplication.createApplication(ApplicationConfigurerTests.class)
@@ -66,81 +64,88 @@ public class ApplicationConfigurerTests {
 
     @Test
     @DisplayName("Customizer should be able to modify arguments provided to the application")
-    void testArgumentsCustomizer() {
+    void argumentsCustomizer() {
         ApplicationContext applicationContext = createApplication(configuration -> {
             configuration.arguments(arguments -> {
                 arguments.add("sample.x.y=z");
             });
         });
         PropertyRegistry propertyRegistry = applicationContext.environment().propertyRegistry();
-        assertTrue(propertyRegistry.contains("sample.x.y"));
+        assertThat(propertyRegistry.contains("sample.x.y")).isTrue();
         String value = propertyRegistry.value("sample.x.y")
             .orElseThrow(() -> new AssertionError("Property not found"));
-        assertEquals("z", value);
+        assertThat(value).isEqualTo("z");
     }
 
     @Test
     @DisplayName("Customizer should be able to modify module activators")
-    void testModuleActivatorsCustomizer() {
+    void moduleActivatorsCustomizer() {
         ApplicationContext applicationContext = createApplication(configuration -> {
             configuration.activators(activators -> {
                 activators.add(TypeUtils.annotation(UseSampleActivator.class));
             });
         });
-        assertTrue(applicationContext.activators().hasActivator(UseSampleActivator.class));
+        assertThat(applicationContext.activators().hasActivator(UseSampleActivator.class)).isTrue();
     }
 
     @Test
     @DisplayName("Customizer should be able to modify default pre-processors")
-    void testPreProcessorsCustomizer() {
+    void preProcessorsCustomizer() {
         SamplePreProcessor processor = new SamplePreProcessor();
         ApplicationContext applicationContext = createApplication(configuration -> {
             configuration.componentPreProcessors(preProcessors -> {
                 preProcessors.add(processor);
             });
         });
-        ProcessableApplicationContext processableApplicationContext =
-            assertInstanceOf(ProcessableApplicationContext.class, applicationContext);
-        MultiMap<Integer, ComponentPreProcessor> processors =
-            processableApplicationContext.defaultProvider()
-                .processorRegistry().preProcessors();
-        assertTrue(processors.containsValue(processor));
+        ProcessableApplicationContext processableApplicationContext = assertThat(applicationContext)
+                .asInstanceOf(InstanceOfAssertFactories.type(ProcessableApplicationContext.class))
+                .actual();
+        MultiMap<Integer, ComponentPreProcessor> processors = processableApplicationContext
+                .defaultProvider()
+                .processorRegistry()
+                .preProcessors();
+        assertThat(processors.containsValue(processor)).isTrue();
     }
 
     @Test
     @DisplayName("Customizer should be able to modify default post-processors")
-    void testPostProcessorsCustomizer() {
+    void postProcessorsCustomizer() {
         SamplePostProcessor processor = new SamplePostProcessor();
         ApplicationContext applicationContext = createApplication(configuration -> {
             configuration.componentPostProcessors(postProcessors -> {
                 postProcessors.add(processor);
             });
         });
-        DelegatingApplicationContext processableApplicationContext =
-            assertInstanceOf(DelegatingApplicationContext.class, applicationContext);
+        DelegatingApplicationContext processableApplicationContext = assertThat(applicationContext)
+                .asInstanceOf(InstanceOfAssertFactories.type(DelegatingApplicationContext.class))
+                .actual();
         ComponentProvider componentProvider = processableApplicationContext.componentProvider();
         PostProcessingComponentProvider postProcessingComponentProvider =
-            assertInstanceOf(PostProcessingComponentProvider.class, componentProvider);
+                assertThat(componentProvider)
+                        .asInstanceOf(InstanceOfAssertFactories.type(
+                                PostProcessingComponentProvider.class
+                        ))
+                        .actual();
         MultiMap<Integer, ComponentPostProcessor> processors =
             postProcessingComponentProvider.processorRegistry().postProcessors();
-        assertTrue(processors.containsValue(processor));
+        assertThat(processors.containsValue(processor)).isTrue();
     }
 
     @Test
     @DisplayName("Customizer should be able to modify standalone components")
-    void testStandaloneComponentsCustomizer() {
+    void standaloneComponentsCustomizer() {
         ApplicationContext applicationContext = createApplication(configuration -> {
             configuration.standaloneComponents(components -> {
                 components.add(DummyUnmanagedComponent.class);
             });
         });
         ComponentRegistry componentRegistry = applicationContext.get(ComponentRegistry.class);
-        assertTrue(componentRegistry.container(DummyUnmanagedComponent.class).present());
+        assertThat(componentRegistry.container(DummyUnmanagedComponent.class).present()).isTrue();
     }
 
     @Test
     @DisplayName("Customizer should be able to modify scanned packages")
-    void testScannedPackagesCustomizer() {
+    void scannedPackagesCustomizer() {
         final String dummyPackage = "test.dummy.package";
         ApplicationContext applicationContext = createApplication(configuration -> {
             configuration.scanPackages(packages -> {
@@ -149,7 +154,7 @@ public class ApplicationConfigurerTests {
         });
         Option<TypeReferenceCollectorContext> collectorContextCandidate =
             applicationContext.firstContext(TypeReferenceCollectorContext.class);
-        assertTrue(collectorContextCandidate.present());
+        assertThat(collectorContextCandidate.present()).isTrue();
 
         TypeReferenceCollectorContext collectorContext = collectorContextCandidate.get();
         Set<String> packages = collectorContext.collectors().stream()
@@ -157,12 +162,12 @@ public class ApplicationConfigurerTests {
             .map(ClasspathTypeReferenceCollector.class::cast)
             .map(ClasspathTypeReferenceCollector::packageName)
             .collect(Collectors.toSet());
-        assertTrue(packages.contains(dummyPackage));
+        assertThat(packages).contains(dummyPackage);
     }
 
     @Test
     @DisplayName("Customizer should be able to enable banner printing")
-    void testBannerPrintingCustomizer() {
+    void bannerPrintingCustomizer() {
         Logger logger = LoggerFactory.getLogger(ApplicationConfigurerTests.class);
         OutputCaptureAppender appender = OutputCaptureAppender.registerForLogger(logger);
         createApplication(applicationConfigurer -> {
@@ -182,7 +187,7 @@ public class ApplicationConfigurerTests {
 
     @Test
     @DisplayName("Customizer should be able to disable banner printing")
-    void testBannerPrintingDisabledCustomizer() {
+    void bannerPrintingDisabledCustomizer() {
         Logger logger = LoggerFactory.getLogger(ApplicationConfigurerTests.class);
         OutputCaptureAppender appender = OutputCaptureAppender.registerForLogger(logger);
         createApplication(applicationConfigurer -> {
@@ -201,92 +206,101 @@ public class ApplicationConfigurerTests {
 
     @Test
     @DisplayName("Customizer should be able to enable batch mode")
-    void testBatchModeCustomizer() {
+    void batchModeCustomizer() {
         ApplicationContext applicationContext =
             createApplication(HartshornApplicationConfigurer::enableBatchMode);
-        assertTrue(applicationContext.environment().isBatchMode());
+        assertThat(applicationContext.environment().isBatchMode()).isTrue();
     }
 
     @Test
     @DisplayName("Customizer should be able to disable batch mode")
-    void testBatchModeDisabledCustomizer() {
+    void batchModeDisabledCustomizer() {
         ApplicationContext applicationContext =
             createApplication(HartshornApplicationConfigurer::disableBatchMode);
-        assertFalse(applicationContext.environment().isBatchMode());
+        assertThat(applicationContext.environment().isBatchMode()).isFalse();
     }
 
     @Test
     @DisplayName("Customizer should be able to enable strict mode")
-    void testStrictModeCustomizer() {
+    void strictModeCustomizer() {
         ApplicationContext applicationContext =
             createApplication(HartshornApplicationConfigurer::enableStrictMode);
-        assertTrue(applicationContext.environment().isStrictMode());
+        assertThat(applicationContext.environment().isStrictMode()).isTrue();
     }
 
     @Test
     @DisplayName("Customizer should be able to disable strict mode")
-    void testStrictModeDisabledCustomizer() {
+    void strictModeDisabledCustomizer() {
         ApplicationContext applicationContext =
             createApplication(HartshornApplicationConfigurer::disableStrictMode);
-        assertFalse(applicationContext.environment().isStrictMode());
+        assertThat(applicationContext.environment().isStrictMode()).isFalse();
     }
 
     @Test
     @DisplayName("Customizer should be able to enable stacktraces")
-    void testShowStacktracesCustomizer() {
+    void showStacktracesCustomizer() {
         ApplicationContext applicationContext =
             createApplication(HartshornApplicationConfigurer::showStacktraces);
         ConfigurableApplicationEnvironment configurableApplicationEnvironment =
-            assertInstanceOf(ConfigurableApplicationEnvironment.class,
-                applicationContext.environment());
+            assertThat(applicationContext.environment())
+                    .asInstanceOf(InstanceOfAssertFactories.type(ConfigurableApplicationEnvironment.class))
+                    .actual();
         LoggingExceptionHandler exceptionHandler =
-            assertInstanceOf(LoggingExceptionHandler.class,
-                configurableApplicationEnvironment.exceptionHandler());
-        assertTrue(exceptionHandler.printStackTraces());
+            assertThat(configurableApplicationEnvironment.exceptionHandler())
+                    .asInstanceOf(InstanceOfAssertFactories.type(LoggingExceptionHandler.class))
+                    .actual();
+        assertThat(exceptionHandler.printStackTraces()).isTrue();
     }
 
     @Test
     @DisplayName("Customizer should be able to disable stacktraces")
-    void testHideStacktracesCustomizer() {
-        ApplicationContext applicationContext =
-            createApplication(HartshornApplicationConfigurer::hideStacktraces);
+    void hideStacktracesCustomizer() {
+        ApplicationContext applicationContext = createApplication(
+                HartshornApplicationConfigurer::hideStacktraces
+        );
+
         ConfigurableApplicationEnvironment configurableApplicationEnvironment =
-            assertInstanceOf(ConfigurableApplicationEnvironment.class,
-                applicationContext.environment());
+            assertThat(applicationContext.environment())
+                    .asInstanceOf(InstanceOfAssertFactories.type(
+                            ConfigurableApplicationEnvironment.class
+                    ))
+                    .actual();
+
         LoggingExceptionHandler exceptionHandler =
-            assertInstanceOf(LoggingExceptionHandler.class,
-                configurableApplicationEnvironment.exceptionHandler());
-        assertFalse(exceptionHandler.printStackTraces());
+            assertThat(configurableApplicationEnvironment.exceptionHandler())
+                    .asInstanceOf(InstanceOfAssertFactories.type(LoggingExceptionHandler.class))
+                    .actual();
+        assertThat(exceptionHandler.printStackTraces()).isFalse();
     }
 
     @Test
     @DisplayName("Customizer should be able to indicate build environment")
-    void testBuildEnvironmentCustomizer() {
+    void buildEnvironmentCustomizer() {
         ApplicationContext applicationContext = createApplication(configuration -> {
             configuration.isBuildEnvironment(true);
         });
-        assertTrue(applicationContext.environment().isBuildEnvironment());
+        assertThat(applicationContext.environment().isBuildEnvironment()).isTrue();
     }
 
     @Test
     @DisplayName("Customizer should be able to indicate non-build environment")
-    void testNonBuildEnvironmentCustomizer() {
+    void nonBuildEnvironmentCustomizer() {
         ApplicationContext applicationContext = createApplication(configuration -> {
             configuration.isBuildEnvironment(false);
         });
-        assertFalse(applicationContext.environment().isBuildEnvironment());
+        assertThat(applicationContext.environment().isBuildEnvironment()).isFalse();
     }
 
     @Test
     @DisplayName("Customizer should be able to modify default bindings")
-    void testDefaultBindingsCustomizer() {
+    void defaultBindingsCustomizer() {
         ApplicationContext applicationContext = createApplication(configuration -> {
             configuration.defaultBindings(bindings -> {
                 bindings.bind(String.class).singleton("test");
             });
         });
         String value = applicationContext.get(String.class);
-        assertEquals("test", value);
+        assertThat(value).isEqualTo("test");
     }
 
     @ModuleActivator

--- a/hartshorn-launchpad/src/test/java/test/org/dockbox/hartshorn/launchpad/HartshornApplicationTests.java
+++ b/hartshorn-launchpad/src/test/java/test/org/dockbox/hartshorn/launchpad/HartshornApplicationTests.java
@@ -21,30 +21,31 @@ import org.dockbox.hartshorn.launchpad.InvalidActivationSourceException;
 import test.org.dockbox.hartshorn.launchpad.activators.AbstractActivator;
 import test.org.dockbox.hartshorn.launchpad.activators.InterfaceActivator;
 import test.org.dockbox.hartshorn.launchpad.activators.ValidActivator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class HartshornApplicationTests {
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class HartshornApplicationTests {
 
     @Test
-    void testCreationFailsWithAbstractActivator() {
-        Assertions.assertThrows(InvalidActivationSourceException.class,
-            () -> HartshornApplication.create(AbstractActivator.class));
+    void creationFailsWithAbstractActivator() {
+        assertThatExceptionOfType(InvalidActivationSourceException.class).isThrownBy(() -> HartshornApplication.create(AbstractActivator.class));
     }
 
     @Test
-    void testCreationFailsWithInterfaceActivator() {
-        Assertions.assertThrows(InvalidActivationSourceException.class,
-            () -> HartshornApplication.create(InterfaceActivator.class));
+    void creationFailsWithInterfaceActivator() {
+        assertThatExceptionOfType(InvalidActivationSourceException.class).isThrownBy(() -> HartshornApplication.create(InterfaceActivator.class));
     }
 
     @Test
-    void testCreationSucceedsWithValidActivator() {
-        Assertions.assertDoesNotThrow(() -> HartshornApplication.create(ValidActivator.class));
+    void creationSucceedsWithValidActivator() {
+        assertThatCode(() -> HartshornApplication.create(ValidActivator.class))
+                .doesNotThrowAnyException();
     }
 
     @Test
-    void testCreationSucceedsWithValidDeducedActivator() {
-        Assertions.assertDoesNotThrow(() -> ValidActivator.main());
+    void creationSucceedsWithValidDeducedActivator() {
+        assertThatCode(() -> ValidActivator.main()).doesNotThrowAnyException();
     }
 }

--- a/hartshorn-launchpad/src/test/java/test/org/dockbox/hartshorn/launchpad/resources/ResourcesTests.java
+++ b/hartshorn-launchpad/src/test/java/test/org/dockbox/hartshorn/launchpad/resources/ResourcesTests.java
@@ -18,7 +18,6 @@ package test.org.dockbox.hartshorn.launchpad.resources;
 
 import org.dockbox.hartshorn.launchpad.resources.Resources;
 import org.dockbox.hartshorn.util.collections.CollectionUtilities;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -26,73 +25,71 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Set;
 
-public class ResourcesTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class ResourcesTests {
 
     @Test
-    void testGetResourceURLReturnsValidURL() {
-        URL url = Assertions.assertDoesNotThrow(() -> Resources.getResourceURL("sample.txt"));
-        Assertions.assertNotNull(url);
+    void getResourceURLReturnsValidURL() throws Exception {
+        URL url = Resources.getResourceURL("sample.txt");
+        assertThat(url).isNotNull();
     }
 
     @Test
-    void testGetResourceURLThrowsExceptionWhenResourceNotExists() {
-        IOException exception = Assertions.assertThrows(IOException.class,
-            () -> Resources.getResourceURL("not-exists.txt"));
-        Assertions.assertEquals("Could not find resource not-exists.txt", exception.getMessage());
+    void getResourceURLThrowsExceptionWhenResourceNotExists() {
+        IOException exception = assertThatExceptionOfType(IOException.class)
+                .isThrownBy(() -> Resources.getResourceURL("not-exists.txt"))
+                .actual();
+        assertThat(exception.getMessage()).isEqualTo("Could not find resource not-exists.txt");
     }
 
     @Test
-    void testGetResourceAsFileReturnsValidStream() {
-        InputStream file =
-            Assertions.assertDoesNotThrow(() -> Resources.getResourceAsInputStream("sample.txt"));
-        Assertions.assertNotNull(file);
+    void getResourceAsFileReturnsValidStream() throws Exception {
+        InputStream file = Resources.getResourceAsInputStream("sample.txt");
+        assertThat(file).isNotNull();
     }
 
     @Test
-    void testGetResourceAsFileThrowsExceptionWhenResourceNotExists() {
-        IOException exception = Assertions.assertThrows(IOException.class,
-            () -> Resources.getResourceAsInputStream("not-exists.txt"));
-        Assertions.assertEquals("Could not find resource not-exists.txt", exception.getMessage());
+    void getResourceAsFileThrowsExceptionWhenResourceNotExists() {
+        IOException exception = assertThatExceptionOfType(IOException.class)
+                .isThrownBy(() -> Resources.getResourceAsInputStream("not-exists.txt"))
+                .actual();
+        assertThat(exception.getMessage()).isEqualTo("Could not find resource not-exists.txt");
     }
 
     @Test
-    void testGetResourceURLsReturnsValidURLs() {
-        Set<URL> urls =
-            Assertions.assertDoesNotThrow(() -> Resources.getResourceURLs("sample.txt"));
-        Assertions.assertNotNull(urls);
-        Assertions.assertFalse(urls.isEmpty());
-        Assertions.assertEquals(1, urls.size());
-
-        URL url = CollectionUtilities.first(urls);
-        Assertions.assertNotNull(url);
+    void getResourceURLsReturnsValidURLs() throws Exception {
+        Set<URL> urls = Resources.getResourceURLs("sample.txt");
+        assertThat(urls)
+                .isNotEmpty()
+                .hasSize(1)
+                .first()
+                .isNotNull();
     }
 
     @Test
-    void testGetResourceURLsReturnsEmptyWhenResourceNotExists() {
-        Set<URL> urls =
-            Assertions.assertDoesNotThrow(() -> Resources.getResourceURLs("not-exists.txt"));
-        Assertions.assertNotNull(urls);
-        Assertions.assertTrue(urls.isEmpty());
+    void getResourceURLsReturnsEmptyWhenResourceNotExists() throws Exception {
+        Set<URL> urls = Resources.getResourceURLs("not-exists.txt");
+        assertThat(urls).isNotNull();
+        assertThat(urls).isEmpty();
     }
 
     @Test
-    void testGetResourceAsFilesReturnsValidFiles() {
-        Set<InputStream> files =
-            Assertions.assertDoesNotThrow(() -> Resources.getResourcesAsInputStreams("sample.txt"));
-        Assertions.assertNotNull(files);
-        Assertions.assertFalse(files.isEmpty());
-        Assertions.assertEquals(1, files.size());
+    void getResourceAsFilesReturnsValidFiles() throws Exception {
+        Set<InputStream> files = Resources.getResourcesAsInputStreams("sample.txt");
+        assertThat(files)
+                .isNotEmpty()
+                .hasSize(1);
 
         InputStream file = CollectionUtilities.first(files);
-        Assertions.assertNotNull(file);
+        assertThat(file).isNotNull();
     }
 
     @Test
-    void testGetResourceAsFilesReturnsEmptyWhenResourceNotExists() {
-        Set<InputStream> files =
-            Assertions.assertDoesNotThrow(() -> Resources.getResourcesAsInputStreams(
-                "not-exists.txt"));
-        Assertions.assertNotNull(files);
-        Assertions.assertTrue(files.isEmpty());
+    void getResourceAsFilesReturnsEmptyWhenResourceNotExists() throws Exception {
+        Set<InputStream> files = Resources.getResourcesAsInputStreams("not-exists.txt");
+        assertThat(files).isNotNull();
+        assertThat(files).isEmpty();
     }
 }

--- a/hartshorn-profiles/src/test/java/test/org/dockbox/hartshorn/profiles/ProfileAggregationTests.java
+++ b/hartshorn-profiles/src/test/java/test/org/dockbox/hartshorn/profiles/ProfileAggregationTests.java
@@ -27,25 +27,24 @@ import org.dockbox.hartshorn.properties.MapPropertyRegistry;
 import org.dockbox.hartshorn.properties.SingleConfiguredProperty;
 import org.dockbox.hartshorn.properties.ValueProperty;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ProfileAggregationTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProfileAggregationTests {
 
     @Test
-    void testAggregationWithoutProfiles() {
+    void aggregationWithoutProfiles() {
         ProfilePropertyRegistryAggregator aggregator =
             new SimpleProfilePropertyRegistryAggregator();
         ProfileRegistry profileRegistry = new ConcurrentProfileRegistry();
-        ProfilePropertyRegistry profilePropertyRegistry = Assertions.assertDoesNotThrow(
-            () -> aggregator.aggregate(profileRegistry)
-        );
-        Assertions.assertTrue(profilePropertyRegistry.keys().isEmpty());
-        Assertions.assertTrue(profilePropertyRegistry.profileRegistry().profiles().isEmpty());
+        ProfilePropertyRegistry profilePropertyRegistry = aggregator.aggregate(profileRegistry);
+        assertThat(profilePropertyRegistry.keys()).isEmpty();
+        assertThat(profilePropertyRegistry.profileRegistry().profiles()).isEmpty();
     }
 
     @Test
-    void testAggregationWithSingleProfile() {
+    void aggregationWithSingleProfile() {
         ProfilePropertyRegistryAggregator aggregator =
             new SimpleProfilePropertyRegistryAggregator();
         ProfileRegistry profileRegistry = new ConcurrentProfileRegistry();
@@ -54,20 +53,18 @@ public class ProfileAggregationTests {
         profile1.propertyRegistry().register(new SingleConfiguredProperty("key", "value1"));
         profileRegistry.register(0, profile1);
 
-        ProfilePropertyRegistry profilePropertyRegistry = Assertions.assertDoesNotThrow(
-            () -> aggregator.aggregate(profileRegistry)
-        );
-        Assertions.assertEquals(1, profilePropertyRegistry.keys().size());
-        Assertions.assertTrue(profilePropertyRegistry.contains("key"));
+        ProfilePropertyRegistry profilePropertyRegistry = aggregator.aggregate(profileRegistry);
+        assertThat(profilePropertyRegistry.keys()).hasSize(1);
+        assertThat(profilePropertyRegistry.contains("key")).isTrue();
 
-        Assertions.assertEquals(1, profilePropertyRegistry.profileRegistry().profiles().size());
-        Assertions.assertTrue(profilePropertyRegistry.profileRegistry()
+        assertThat(profilePropertyRegistry.profileRegistry().profiles()).hasSize(1);
+        assertThat(profilePropertyRegistry.profileRegistry()
             .profile("profile1")
-            .present());
+            .present()).isTrue();
     }
 
     @Test
-    void testAggregationWithMultipleProfiles_UsesCorrectPriority() {
+    void aggregationWithMultipleProfilesUsesCorrectPriority() {
         ProfilePropertyRegistryAggregator aggregator =
             new SimpleProfilePropertyRegistryAggregator();
         ProfileRegistry profileRegistry = new ConcurrentProfileRegistry();
@@ -82,23 +79,21 @@ public class ProfileAggregationTests {
         profile2.propertyRegistry().register(new SingleConfiguredProperty("key", "value2"));
         profileRegistry.register(1, profile2);
 
-        ProfilePropertyRegistry profilePropertyRegistry = Assertions.assertDoesNotThrow(
-            () -> aggregator.aggregate(profileRegistry)
-        );
-        Assertions.assertEquals(1, profilePropertyRegistry.keys().size());
-        Assertions.assertTrue(profilePropertyRegistry.contains("key"));
+        ProfilePropertyRegistry profilePropertyRegistry = aggregator.aggregate(profileRegistry);
+        assertThat(profilePropertyRegistry.keys()).hasSize(1);
+        assertThat(profilePropertyRegistry.contains("key")).isTrue();
 
         Option<ValueProperty> valueProperty = profilePropertyRegistry.get("key");
-        Assertions.assertTrue(valueProperty.present());
+        assertThat(valueProperty.present()).isTrue();
         // profile2 has a higher priority, thus after aggregation the value from profile2 should be used
-        Assertions.assertTrue(valueProperty.get().value().contains("value2"));
+        assertThat(valueProperty.get().value().contains("value2")).isTrue();
 
-        Assertions.assertEquals(2, profilePropertyRegistry.profileRegistry().profiles().size());
-        Assertions.assertTrue(profilePropertyRegistry.profileRegistry()
+        assertThat(profilePropertyRegistry.profileRegistry().profiles()).hasSize(2);
+        assertThat(profilePropertyRegistry.profileRegistry()
             .profile("profile1")
-            .present());
-        Assertions.assertTrue(profilePropertyRegistry.profileRegistry()
+            .present()).isTrue();
+        assertThat(profilePropertyRegistry.profileRegistry()
             .profile("profile2")
-            .present());
+            .present()).isTrue();
     }
 }

--- a/hartshorn-profiles/src/test/java/test/org/dockbox/hartshorn/profiles/ProfileNameResolverTests.java
+++ b/hartshorn-profiles/src/test/java/test/org/dockbox/hartshorn/profiles/ProfileNameResolverTests.java
@@ -24,15 +24,16 @@ import org.dockbox.hartshorn.properties.PropertyRegistry;
 import org.dockbox.hartshorn.properties.SingleConfiguredProperty;
 import org.dockbox.hartshorn.properties.loader.path.PropertyPathStyle;
 import org.dockbox.hartshorn.properties.loader.path.StandardPropertyPathStyle;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-public class ProfileNameResolverTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProfileNameResolverTests {
 
     @Test
-    void testFromPropertyProfileNameResolver_SupportsListValue() {
+    void fromPropertyProfileNameResolverSupportsListValue() {
         PropertyRegistry registry = new MapPropertyRegistry();
         PropertyPathStyle style = StandardPropertyPathStyle.INSTANCE;
 
@@ -49,13 +50,14 @@ public class ProfileNameResolverTests {
         ProfileNameResolver resolver = new FromPropertyProfileNameResolver();
         Set<String> profileNames = resolver.resolveProfileNames(registry);
 
-        Assertions.assertEquals(2, profileNames.size());
-        Assertions.assertTrue(profileNames.contains("development"));
-        Assertions.assertTrue(profileNames.contains("testing"));
+        assertThat(profileNames)
+                .hasSize(2)
+                .contains("development")
+                .contains("testing");
     }
 
     @Test
-    void testFromPropertyProfileNameResolver_SupportsCommaSeparatedValue() {
+    void fromPropertyProfileNameResolverSupportsCommaSeparatedValue() {
         PropertyRegistry registry = new MapPropertyRegistry();
 
         ConfiguredProperty profiles = new SingleConfiguredProperty(
@@ -65,17 +67,17 @@ public class ProfileNameResolverTests {
         ProfileNameResolver resolver = new FromPropertyProfileNameResolver();
         Set<String> profileNames = resolver.resolveProfileNames(registry);
 
-        Assertions.assertEquals(2, profileNames.size());
-        Assertions.assertTrue(profileNames.contains("development"));
-        Assertions.assertTrue(profileNames.contains("testing"));
+        assertThat(profileNames)
+                .hasSize(2)
+                .contains("development")
+                .contains("testing");
     }
 
     @Test
-    void testFromPropertyProfileNameResolver_SupportsAbsentProperty() {
+    void fromPropertyProfileNameResolverSupportsAbsentProperty() {
         PropertyRegistry registry = new MapPropertyRegistry();
         ProfileNameResolver resolver = new FromPropertyProfileNameResolver();
-        Set<String> profileNames =
-            Assertions.assertDoesNotThrow(() -> resolver.resolveProfileNames(registry));
-        Assertions.assertTrue(profileNames.isEmpty());
+        Set<String> profileNames = resolver.resolveProfileNames(registry);
+        assertThat(profileNames).isEmpty();
     }
 }

--- a/hartshorn-profiles/src/test/java/test/org/dockbox/hartshorn/profiles/ProfileRegistryFactoryTests.java
+++ b/hartshorn-profiles/src/test/java/test/org/dockbox/hartshorn/profiles/ProfileRegistryFactoryTests.java
@@ -19,39 +19,41 @@ package test.org.dockbox.hartshorn.profiles;
 import java.util.List;
 import java.util.Set;
 import org.dockbox.hartshorn.profiles.EnvironmentProfile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import org.dockbox.hartshorn.profiles.ProfileRegistry;
 import org.dockbox.hartshorn.profiles.ProfileRegistryFactory;
 import org.dockbox.hartshorn.profiles.support.ConfigurationProfileRegistryFactory;
 import org.dockbox.hartshorn.properties.MapPropertyRegistry;
 import org.dockbox.hartshorn.util.collections.CollectionUtilities;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ProfileRegistryFactoryTests {
+class ProfileRegistryFactoryTests {
 
     @Test
-    void testProfilesAreRegisteredWithCorrectPriority() {
+    void profilesAreRegisteredWithCorrectPriority() {
         ProfileRegistryFactory factory = new ConfigurationProfileRegistryFactory(
             (registry, path) -> {
                 // Do nothing, resource resolver has no URIs to index, so this will never be called
-                Assertions.fail("Should never be called");
+                fail("Should never be called");
             },
             profileName -> Set.of(),
             MapPropertyRegistry::new,
             rootRegistry -> CollectionUtilities.sequencedSet("profile1", "profile2")
         );
         ProfileRegistry profileRegistry = factory.create(new MapPropertyRegistry());
-        Assertions.assertNotNull(profileRegistry);
+        assertThat(profileRegistry).isNotNull();
 
         List<EnvironmentProfile> profiles = profileRegistry.profiles();
-        Assertions.assertEquals(3, profiles.size());
+        assertThat(profiles).hasSize(3);
 
         // Default profile is always priority 0 (highest)
-        Assertions.assertEquals(ConfigurationProfileRegistryFactory.DEFAULT_PROFILE_NAME,
-            profiles.get(0).name());
+        assertThat(profiles.get(0).name()).isEqualTo(ConfigurationProfileRegistryFactory.DEFAULT_PROFILE_NAME);
         // profile1 was provided first in resolver passed to constructor, thus should have priority 1 (higher than profile2, but lower than default)
-        Assertions.assertEquals("profile1", profiles.get(1).name());
+        assertThat(profiles.get(1).name()).isEqualTo("profile1");
         // profile2 was provided last in resolver passed to constructor, thus should have priority 2 (lowest)
-        Assertions.assertEquals("profile2", profiles.get(2).name());
+        assertThat(profiles.get(2).name()).isEqualTo("profile2");
     }
 }

--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/FilePropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/FilePropertyRegistryLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.properties.loader;
 
 import java.util.Set;

--- a/hartshorn-properties/src/test/java/test/org/dockbox/hartshorn/properties/PropertyRegistryTests.java
+++ b/hartshorn-properties/src/test/java/test/org/dockbox/hartshorn/properties/PropertyRegistryTests.java
@@ -24,7 +24,6 @@ import org.dockbox.hartshorn.properties.PropertyRegistry;
 import org.dockbox.hartshorn.properties.SingleConfiguredProperty;
 import org.dockbox.hartshorn.properties.ValueProperty;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
-public class PropertyRegistryTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PropertyRegistryTests {
 
     void assertWithRegistry(
         Collection<ConfiguredProperty> properties,
@@ -45,19 +46,19 @@ public class PropertyRegistryTests {
 
     @Test
     @DisplayName("Test object access with object on root level of registry")
-    void testNonNestedObjectAccess() {
+    void nonNestedObjectAccess() {
         this.assertObjectAccess("sample");
     }
 
     @Test
     @DisplayName("Test object access with object nested in another object")
-    void testNestedInObjectAccess() {
+    void nestedInObjectAccess() {
         this.assertObjectAccess("sample.nested");
     }
 
     @Test
     @DisplayName("Test object access with object nested in another list")
-    void testNestedInListAccess() {
+    void nestedInListAccess() {
         this.assertObjectAccess("sample.nested[0]");
     }
 
@@ -67,37 +68,37 @@ public class PropertyRegistryTests {
             new SingleConfiguredProperty(objectKey + ".two", "two")
         ), registry -> {
             Option<ObjectProperty> object = registry.object(objectKey);
-            Assertions.assertTrue(object.present());
+            assertThat(object.present()).isTrue();
             object.peek(obj -> {
-                Assertions.assertEquals(objectKey, obj.name());
+                assertThat(obj.name()).isEqualTo(objectKey);
                 Option<ValueProperty> one = obj.get("one");
-                Assertions.assertTrue(one.present());
-                Assertions.assertEquals("one", one.get().value().get());
-                Assertions.assertEquals(objectKey + ".one", one.get().name());
+                assertThat(one.present()).isTrue();
+                assertThat(one.get().value().get()).isEqualTo("one");
+                assertThat(one.get().name()).isEqualTo(objectKey + ".one");
 
                 Option<ValueProperty> two = obj.get("two");
-                Assertions.assertTrue(two.present());
-                Assertions.assertEquals("two", two.get().value().get());
-                Assertions.assertEquals(objectKey + ".two", two.get().name());
+                assertThat(two.present()).isTrue();
+                assertThat(two.get().value().get()).isEqualTo("two");
+                assertThat(two.get().name()).isEqualTo(objectKey + ".two");
             });
         });
     }
 
     @Test
     @DisplayName("Test list access with list on root level of registry")
-    void testNonNestedListAccess() {
+    void nonNestedListAccess() {
         this.testListAccess("sample");
     }
 
     @Test
     @DisplayName("Test list access with list nested in another object")
-    void testNestedInObjectListAccess() {
+    void nestedInObjectListAccess() {
         this.testListAccess("sample.nested");
     }
 
     @Test
     @DisplayName("Test list access with list nested in another list")
-    void testNestedInListListAccess() {
+    void nestedInListListAccess() {
         this.testListAccess("sample.nested[0]");
     }
 
@@ -107,37 +108,37 @@ public class PropertyRegistryTests {
             new SingleConfiguredProperty(listKey + "[1]", "two")
         ), registry -> {
             Option<ListProperty> list = registry.list(listKey);
-            Assertions.assertTrue(list.present());
+            assertThat(list.present()).isTrue();
             list.peek(l -> {
-                Assertions.assertEquals(listKey, l.name());
+                assertThat(l.name()).isEqualTo(listKey);
                 Option<ValueProperty> one = l.get(0);
-                Assertions.assertTrue(one.present());
-                Assertions.assertEquals("one", one.get().value().get());
-                Assertions.assertEquals(listKey + "[0]", one.get().name());
+                assertThat(one.present()).isTrue();
+                assertThat(one.get().value().get()).isEqualTo("one");
+                assertThat(one.get().name()).isEqualTo(listKey + "[0]");
 
                 Option<ValueProperty> two = l.get(1);
-                Assertions.assertTrue(two.present());
-                Assertions.assertEquals("two", two.get().value().get());
-                Assertions.assertEquals(listKey + "[1]", two.get().name());
+                assertThat(two.present()).isTrue();
+                assertThat(two.get().value().get()).isEqualTo("two");
+                assertThat(two.get().name()).isEqualTo(listKey + "[1]");
             });
         });
     }
 
     @Test
     @DisplayName("Test value access with value on root level of registry")
-    void testNonNestedValueAccess() {
+    void nonNestedValueAccess() {
         this.testValueAccess("sample");
     }
 
     @Test
     @DisplayName("Test value access with value nested in another object")
-    void testNestedInObjectValueAccess() {
+    void nestedInObjectValueAccess() {
         this.testValueAccess("sample.nested");
     }
 
     @Test
     @DisplayName("Test value access with value nested in another list")
-    void testNestedInListValueAccess() {
+    void nestedInListValueAccess() {
         this.testValueAccess("sample.nested[0]");
     }
 
@@ -146,59 +147,58 @@ public class PropertyRegistryTests {
             new SingleConfiguredProperty(valueKey, "value")
         ), registry -> {
             Option<ValueProperty> value = registry.get(valueKey);
-            Assertions.assertTrue(value.present());
+            assertThat(value.present()).isTrue();
             value.peek(v -> {
-                Assertions.assertEquals(valueKey, v.name());
-                Assertions.assertEquals("value", v.value().get());
+                assertThat(v.name()).isEqualTo(valueKey);
+                assertThat(v.value().get()).isEqualTo("value");
             });
         });
     }
 
     @Test
     @DisplayName("Test access to deeply nested value with step-by-step access")
-    void testComplexAccess() {
+    void complexAccess() {
         this.assertWithRegistry(
             List.of(new SingleConfiguredProperty("sample[0][1][0].property.sample[1].value",
                 "value")),
             registry -> {
                 // sample
                 Option<ListProperty> sample = registry.list("sample");
-                Assertions.assertTrue(sample.present());
+                assertThat(sample.present()).isTrue();
 
                 // sample[0]
                 Option<ListProperty> sampleIndex0 = sample.get().list(0);
-                Assertions.assertTrue(sampleIndex0.present());
+                assertThat(sampleIndex0.present()).isTrue();
 
                 // sample[0][1]
                 Option<ListProperty> sampleIndex0Index1 = sampleIndex0.get().list(1);
-                Assertions.assertTrue(sampleIndex0Index1.present());
+                assertThat(sampleIndex0Index1.present()).isTrue();
 
                 // sample[0][1][0]
                 Option<ObjectProperty> sampleIndex0Index1Index0 =
                     sampleIndex0Index1.get().object(0);
-                Assertions.assertTrue(sampleIndex0Index1Index0.present());
+                assertThat(sampleIndex0Index1Index0.present()).isTrue();
 
                 // sample[0][1][0].property
                 Option<ObjectProperty> sampleIndex0Index1Index0Property =
                     sampleIndex0Index1Index0.get().object("property");
-                Assertions.assertTrue(sampleIndex0Index1Index0Property.present());
+                assertThat(sampleIndex0Index1Index0Property.present()).isTrue();
 
                 // sample[0][1][0].property.sample
                 Option<ListProperty> sampleIndex0Index1Index0PropertySample =
                     sampleIndex0Index1Index0Property.get().list("sample");
-                Assertions.assertTrue(sampleIndex0Index1Index0PropertySample.present());
+                assertThat(sampleIndex0Index1Index0PropertySample.present()).isTrue();
 
                 // sample[0][1][0].property.sample[1]
                 Option<ObjectProperty> sampleIndex0Index1Index0PropertySampleIndex1 =
                     sampleIndex0Index1Index0PropertySample.get().object(1);
-                Assertions.assertTrue(sampleIndex0Index1Index0PropertySampleIndex1.present());
+                assertThat(sampleIndex0Index1Index0PropertySampleIndex1.present()).isTrue();
 
                 // sample[0][1][0].property.sample[1].value
                 Option<ValueProperty> sampleIndex0Index1Index0PropertySampleIndex1Value =
                     sampleIndex0Index1Index0PropertySampleIndex1.get().get("value");
-                Assertions.assertTrue(sampleIndex0Index1Index0PropertySampleIndex1Value.present());
-                Assertions.assertEquals("value",
-                    sampleIndex0Index1Index0PropertySampleIndex1Value.get().value().get());
+                assertThat(sampleIndex0Index1Index0PropertySampleIndex1Value.present()).isTrue();
+                assertThat(sampleIndex0Index1Index0PropertySampleIndex1Value.get().value().get()).isEqualTo("value");
             });
     }
 }

--- a/hartshorn-properties/src/test/java/test/org/dockbox/hartshorn/properties/loader/JacksonPropertyRegistryPathLoaderTests.java
+++ b/hartshorn-properties/src/test/java/test/org/dockbox/hartshorn/properties/loader/JacksonPropertyRegistryPathLoaderTests.java
@@ -23,18 +23,18 @@ import org.dockbox.hartshorn.properties.loader.PropertyRegistryPathLoader;
 import org.dockbox.hartshorn.properties.loader.StylePropertyPathFormatter;
 import org.dockbox.hartshorn.properties.loader.support.JacksonYamlPropertyRegistryLoader;
 import org.dockbox.hartshorn.properties.value.StandardValuePropertyParsers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 
-public class JacksonPropertyRegistryPathLoaderTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JacksonPropertyRegistryPathLoaderTests {
 
     @Test
-    void testComplexYamlConfigurationCanBeLoaded() throws IOException {
+    void complexYamlConfigurationCanBeLoaded() throws Exception {
         // Given
         PropertyRegistryPathLoader loader =
             new JacksonYamlPropertyRegistryLoader(new StylePropertyPathFormatter());
@@ -46,70 +46,70 @@ public class JacksonPropertyRegistryPathLoaderTests {
 
         // Then: Should contain all expected keys
         List<ConfiguredProperty> properties = registry.find(property -> true);
-        Assertions.assertEquals(12, properties.size());
+        assertThat(properties).hasSize(12);
 
         // Then: Keys should be ordered
         Iterator<ConfiguredProperty> iterator = properties.iterator();
-        Assertions.assertEquals("sample.complex.configuration[0].name", iterator.next().name());
-        Assertions.assertEquals("sample.complex.configuration[0].value", iterator.next().name());
-        Assertions.assertEquals("sample.complex.configuration[1].name", iterator.next().name());
-        Assertions.assertEquals("sample.complex.configuration[1].value", iterator.next().name());
-        Assertions.assertEquals("sample.complex.configuration[2].name", iterator.next().name());
-        Assertions.assertEquals("sample.complex.configuration[2].value", iterator.next().name());
-        Assertions.assertEquals("sample.complex.flat", iterator.next().name());
-        Assertions.assertEquals("sample.complex.list[0].name", iterator.next().name());
-        Assertions.assertEquals("sample.complex.list[0].value", iterator.next().name());
-        Assertions.assertEquals("sample.complex.list[1].name", iterator.next().name());
-        Assertions.assertEquals("sample.complex.list[1].value", iterator.next().name());
-        Assertions.assertEquals("sample.complex.values", iterator.next().name());
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.configuration[0].name");
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.configuration[0].value");
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.configuration[1].name");
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.configuration[1].value");
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.configuration[2].name");
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.configuration[2].value");
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.flat");
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.list[0].name");
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.list[0].value");
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.list[1].name");
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.list[1].value");
+        assertThat(iterator.next().name()).isEqualTo("sample.complex.values");
 
         // Then: Property values should be loaded correctly
         registry.value("sample.complex.configuration[0].name")
-            .peek(value -> Assertions.assertEquals("name1", value))
+            .peek(value -> assertThat(value).isEqualTo("name1"))
             .orElseThrow(() -> new AssertionError("Property not found"));
         registry.value("sample.complex.configuration[0].value")
-            .peek(value -> Assertions.assertEquals("value1", value))
+            .peek(value -> assertThat(value).isEqualTo("value1"))
             .orElseThrow(() -> new AssertionError("Property not found"));
 
         registry.value("sample.complex.configuration[1].name")
-            .peek(value -> Assertions.assertEquals("name2", value))
+            .peek(value -> assertThat(value).isEqualTo("name2"))
             .orElseThrow(() -> new AssertionError("Property not found"));
         registry.value("sample.complex.configuration[1].value")
-            .peek(value -> Assertions.assertEquals("value2", value))
+            .peek(value -> assertThat(value).isEqualTo("value2"))
             .orElseThrow(() -> new AssertionError("Property not found"));
 
         registry.value("sample.complex.configuration[2].name")
-            .peek(value -> Assertions.assertEquals("name3", value))
+            .peek(value -> assertThat(value).isEqualTo("name3"))
             .orElseThrow(() -> new AssertionError("Property not found"));
         registry.value("sample.complex.configuration[2].value")
-            .peek(value -> Assertions.assertEquals("value3", value))
+            .peek(value -> assertThat(value).isEqualTo("value3"))
             .orElseThrow(() -> new AssertionError("Property not found"));
 
         registry.value("sample.complex.values", StandardValuePropertyParsers.STRING_LIST)
             .peek(values -> {
-                Assertions.assertEquals(3, values.length);
-                Assertions.assertEquals("value1", values[0]);
-                Assertions.assertEquals("value2", values[1]);
-                Assertions.assertEquals("value3", values[2]);
+                assertThat(values.length).isEqualTo(3);
+                assertThat(values[0]).isEqualTo("value1");
+                assertThat(values[1]).isEqualTo("value2");
+                assertThat(values[2]).isEqualTo("value3");
             })
             .orElseThrow(() -> new AssertionError("Property not found"));
 
         registry.value("sample.complex.flat")
-            .peek(value -> Assertions.assertEquals("value1", value))
+            .peek(value -> assertThat(value).isEqualTo("value1"))
             .orElseThrow(() -> new AssertionError("Property not found"));
 
         registry.value("sample.complex.list[0].name")
-            .peek(value -> Assertions.assertEquals("name1", value))
+            .peek(value -> assertThat(value).isEqualTo("name1"))
             .orElseThrow(() -> new AssertionError("Property not found"));
         registry.value("sample.complex.list[0].value")
-            .peek(value -> Assertions.assertEquals("value1", value))
+            .peek(value -> assertThat(value).isEqualTo("value1"))
             .orElseThrow(() -> new AssertionError("Property not found"));
 
         registry.value("sample.complex.list[1].name")
-            .peek(value -> Assertions.assertEquals("name2", value))
+            .peek(value -> assertThat(value).isEqualTo("name2"))
             .orElseThrow(() -> new AssertionError("Property not found"));
         registry.value("sample.complex.list[1].value")
-            .peek(value -> Assertions.assertEquals("value2", value))
+            .peek(value -> assertThat(value).isEqualTo("value2"))
             .orElseThrow(() -> new AssertionError("Property not found"));
     }
 }

--- a/hartshorn-proxy-test-fixtures/src/main/java/test/org/dockbox/hartshorn/proxy/MethodStubTests.java
+++ b/hartshorn-proxy-test-fixtures/src/main/java/test/org/dockbox/hartshorn/proxy/MethodStubTests.java
@@ -22,18 +22,19 @@ import org.dockbox.hartshorn.proxy.ProxyOrchestrator;
 import org.dockbox.hartshorn.proxy.ProxyOrchestratorLoader;
 import org.dockbox.hartshorn.proxy.advice.stub.DefaultValueResponseMethodStub;
 import org.dockbox.hartshorn.proxy.advice.stub.MethodStub;
-import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.ApplicationRuntimeException;
 import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import test.org.dockbox.hartshorn.proxy.support.standard.InterfaceProxyTarget;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import test.org.dockbox.hartshorn.proxy.support.standard.InterfaceProxyTarget;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 /**
  * Tests for the default behavior of method stubs.
@@ -49,50 +50,50 @@ public abstract class MethodStubTests {
     protected abstract Introspector introspector();
 
     @Test
-    void testDefaultBehaviorIsDefaultOrNull() throws ApplicationException {
+    void defaultBehaviorIsDefaultOrNull() throws Exception {
         ProxyOrchestrator orchestrator = this.orchestratorLoader().create(this.introspector());
         ProxyFactory<InterfaceProxyTarget> proxyFactory =
             orchestrator.factory(InterfaceProxyTarget.class);
         InterfaceProxyTarget proxy = proxyFactory.proxy().get();
 
         Option<ProxyManager<InterfaceProxyTarget>> manager = orchestrator.manager(proxy);
-        Assertions.assertTrue(manager.present());
+        assertThat(manager.present()).isTrue();
 
         MethodStub<InterfaceProxyTarget> methodStub =
             manager.get().advisor().resolver().defaultStub().get();
-        Assertions.assertInstanceOf(DefaultValueResponseMethodStub.class, methodStub);
+        assertThat(methodStub).isInstanceOf(DefaultValueResponseMethodStub.class);
 
-        String stringValue = Assertions.assertDoesNotThrow(proxy::stringTest);
-        Assertions.assertNull(stringValue);
+        String stringValue = proxy.stringTest();
+        assertThat(stringValue).isNull();
 
-        int intValue = Assertions.assertDoesNotThrow(proxy::integerTest);
-        Assertions.assertEquals(0, intValue);
+        int intValue = proxy.integerTest();
+        assertThat(intValue).isZero();
     }
 
     @Test
-    void testStubBehaviorCanBeChanged() throws ApplicationException {
-        ProxyFactory<InterfaceProxyTarget> proxyFactory =
-            this.orchestratorLoader().create(this.introspector()).factory(
-                InterfaceProxyTarget.class);
+    void stubBehaviorCanBeChanged() throws Exception {
+        ProxyFactory<InterfaceProxyTarget> proxyFactory = this.orchestratorLoader()
+                .create(this.introspector())
+                .factory(InterfaceProxyTarget.class);
 
         // Also verifies that the stub result is not cached
         AtomicInteger integer = new AtomicInteger(0);
-        proxyFactory.advisors().defaultStub(context -> integer.incrementAndGet());
+        proxyFactory.advisors().defaultStub(_ -> integer.incrementAndGet());
 
         InterfaceProxyTarget proxy = proxyFactory.proxy().get();
 
-        int one = Assertions.<Integer>assertDoesNotThrow(proxy::integerTest);
-        Assertions.assertEquals(1, one);
+        int one = proxy.integerTest();
+        assertThat(one).isOne();
 
-        int two = Assertions.<Integer>assertDoesNotThrow(proxy::integerTest);
-        Assertions.assertEquals(2, two);
+        int two = proxy.integerTest();
+        assertThat(two).isEqualTo(2);
     }
 
     @Test
-    void testStubsAreObserved() throws ApplicationException, NoSuchMethodException {
-        ProxyFactory<InterfaceProxyTarget> proxyFactory =
-            this.orchestratorLoader().create(this.introspector()).factory(
-                InterfaceProxyTarget.class);
+    void stubsAreObserved() throws Exception {
+        ProxyFactory<InterfaceProxyTarget> proxyFactory = this.orchestratorLoader()
+                .create(this.introspector())
+                .factory(InterfaceProxyTarget.class);
 
         AtomicBoolean beforeObserved = new AtomicBoolean(false);
         AtomicBoolean afterObserved = new AtomicBoolean(false);
@@ -102,11 +103,11 @@ public abstract class MethodStubTests {
 
         Method stringTest = InterfaceProxyTarget.class.getDeclaredMethod("stringTest");
         proxyFactory.advisors().method(stringTest).wrapAround(wrapper -> wrapper
-                .before(context -> beforeObserved.set(true))
-                .after(context -> afterObserved.set(true))
-                .onError(context -> errorObserved.set(true))
+                .before(_ -> beforeObserved.set(true))
+                .after(_ -> afterObserved.set(true))
+                .onError(_ -> errorObserved.set(true))
             )
-            .defaultStub(context -> {
+            .defaultStub(_ -> {
                 // RuntimeException, as it is not declared in the interface
                 if (shouldThrow.get()) {
                     throw new ApplicationRuntimeException("Test");
@@ -115,21 +116,21 @@ public abstract class MethodStubTests {
             });
 
         InterfaceProxyTarget proxy = proxyFactory.proxy().get();
-        Assertions.assertDoesNotThrow(proxy::stringTest);
+        assertThatCode(proxy::stringTest).doesNotThrowAnyException();
 
-        Assertions.assertTrue(beforeObserved.get());
-        Assertions.assertTrue(afterObserved.get());
-        Assertions.assertFalse(errorObserved.get());
+        assertThat(beforeObserved.get()).isTrue();
+        assertThat(afterObserved.get()).isTrue();
+        assertThat(errorObserved.get()).isFalse();
 
         beforeObserved.set(false);
         afterObserved.set(false);
         errorObserved.set(false);
         shouldThrow.set(true);
 
-        Assertions.assertThrows(ApplicationRuntimeException.class, proxy::stringTest);
+        assertThatExceptionOfType(ApplicationRuntimeException.class).isThrownBy(proxy::stringTest);
 
-        Assertions.assertTrue(beforeObserved.get());
-        Assertions.assertFalse(afterObserved.get());
-        Assertions.assertTrue(errorObserved.get());
+        assertThat(beforeObserved.get()).isTrue();
+        assertThat(afterObserved.get()).isFalse();
+        assertThat(errorObserved.get()).isTrue();
     }
 }

--- a/hartshorn-proxy-test-fixtures/src/main/java/test/org/dockbox/hartshorn/proxy/ProxyTests.java
+++ b/hartshorn-proxy-test-fixtures/src/main/java/test/org/dockbox/hartshorn/proxy/ProxyTests.java
@@ -302,7 +302,8 @@ public abstract class ProxyTests {
                 Throwable error = context.error();
                 assertThat(error)
                         .asInstanceOf(InstanceOfAssertFactories.type(IllegalStateException.class))
-                        .extracting(Throwable::getMessage);
+                        .extracting(Throwable::getMessage)
+                        .isEqualTo("not done");
                 assertThat(count.getAndIncrement()).isOne();
             }
         });
@@ -525,6 +526,7 @@ public abstract class ProxyTests {
     }
 
     @Test
+    @SuppressWarnings("SelfAssertion")
     void concreteProxySelfEquality() throws Exception {
         ProxyFactory<EqualProxy> factory =
             this.orchestratorLoader().create(this.introspector()).factory(EqualProxy.class);
@@ -537,6 +539,7 @@ public abstract class ProxyTests {
     }
 
     @Test
+    @SuppressWarnings("SelfAssertion")
     void serviceSelfEquality() throws Exception {
         AbstractEqualProxy service = this.orchestratorLoader()
             .create(this.introspector())
@@ -548,6 +551,7 @@ public abstract class ProxyTests {
     }
 
     @Test
+    @SuppressWarnings("SelfAssertion")
     void interfaceProxySelfEquality() throws Exception {
         ProxyFactory<EqualInterfaceProxy> factory = this.orchestratorLoader()
             .create(this.introspector())

--- a/hartshorn-proxy-test-fixtures/src/main/java/test/org/dockbox/hartshorn/proxy/ProxyTests.java
+++ b/hartshorn-proxy-test-fixtures/src/main/java/test/org/dockbox/hartshorn/proxy/ProxyTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.proxy;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.proxy.Proxy;
 import org.dockbox.hartshorn.proxy.ProxyFactory;
 import org.dockbox.hartshorn.proxy.ProxyManager;
@@ -32,17 +33,10 @@ import org.dockbox.hartshorn.util.introspect.Introspector;
 import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.lang.reflect.Method;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
 import test.org.dockbox.hartshorn.proxy.support.basic.ConcreteProxyWithNonDefaultConstructor;
 import test.org.dockbox.hartshorn.proxy.support.basic.DescribedProxy;
 import test.org.dockbox.hartshorn.proxy.support.equals.AbstractEqualProxy;
@@ -60,6 +54,15 @@ import test.org.dockbox.hartshorn.proxy.support.standard.FinalMethodProxyTarget;
 import test.org.dockbox.hartshorn.proxy.support.standard.RecordProxy;
 import test.org.dockbox.hartshorn.proxy.support.standard.SealedProxy;
 
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 /**
  * Tests for the default behavior of proxies of various types.
  *
@@ -75,30 +78,30 @@ public abstract class ProxyTests {
     protected abstract Introspector introspector();
 
     @Test
-    void testConcreteMethodsCanBeProxied() throws ApplicationException, NoSuchMethodException {
+    void concreteMethodsCanBeProxied() throws Exception {
         Method name = ConcreteProxyTarget.class.getMethod("name");
         ProxyFactory<ConcreteProxyTarget> handler = this.orchestratorLoader()
             .create(this.introspector())
             .factory(ConcreteProxyTarget.class);
-        handler.advisors().method(name).intercept(context -> "Hartshorn");
+        handler.advisors().method(name).intercept(_ -> "Hartshorn");
         ConcreteProxyTarget proxy = handler.proxy().get();
 
-        Assertions.assertNotNull(proxy);
-        Assertions.assertNotNull(proxy.name());
-        Assertions.assertEquals("Hartshorn", proxy.name());
+        assertThat(proxy).isNotNull();
+        assertThat(proxy.name()).isNotNull();
+        assertThat(proxy.name()).isEqualTo("Hartshorn");
     }
 
     @Test
-    void testFinalMethodsCanNotBeProxied() throws NoSuchMethodException {
+    void finalMethodsCanNotBeProxied() throws Exception {
         Method name = FinalMethodProxyTarget.class.getMethod("name");
         ProxyFactory<FinalMethodProxyTarget> handler = this.orchestratorLoader()
             .create(this.introspector())
             .factory(FinalMethodProxyTarget.class);
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> handler.advisors()
-            .method(name)
-            .intercept(context -> "Hartshorn")
-        );
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> handler
+                .advisors()
+                .method(name)
+                .intercept(_ -> "Hartshorn"));
     }
 
     public static Stream<Arguments> proxyTypes() {
@@ -110,106 +113,118 @@ public abstract class ProxyTests {
     }
 
     @Test
-    void testRecordProxyCannotBeCreated() {
+    void recordProxyCannotBeCreated() {
         // Records are and cannot be proxied
-        ProxyFactory<RecordProxy> handler =
-            this.orchestratorLoader().create(this.introspector()).factory(RecordProxy.class);
-        Assertions.assertThrows(ProxyConstraintViolationException.class, handler::proxy);
+        ProxyFactory<RecordProxy> handler = this.orchestratorLoader()
+                .create(this.introspector())
+                .factory(RecordProxy.class);
+        assertThatExceptionOfType(ProxyConstraintViolationException.class)
+                .isThrownBy(handler::proxy);
     }
 
     @Test
-    void testSealedClassProxyCannotBeCreated() {
+    void sealedClassProxyCannotBeCreated() {
         // Sealed classes only allow for a limited number of subclasses and should not be proxied
-        ProxyFactory<SealedProxy> handler =
-            this.orchestratorLoader().create(this.introspector()).factory(SealedProxy.class);
-        Assertions.assertThrows(ProxyConstraintViolationException.class, handler::proxy);
+        ProxyFactory<SealedProxy> handler = this.orchestratorLoader()
+                .create(this.introspector())
+                .factory(SealedProxy.class);
+        assertThatExceptionOfType(ProxyConstraintViolationException.class)
+                .isThrownBy(handler::proxy);
     }
 
     @Test
-    void testFinalClassProxyCannotBeCreated() {
+    void finalClassProxyCannotBeCreated() {
         // Final classes cannot be extended and should not be proxied
         ProxyFactory<FinalClassProxyTarget> handler = this.orchestratorLoader()
             .create(this.introspector())
             .factory(FinalClassProxyTarget.class);
-        Assertions.assertThrows(ProxyConstraintViolationException.class, handler::proxy);
+        assertThatExceptionOfType(ProxyConstraintViolationException.class)
+                .isThrownBy(handler::proxy);
     }
 
     @ParameterizedTest
     @MethodSource("proxyTypes")
-    void testEmptyProxyCanCreate(Class<? extends InterfaceProxy> proxyParent)
-        throws ApplicationException {
+    void emptyProxyCanCreate(Class<? extends InterfaceProxy> proxyParent)
+        throws Exception {
         ProxyFactory<? extends InterfaceProxy> handler =
             this.orchestratorLoader().create(this.introspector()).factory(proxyParent);
         InterfaceProxy proxy = handler.proxy().get();
-        Assertions.assertNotNull(proxy);
+        assertThat(proxy).isNotNull();
     }
 
     @ParameterizedTest
     @MethodSource("proxyTypes")
-    void testMethodsCanBeDelegatedToOriginalInstance(Class<InterfaceProxy> proxyType)
-        throws ApplicationException {
+    void methodsCanBeDelegatedToOriginalInstance(Class<InterfaceProxy> proxyType)
+        throws Exception {
         ProxyFactory<InterfaceProxy> factory =
             this.orchestratorLoader().create(this.introspector()).factory(proxyType);
         factory.advisors().type().delegate(new ConcreteProxy());
         Option<InterfaceProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         InterfaceProxy proxyInstance = proxy.get();
-        Assertions.assertEquals("concrete", proxyInstance.name());
+        assertThat(proxyInstance.name()).isEqualTo("concrete");
     }
 
     @Test
-    void testConcreteProxyWithNonDefaultConstructorUsesConstructor() {
+    void concreteProxyWithNonDefaultConstructorUsesConstructor() throws Exception {
         StateAwareProxyFactory<ConcreteProxyWithNonDefaultConstructor> factory =
             this.orchestratorLoader()
                 .create(this.introspector())
                 .factory(ConcreteProxyWithNonDefaultConstructor.class);
 
-        TypeView<ConcreteProxyWithNonDefaultConstructor> typeView =
-            this.introspector().introspect(ConcreteProxyWithNonDefaultConstructor.class);
-        ConstructorView<ConcreteProxyWithNonDefaultConstructor> constructor =
-            typeView.constructors().all().get(0);
-        Option<ConcreteProxyWithNonDefaultConstructor> proxy =
-            Assertions.assertDoesNotThrow(() -> factory.proxy(constructor,
-                new Object[] {"Hello world"}));
-        Assertions.assertTrue(proxy.present());
+        TypeView<ConcreteProxyWithNonDefaultConstructor> typeView = this.introspector()
+                .introspect(ConcreteProxyWithNonDefaultConstructor.class);
+        ConstructorView<ConcreteProxyWithNonDefaultConstructor> constructor = typeView
+                .constructors()
+                .all()
+                .getFirst();
+        Option<ConcreteProxyWithNonDefaultConstructor> proxy = factory.proxy(
+                constructor,
+                new Object[]{"Hello world"}
+        );
+        assertThat(proxy.present()).isTrue();
 
         ConcreteProxyWithNonDefaultConstructor proxyInstance = proxy.get();
-        Assertions.assertEquals("Hello world", proxyInstance.message());
+        assertThat(proxyInstance.message()).isEqualTo("Hello world");
     }
 
     @ParameterizedTest
     @MethodSource("proxyTypes")
-    void testMethodsCanBeIntercepted(Class<? extends InterfaceProxy> proxyType)
-        throws ApplicationException, NoSuchMethodException {
-        ProxyFactory<? extends InterfaceProxy> factory =
-            this.orchestratorLoader().create(this.introspector()).factory(proxyType);
-        factory.advisors().method(proxyType.getMethod("name")).intercept(context -> "Hartshorn");
+    void methodsCanBeIntercepted(Class<? extends InterfaceProxy> proxyType)
+        throws Exception {
+        ProxyFactory<? extends InterfaceProxy> factory = this.orchestratorLoader()
+                .create(this.introspector())
+                .factory(proxyType);
+
+        factory.advisors()
+                .method(proxyType.getMethod("name"))
+                .intercept(_ -> "Hartshorn");
         Option<? extends InterfaceProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         InterfaceProxy proxyInstance = proxy.get();
-        Assertions.assertEquals("Hartshorn", proxyInstance.name());
+        assertThat(proxyInstance.name()).isEqualTo("Hartshorn");
     }
 
     @ParameterizedTest
     @MethodSource("proxyTypes")
-    void testMethodsCanBeDelegated(Class<? extends InterfaceProxy> proxyType)
-        throws ApplicationException, NoSuchMethodException {
+    void methodsCanBeDelegated(Class<? extends InterfaceProxy> proxyType)
+        throws Exception {
         ProxyFactory<InterfaceProxy> factory =
             (ProxyFactory<InterfaceProxy>) this.orchestratorLoader()
                 .create(this.introspector())
                 .factory(proxyType);
         factory.advisors().method(proxyType.getMethod("name")).delegate(new ConcreteProxy());
         Option<? extends InterfaceProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         InterfaceProxy proxyInstance = proxy.get();
-        Assertions.assertEquals("concrete", proxyInstance.name());
+        assertThat(proxyInstance.name()).isEqualTo("concrete");
     }
 
     @Test
-    void testTypesCanBeDelegated() throws ApplicationException {
+    void typesCanBeDelegated() throws Exception {
         // Use a custom interface for this type of delegation, as the other proxy types override
         // methods from their parent
         ProxyFactory<NamedAgedProxy> factory =
@@ -217,103 +232,104 @@ public abstract class ProxyTests {
         factory.advisors().type(AgedProxy.class).delegate(() -> 12);
         factory.advisors().type(NamedProxy.class).delegate(() -> "NamedProxy");
         Option<NamedAgedProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         NamedAgedProxy proxyInstance = proxy.get();
-        Assertions.assertEquals(12, proxyInstance.age());
-        Assertions.assertEquals("NamedProxy", proxyInstance.name());
+        assertThat(proxyInstance.age()).isEqualTo(12);
+        assertThat(proxyInstance.name()).isEqualTo("NamedProxy");
     }
 
     @ParameterizedTest
     @MethodSource("proxyTypes")
-    void testWrapperInterceptionIsCorrect(Class<? extends InterfaceProxy> proxyType)
-        throws NoSuchMethodException, ApplicationException {
+    void wrapperInterceptionIsCorrect(Class<? extends InterfaceProxy> proxyType)
+        throws Exception {
         ProxyFactory<InterfaceProxy> factory =
             (ProxyFactory<InterfaceProxy>) this.orchestratorLoader()
                 .create(this.introspector())
                 .factory(proxyType);
         AtomicInteger count = new AtomicInteger();
-        factory.advisors().method(proxyType.getMethod("name")).intercept(context -> "done");
+        factory.advisors().method(proxyType.getMethod("name")).intercept(_ -> "done");
         factory.advisors().method(proxyType.getMethod("name")).wrapAround(new MethodWrapper<>() {
             @Override
             public void acceptBefore(ProxyCallbackContext<InterfaceProxy> context) {
-                Assertions.assertEquals(0, count.getAndIncrement());
+                assertThat(count.getAndIncrement()).isZero();
             }
 
             @Override
             public void acceptAfter(ProxyCallbackContext<InterfaceProxy> context) {
-                Assertions.assertEquals(1, count.getAndIncrement());
+                assertThat(count.getAndIncrement()).isOne();
             }
 
             @Override
             public void acceptError(ProxyCallbackContext<InterfaceProxy> context) {
                 // Not thrown
-                Assertions.fail();
+                fail();
             }
         });
         Option<InterfaceProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         InterfaceProxy proxyInstance = proxy.get();
-        Assertions.assertEquals("done", proxyInstance.name());
-        Assertions.assertEquals(2, count.get());
+        assertThat(proxyInstance.name()).isEqualTo("done");
+        assertThat(count.get()).isEqualTo(2);
     }
 
     @ParameterizedTest
     @MethodSource("proxyTypes")
-    void testErrorWrapperInterceptionIsCorrect(Class<? extends InterfaceProxy> proxyType)
-        throws NoSuchMethodException, ApplicationException {
+    void errorWrapperInterceptionIsCorrect(Class<? extends InterfaceProxy> proxyType)
+        throws Exception {
         ProxyFactory<InterfaceProxy> factory =
             (ProxyFactory<InterfaceProxy>) this.orchestratorLoader()
                 .create(this.introspector())
                 .factory(proxyType);
         AtomicInteger count = new AtomicInteger();
-        factory.advisors().method(proxyType.getMethod("name")).intercept(context -> {
+        factory.advisors().method(proxyType.getMethod("name")).intercept(_ -> {
             throw new IllegalStateException("not done");
         });
         factory.advisors().method(proxyType.getMethod("name")).wrapAround(new MethodWrapper<>() {
             @Override
             public void acceptBefore(ProxyCallbackContext<InterfaceProxy> context) {
-                Assertions.assertEquals(0, count.getAndIncrement());
+                assertThat(count.getAndIncrement()).isZero();
             }
 
             @Override
             public void acceptAfter(ProxyCallbackContext<InterfaceProxy> context) {
-                Assertions.fail();
+                fail();
             }
 
             @Override
             public void acceptError(ProxyCallbackContext<InterfaceProxy> context) {
                 Throwable error = context.error();
-                Assertions.assertNotNull(error);
-                Assertions.assertTrue(error instanceof IllegalStateException);
-                Assertions.assertEquals("not done", error.getMessage());
-                Assertions.assertEquals(1, count.getAndIncrement());
+                assertThat(error)
+                        .asInstanceOf(InstanceOfAssertFactories.type(IllegalStateException.class))
+                        .extracting(Throwable::getMessage);
+                assertThat(count.getAndIncrement()).isOne();
             }
         });
         Option<InterfaceProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         InterfaceProxy proxyInstance = proxy.get();
-        IllegalStateException error =
-            Assertions.assertThrows(IllegalStateException.class, proxyInstance::name);
-        Assertions.assertEquals("not done", error.getMessage());
-        Assertions.assertEquals(2, count.get());
+        IllegalStateException error = assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(proxyInstance::name)
+                .actual();
+        assertThat(error.getMessage()).isEqualTo("not done");
+        assertThat(count.get()).isEqualTo(2);
     }
 
     @Test
-    void testProxyManagerTracksInterceptorsAndDelegates()
-        throws NoSuchMethodException, ApplicationException {
+    void proxyManagerTracksInterceptorsAndDelegates()
+        throws Exception {
         ProxyFactory<NamedAgedProxy> factory =
             this.orchestratorLoader().create(this.introspector()).factory(NamedAgedProxy.class);
 
         AgedProxy aged = () -> 12;
         factory.advisors().type(AgedProxy.class).delegate(aged);
 
-        MethodInterceptor<NamedAgedProxy, Object> named = context -> "NamedProxy";
+        MethodInterceptor<NamedAgedProxy, Object> named = _ -> "NamedProxy";
         factory.advisors().method(NamedProxy.class.getMethod("name")).intercept(named);
         Option<NamedAgedProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         Proxy<?> proxyInstance = (Proxy<?>) proxy.get();
         ProxyManager<?> manager = proxyInstance.manager();
@@ -322,113 +338,116 @@ public abstract class ProxyTests {
             .resolver()
             .type(AgedProxy.class)
             .delegate();
-        Assertions.assertTrue(agedDelegate.present());
-        Assertions.assertSame(agedDelegate.get(), aged);
+        assertThat(agedDelegate.present()).isTrue();
+        assertThat(aged).isSameAs(agedDelegate.get());
 
         Option<?> namedInterceptor = manager.advisor()
             .resolver()
             .method(NamedProxy.class.getMethod("name"))
             .interceptor();
-        Assertions.assertTrue(namedInterceptor.present());
-        Assertions.assertSame(namedInterceptor.get(), named);
+        assertThat(namedInterceptor.present()).isTrue();
+        assertThat(named).isSameAs(namedInterceptor.get());
     }
 
     @ParameterizedTest
     @MethodSource("proxyTypes")
-    void testProxyCanHaveExtraInterfaces(Class<? extends InterfaceProxy> proxyType)
-        throws ApplicationException {
+    void proxyCanHaveExtraInterfaces(Class<? extends InterfaceProxy> proxyType)
+        throws Exception {
         ProxyFactory<InterfaceProxy> factory =
             (ProxyFactory<InterfaceProxy>) this.orchestratorLoader()
                 .create(this.introspector())
                 .factory(proxyType);
         factory.implement(DescribedProxy.class);
         Option<InterfaceProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         InterfaceProxy proxyInstance = proxy.get();
-        Assertions.assertTrue(proxyInstance instanceof DescribedProxy);
+        assertThat(proxyInstance).isInstanceOf(DescribedProxy.class);
     }
 
     @ParameterizedTest
     @MethodSource("proxyTypes")
-    void testProxiesAlwaysImplementProxyType(Class<? extends InterfaceProxy> proxyType)
-        throws ApplicationException {
+    void proxiesAlwaysImplementProxyType(Class<? extends InterfaceProxy> proxyType)
+        throws Exception {
         ProxyFactory<InterfaceProxy> factory =
             (ProxyFactory<InterfaceProxy>) this.orchestratorLoader()
                 .create(this.introspector())
                 .factory(proxyType);
         Option<InterfaceProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
         InterfaceProxy proxyInstance = proxy.get();
-        Assertions.assertTrue(proxyInstance instanceof Proxy);
+        assertThat(proxyInstance).isInstanceOf(Proxy.class);
     }
 
     @ParameterizedTest
     @MethodSource("proxyTypes")
-    void testProxiesExposeManager(Class<? extends InterfaceProxy> proxyType)
-        throws ApplicationException {
+    void proxiesExposeManager(Class<? extends InterfaceProxy> proxyType)
+        throws Exception {
         ProxyFactory<InterfaceProxy> factory =
             (ProxyFactory<InterfaceProxy>) this.orchestratorLoader()
                 .create(this.introspector())
                 .factory(proxyType);
         Option<InterfaceProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         Proxy<?> proxyInstance = (Proxy<?>) proxy.get();
-        Assertions.assertNotNull(proxyInstance.manager());
+        assertThat(proxyInstance.manager()).isNotNull();
     }
 
     @ParameterizedTest
     @MethodSource("proxyTypes")
-    void testProxyManagerExposesTargetAndProxyType(Class<? extends InterfaceProxy> proxyType)
-        throws ApplicationException {
+    void proxyManagerExposesTargetAndProxyType(Class<? extends InterfaceProxy> proxyType)
+        throws Exception {
         ProxyFactory<InterfaceProxy> factory =
             (ProxyFactory<InterfaceProxy>) this.orchestratorLoader()
                 .create(this.introspector())
                 .factory(proxyType);
         Option<InterfaceProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         ProxyManager<InterfaceProxy> manager = ((Proxy<InterfaceProxy>) proxy.get()).manager();
-        Assertions.assertNotNull(manager.proxyClass());
-        Assertions.assertNotNull(manager.targetClass());
+        assertThat(manager.proxyClass()).isNotNull();
+        assertThat(manager.targetClass()).isNotNull();
 
-        Assertions.assertNotEquals(proxyType, manager.proxyClass());
-        Assertions.assertSame(proxyType, manager.targetClass());
+        assertThat(manager.proxyClass()).isNotEqualTo(proxyType);
+        assertThat(manager.targetClass()).isSameAs(proxyType);
 
-        Assertions.assertTrue(manager.orchestrator().isProxy(manager.proxyClass()));
+        assertThat(manager.orchestrator().isProxy(manager.proxyClass())).isTrue();
     }
 
     @Test
-    void testInterfaceProxyDoesNotEqual() throws ApplicationException {
+    void interfaceProxyDoesNotEqual() throws Exception {
         DemoServiceA serviceA1 = this.createProxy(DemoServiceA.class);
         DemoServiceA serviceA2 = this.createProxy(DemoServiceA.class);
 
-        Assertions.assertNotSame(serviceA1, serviceA2);
-        Assertions.assertNotEquals(serviceA1, serviceA2);
+        assertThat(serviceA2)
+                .isNotSameAs(serviceA1)
+                .isNotEqualTo(serviceA1);
     }
 
     @Test
-    void testAbstractClassProxyDoesNotEqual() throws ApplicationException {
+    void abstractClassProxyDoesNotEqual() throws Exception {
         DemoServiceB serviceC1 = this.createProxy(DemoServiceB.class);
         DemoServiceB serviceC2 = this.createProxy(DemoServiceB.class);
 
-        Assertions.assertNotSame(serviceC1, serviceC2);
-        Assertions.assertNotEquals(serviceC1, serviceC2);
+        assertThat(serviceC2)
+                .isNotSameAs(serviceC1)
+                .isNotEqualTo(serviceC1);
     }
 
     @Test
-    void testConcreteClassProxyWithoutDelegateDoesNotEqual() throws ApplicationException {
+    void concreteClassProxyWithoutDelegateDoesNotEqual() throws Exception {
         DemoServiceC serviceB1 = this.createProxy(DemoServiceC.class);
         DemoServiceC serviceB2 = this.createProxy(DemoServiceC.class);
 
-        Assertions.assertNotSame(serviceB1, serviceB2);
-        Assertions.assertNotEquals(serviceB1, serviceB2);
+        assertThat(serviceB2)
+                .isNotSameAs(serviceB1)
+                .isNotEqualTo(serviceB1);
     }
 
     @Test
-    public void testConcreteClassProxyWithNonEqualsImplementedDelegateDoesNotEqual()
-        throws ApplicationException {
+    public void concreteClassProxyWithNonEqualsImplementedDelegateDoesNotEqual()
+        throws Exception {
         CheckedSupplier<DemoServiceC> supplier =
             () -> this.orchestratorLoader().create(this.introspector())
                 .factory(DemoServiceC.class)
@@ -439,12 +458,13 @@ public abstract class ProxyTests {
         DemoServiceC serviceC3 = supplier.get();
         DemoServiceC serviceC4 = supplier.get();
 
-        Assertions.assertNotSame(serviceC3, serviceC4);
-        Assertions.assertNotEquals(serviceC3, serviceC4);
+        assertThat(serviceC4)
+                .isNotSameAs(serviceC3)
+                .isNotEqualTo(serviceC3);
     }
 
     @Test
-    void testConcreteClassProxyWithDelegateDoesNotEqual() throws ApplicationException {
+    void concreteClassProxyWithDelegateDoesNotEqual() throws Exception {
         CheckedSupplier<DemoServiceD> supplier =
             () -> this.orchestratorLoader().create(this.introspector())
                 .factory(DemoServiceD.class)
@@ -455,8 +475,9 @@ public abstract class ProxyTests {
         DemoServiceD serviceD1 = supplier.get();
         DemoServiceD serviceD2 = supplier.get();
 
-        Assertions.assertNotSame(serviceD1, serviceD2);
-        Assertions.assertEquals(serviceD1, serviceD2);
+        assertThat(serviceD2)
+                .isNotSameAs(serviceD1)
+                .isEqualTo(serviceD1);
     }
 
     private <T> T createProxy(Class<T> type) throws ApplicationException {
@@ -504,72 +525,72 @@ public abstract class ProxyTests {
     }
 
     @Test
-    void testConcreteProxySelfEquality() throws ApplicationException {
+    void concreteProxySelfEquality() throws Exception {
         ProxyFactory<EqualProxy> factory =
             this.orchestratorLoader().create(this.introspector()).factory(EqualProxy.class);
         Option<EqualProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         EqualProxy proxyInstance = proxy.get();
-        Assertions.assertEquals(proxyInstance, proxyInstance);
-        Assertions.assertTrue(proxyInstance.test(proxyInstance));
+        assertThat(proxyInstance).isEqualTo(proxyInstance);
+        assertThat(proxyInstance.test(proxyInstance)).isTrue();
     }
 
     @Test
-    void testServiceSelfEquality() throws ApplicationException {
+    void serviceSelfEquality() throws Exception {
         AbstractEqualProxy service = this.orchestratorLoader()
             .create(this.introspector())
             .factory(AbstractEqualProxy.class)
             .proxy()
             .get();
-        Assertions.assertEquals(service, service);
-        Assertions.assertTrue(service.test(service));
+        assertThat(service).isEqualTo(service);
+        assertThat(service.test(service)).isTrue();
     }
 
     @Test
-    void testInterfaceProxySelfEquality() throws ApplicationException {
+    void interfaceProxySelfEquality() throws Exception {
         ProxyFactory<EqualInterfaceProxy> factory = this.orchestratorLoader()
             .create(this.introspector())
             .factory(EqualInterfaceProxy.class);
         Option<EqualInterfaceProxy> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
+        assertThat(proxy.present()).isTrue();
 
         EqualInterfaceProxy proxyInstance = proxy.get();
-        Assertions.assertEquals(proxyInstance, proxyInstance);
-        Assertions.assertTrue(proxyInstance.test(proxyInstance));
+        assertThat(proxyInstance).isEqualTo(proxyInstance);
+        assertThat(proxyInstance.test(proxyInstance)).isTrue();
     }
 
     @Test
-    void testLambdaCanBeProxied() throws NoSuchMethodException, ApplicationException {
+    void lambdaCanBeProxied() throws Exception {
         Class<Supplier<String>> supplierClass = (Class<Supplier<String>>) (Class<?>) Supplier.class;
         StateAwareProxyFactory<Supplier<String>> factory =
             this.orchestratorLoader().create(this.introspector()).factory(supplierClass);
-        factory.advisors().method(Supplier.class.getMethod("get")).intercept(context -> "foo");
+        factory.advisors().method(Supplier.class.getMethod("get")).intercept(_ -> "foo");
         Option<Supplier<String>> proxy = factory.proxy();
-        Assertions.assertTrue(proxy.present());
-        Assertions.assertEquals("foo", proxy.get().get());
+        assertThat(proxy.present()).isTrue();
+        assertThat(proxy.get().get()).isEqualTo("foo");
     }
 
     @Test
-    void testIsProxyIsTrueIfTypeIsProxy() throws ApplicationException {
+    void isProxyIsTrueIfTypeIsProxy() throws Exception {
         Introspector introspector = this.introspector();
         ProxyOrchestrator orchestrator = this.orchestratorLoader().create(introspector);
         ProxyFactory<?> factory = orchestrator.factory(Object.class);
         Object proxy = factory.proxy().get();
 
         boolean instanceIsProxy = orchestrator.isProxy(proxy);
-        Assertions.assertTrue(instanceIsProxy);
+        assertThat(instanceIsProxy).isTrue();
 
         boolean typeIsProxy = orchestrator.isProxy(proxy.getClass());
-        Assertions.assertTrue(typeIsProxy);
+        assertThat(typeIsProxy).isTrue();
     }
 
     @Test
-    void testIsProxyIsFalseIfTypeIsNormal() {
+    void isProxyIsFalseIfTypeIsNormal() {
         Introspector introspector = this.introspector();
         ProxyOrchestrator orchestrator = this.orchestratorLoader().create(introspector);
         TypeView<?> view = introspector.introspect(Object.class);
         boolean isProxy = orchestrator.isProxy(view);
-        Assertions.assertFalse(isProxy);
+        assertThat(isProxy).isFalse();
     }
 }

--- a/hartshorn-reporting/src/test/java/test/org/dockbox/hartshorn/reporting/ApplicationReportingTests.java
+++ b/hartshorn-reporting/src/test/java/test/org/dockbox/hartshorn/reporting/ApplicationReportingTests.java
@@ -16,6 +16,7 @@
 
 package test.org.dockbox.hartshorn.reporting;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.reporting.DiagnosticsReport;
@@ -29,28 +30,29 @@ import org.dockbox.hartshorn.reporting.system.SystemDiagnosticsReporter;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.properties.GroupNode;
 import org.dockbox.hartshorn.util.properties.Node;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @UseReporting
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ApplicationReportingTests {
+class ApplicationReportingTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
-    void testApplicationDiagnosticsReportingPasses() {
+    void applicationDiagnosticsReportingPasses() {
         Reportable configurable = this.applicationContext.get(Reportable.class);
         DiagnosticsReportCollector collector =
             this.applicationContext.get(DiagnosticsReportCollector.class);
 
         DiagnosticsReport report = collector.report(configurable);
-        Assertions.assertNotNull(report);
+        assertThat(report).isNotNull();
     }
 
     @Test
-    void testApplicationDiagnosticsIncludeRequiredDiagnostics() {
+    void applicationDiagnosticsIncludeRequiredDiagnostics() {
         Reportable configurable = this.applicationContext.get(Reportable.class);
         DiagnosticsReportCollector collector =
             this.applicationContext.get(DiagnosticsReportCollector.class);
@@ -58,16 +60,16 @@ public class ApplicationReportingTests {
         DiagnosticsReport report = collector.report(configurable);
         Node<?> root = report.root();
 
-        Assertions.assertNotNull(report);
-        Assertions.assertNotNull(root);
-        Assertions.assertTrue(root instanceof GroupNode);
+        assertThat(report).isNotNull();
+        GroupNode group = assertThat(root)
+                .asInstanceOf(InstanceOfAssertFactories.type(GroupNode.class))
+                .actual();
 
-        GroupNode group = (GroupNode) root;
-        Assertions.assertFalse(group.value().isEmpty());
+        assertThat(group.value()).isNotEmpty();
 
-        Assertions.assertTrue(group.has(ApplicationDiagnosticsReporter.APPLICATION_CATEGORY));
-        Assertions.assertTrue(group.has(ComponentDiagnosticsReporter.COMPONENTS_CATEGORY));
-        Assertions.assertTrue(group.has(ComponentProcessorDiagnosticsReporter.COMPONENT_PROCESSORS_CATEGORY));
-        Assertions.assertTrue(group.has(SystemDiagnosticsReporter.SYSTEM_CATEGORY));
+        assertThat(group.has(ApplicationDiagnosticsReporter.APPLICATION_CATEGORY)).isTrue();
+        assertThat(group.has(ComponentDiagnosticsReporter.COMPONENTS_CATEGORY)).isTrue();
+        assertThat(group.has(ComponentProcessorDiagnosticsReporter.COMPONENT_PROCESSORS_CATEGORY)).isTrue();
+        assertThat(group.has(SystemDiagnosticsReporter.SYSTEM_CATEGORY)).isTrue();
     }
 }

--- a/hartshorn-reporting/src/test/java/test/org/dockbox/hartshorn/reporting/DiagnosticsPropertyWriterTests.java
+++ b/hartshorn-reporting/src/test/java/test/org/dockbox/hartshorn/reporting/DiagnosticsPropertyWriterTests.java
@@ -22,241 +22,243 @@ import org.dockbox.hartshorn.util.properties.GroupNode;
 import org.dockbox.hartshorn.util.properties.Node;
 import org.dockbox.hartshorn.util.properties.SimpleNode;
 import org.dockbox.hartshorn.reporting.collect.StandardDiagnosticsPropertyWriter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class DiagnosticsPropertyWriterTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class DiagnosticsPropertyWriterTests {
 
     protected DiagnosticsPropertyWriter writer(GroupNode group) {
         return new StandardDiagnosticsPropertyWriter("test", null, group);
     }
 
     @Test
-    void testWriterClosingRejectsFurtherChanges() {
+    void writerClosingRejectsFurtherChanges() {
         DiagnosticsPropertyWriter writer = this.writer(new GroupNode(""));
         writer.writeString("test"); // Expecting auto-close
-        Assertions.assertThrows(IllegalStateException.class, () -> writer.writeString("test"));
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> writer.writeString("test"));
     }
 
     @Test
-    void testIntegerPropertyWritingCreatesSimpleNode() {
+    void integerPropertyWritingCreatesSimpleNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeInt(1);
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof SimpleNode);
-        Assertions.assertEquals(node.value(), 1);
+        assertThat(node).isInstanceOf(SimpleNode.class);
+        assertThat(node.value()).isEqualTo(1);
     }
 
     @Test
-    void testLongPropertyWritingCreatesSimpleNode() {
+    void longPropertyWritingCreatesSimpleNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeLong(2L);
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof SimpleNode);
-        Assertions.assertEquals(node.value(), 2L);
+        assertThat(node).isInstanceOf(SimpleNode.class);
+        assertThat(node.value()).isEqualTo(2L);
     }
 
     @Test
-    void testFloatPropertyWritingCreatesSimpleNode() {
+    void floatPropertyWritingCreatesSimpleNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeFloat(3.0f);
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof SimpleNode);
-        Assertions.assertEquals(node.value(), 3.0f);
+        assertThat(node).isInstanceOf(SimpleNode.class);
+        assertThat(node.value()).isEqualTo(3.0f);
     }
 
     @Test
-    void testDoublePropertyWritingCreatesSimpleNode() {
+    void doublePropertyWritingCreatesSimpleNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeDouble(4.0d);
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof SimpleNode);
-        Assertions.assertEquals(node.value(), 4.0d);
+        assertThat(node).isInstanceOf(SimpleNode.class);
+        assertThat(node.value()).isEqualTo(4.0d);
     }
 
     @Test
-    void testBooleanPropertyWritingCreatesSimpleNode() {
+    void booleanPropertyWritingCreatesSimpleNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeBoolean(true);
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof SimpleNode);
-        Assertions.assertEquals(node.value(), true);
+        assertThat(node).isInstanceOf(SimpleNode.class);
+        assertThat(node.value()).isEqualTo(true);
     }
 
     @Test
-    void testStringPropertyWritingCreatesSimpleNode() {
+    void stringPropertyWritingCreatesSimpleNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeString("test");
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof SimpleNode);
-        Assertions.assertEquals(node.value(), "test");
+        assertThat(node).isInstanceOf(SimpleNode.class);
+        assertThat(node.value()).isEqualTo("test");
     }
 
     @Test
-    void testIntegerArrayPropertyWritingCreatesArrayNode() {
+    void integerArrayPropertyWritingCreatesArrayNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeInts(1, 2, 3);
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof ArrayNode);
+        assertThat(node).isInstanceOf(ArrayNode.class);
         ArrayNode<?> arrayNode = (ArrayNode<?>) node;
         List<?> values = arrayNode.value();
-        Assertions.assertEquals(values.size(), 3);
-        Assertions.assertEquals(values.get(0), 1);
-        Assertions.assertEquals(values.get(1), 2);
-        Assertions.assertEquals(values.get(2), 3);
+        assertThat(values).hasSize(3);
+        assertThat(values.get(0)).isEqualTo(1);
+        assertThat(values.get(1)).isEqualTo(2);
+        assertThat(values.get(2)).isEqualTo(3);
     }
 
     @Test
-    void testLongArrayPropertyWritingCreatesArrayNode() {
+    void longArrayPropertyWritingCreatesArrayNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeLongs(1L, 2L, 3L);
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof ArrayNode);
+        assertThat(node).isInstanceOf(ArrayNode.class);
         ArrayNode<?> arrayNode = (ArrayNode<?>) node;
         List<?> values = arrayNode.value();
-        Assertions.assertEquals(values.size(), 3);
-        Assertions.assertEquals(values.get(0), 1L);
-        Assertions.assertEquals(values.get(1), 2L);
-        Assertions.assertEquals(values.get(2), 3L);
+        assertThat(values).hasSize(3);
+        assertThat(values.get(0)).isEqualTo(1L);
+        assertThat(values.get(1)).isEqualTo(2L);
+        assertThat(values.get(2)).isEqualTo(3L);
     }
 
     @Test
-    void testFloatArrayPropertyWritingCreatesArrayNode() {
+    void floatArrayPropertyWritingCreatesArrayNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeFloats(1.0f, 2.0f, 3.0f);
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof ArrayNode);
+        assertThat(node).isInstanceOf(ArrayNode.class);
         ArrayNode<?> arrayNode = (ArrayNode<?>) node;
         List<?> values = arrayNode.value();
-        Assertions.assertEquals(values.size(), 3);
-        Assertions.assertEquals(values.get(0), 1.0f);
-        Assertions.assertEquals(values.get(1), 2.0f);
-        Assertions.assertEquals(values.get(2), 3.0f);
+        assertThat(values).hasSize(3);
+        assertThat(values.get(0)).isEqualTo(1.0f);
+        assertThat(values.get(1)).isEqualTo(2.0f);
+        assertThat(values.get(2)).isEqualTo(3.0f);
     }
 
     @Test
-    void testDoubleArrayPropertyWritingCreatesArrayNode() {
+    void doubleArrayPropertyWritingCreatesArrayNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeDoubles(1.0d, 2.0d, 3.0d);
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof ArrayNode);
+        assertThat(node).isInstanceOf(ArrayNode.class);
         ArrayNode<?> arrayNode = (ArrayNode<?>) node;
         List<?> values = arrayNode.value();
-        Assertions.assertEquals(values.size(), 3);
-        Assertions.assertEquals(values.get(0), 1.0d);
-        Assertions.assertEquals(values.get(1), 2.0d);
-        Assertions.assertEquals(values.get(2), 3.0d);
+        assertThat(values).hasSize(3);
+        assertThat(values.get(0)).isEqualTo(1.0d);
+        assertThat(values.get(1)).isEqualTo(2.0d);
+        assertThat(values.get(2)).isEqualTo(3.0d);
     }
 
     @Test
-    void testBooleanArrayPropertyWritingCreatesArrayNode() {
+    void booleanArrayPropertyWritingCreatesArrayNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeBooleans(true, false, true);
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof ArrayNode);
+        assertThat(node).isInstanceOf(ArrayNode.class);
         ArrayNode<?> arrayNode = (ArrayNode<?>) node;
         List<?> values = arrayNode.value();
-        Assertions.assertEquals(values.size(), 3);
-        Assertions.assertEquals(values.get(0), true);
-        Assertions.assertEquals(values.get(1), false);
-        Assertions.assertEquals(values.get(2), true);
+        assertThat(values).hasSize(3);
+        assertThat(values.get(0)).isEqualTo(true);
+        assertThat(values.get(1)).isEqualTo(false);
+        assertThat(values.get(2)).isEqualTo(true);
     }
 
     @Test
-    void testStringArrayPropertyWritingCreatesArrayNode() {
+    void stringArrayPropertyWritingCreatesArrayNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeStrings("test1", "test2", "test3");
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof ArrayNode);
+        assertThat(node).isInstanceOf(ArrayNode.class);
         ArrayNode<?> arrayNode = (ArrayNode<?>) node;
         List<?> values = arrayNode.value();
-        Assertions.assertEquals(values.size(), 3);
-        Assertions.assertEquals(values.get(0), "test1");
-        Assertions.assertEquals(values.get(1), "test2");
-        Assertions.assertEquals(values.get(2), "test3");
+        assertThat(values).hasSize(3);
+        assertThat(values.get(0)).isEqualTo("test1");
+        assertThat(values.get(1)).isEqualTo("test2");
+        assertThat(values.get(2)).isEqualTo("test3");
     }
 
     @Test
-    void testReportablePropertyWritingCreatesGroupNode() {
+    void reportablePropertyWritingCreatesGroupNode() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
 
         writer.writeDelegate(collector -> collector.property("test2").writeString("test2"));
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof GroupNode);
+        assertThat(node).isInstanceOf(GroupNode.class);
 
         GroupNode groupNode = (GroupNode) node;
-        Assertions.assertTrue(groupNode.has("test2"));
-        Assertions.assertEquals(groupNode.get("test2").value(), "test2");
+        assertThat(groupNode.has("test2")).isTrue();
+        assertThat(groupNode.get("test2").value()).isEqualTo("test2");
     }
 
     @Test
-    void testReportableArrayPropertyWritingCreatesArrayNodeOfGroups() {
+    void reportableArrayPropertyWritingCreatesArrayNodeOfGroups() {
         String propertyName = "test";
         GroupNode group = new GroupNode("test");
         DiagnosticsPropertyWriter writer = this.writer(group);
@@ -265,23 +267,22 @@ public class DiagnosticsPropertyWriterTests {
             collector -> collector.property("test2").writeString("test2"),
             collector -> collector.property("test3").writeString("test3")
         );
-        Assertions.assertTrue(group.has(propertyName));
+        assertThat(group.has(propertyName)).isTrue();
 
         Node<?> node = group.get(propertyName);
-        Assertions.assertTrue(node instanceof ArrayNode<?>);
+        assertThat(node).isInstanceOf(ArrayNode.class);
 
         ArrayNode<?> arrayNode = (ArrayNode<?>) node;
 
-        Assertions.assertEquals(arrayNode.value().size(), 2);
-        Assertions.assertTrue(arrayNode.value().get(0) instanceof GroupNode);
-        Assertions.assertTrue(arrayNode.value().get(1) instanceof GroupNode);
+        assertThat(arrayNode.value()).hasSize(2);
+        assertThat(arrayNode.value()).allMatch(GroupNode.class::isInstance);
 
         GroupNode groupNode1 = (GroupNode) arrayNode.value().get(0);
-        Assertions.assertTrue(groupNode1.has("test2"));
-        Assertions.assertEquals(groupNode1.get("test2").value(), "test2");
+        assertThat(groupNode1.has("test2")).isTrue();
+        assertThat(groupNode1.get("test2").value()).isEqualTo("test2");
 
         GroupNode groupNode2 = (GroupNode) arrayNode.value().get(1);
-        Assertions.assertTrue(groupNode2.has("test3"));
-        Assertions.assertEquals(groupNode2.get("test3").value(), "test3");
+        assertThat(groupNode2.has("test3")).isTrue();
+        assertThat(groupNode2.get("test3").value()).isEqualTo("test3");
     }
 }

--- a/hartshorn-reporting/src/test/java/test/org/dockbox/hartshorn/reporting/ReportingTests.java
+++ b/hartshorn-reporting/src/test/java/test/org/dockbox/hartshorn/reporting/ReportingTests.java
@@ -19,26 +19,26 @@ package test.org.dockbox.hartshorn.reporting;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.reporting.DiagnosticsReport;
 import org.dockbox.hartshorn.reporting.DiagnosticsReportCollector;
-import org.dockbox.hartshorn.reporting.ReportSerializationException;
 import org.dockbox.hartshorn.reporting.Reportable;
 import org.dockbox.hartshorn.reporting.UseReporting;
 import org.dockbox.hartshorn.reporting.serialize.ObjectMapperReportSerializer.JsonReportSerializer;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.properties.Node;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.dockbox.hartshorn.inject.annotations.Inject;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @UseReporting
 @HartshornIntegrationTest(includeBasePackages = false)
-public class ReportingTests {
+class ReportingTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
     @Test
-    void testSystemReporterCreatesNonNullReport() {
+    void systemReporterCreatesNonNullReport() {
         // Given
         Reportable configurable = this.applicationContext.get(Reportable.class);
         DiagnosticsReportCollector collector =
@@ -49,12 +49,12 @@ public class ReportingTests {
         Node<?> root = report.root();
 
         // Then
-        Assertions.assertNotNull(root);
+        assertThat(root).isNotNull();
     }
 
     @Test
-    void testSystemReporterCreatesNonNullReportWithCustomReportable()
-        throws ReportSerializationException {
+    void systemReporterCreatesNonNullReportWithCustomReportable()
+        throws Exception {
         // Given
         Reportable configurable = this.applicationContext.get(Reportable.class);
         DiagnosticsReportCollector collector =
@@ -64,8 +64,7 @@ public class ReportingTests {
         DiagnosticsReport report = collector.report(configurable);
         String serialized = report.serialize(new JsonReportSerializer());
 
-        // Then
-        Assertions.assertNotNull(serialized);
-        Assertions.assertFalse(serialized.isEmpty());
+        assertThat(serialized)
+                .isNotEmpty();
     }
 }

--- a/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/ContextTests.java
+++ b/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/ContextTests.java
@@ -19,19 +19,20 @@ package test.org.dockbox.hartshorn.util;
 import java.util.List;
 
 import org.dockbox.hartshorn.context.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.dockbox.hartshorn.context.ContextIdentity;
 import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.context.DefaultContext;
 import org.dockbox.hartshorn.context.DefaultNamedContext;
 import org.dockbox.hartshorn.context.SimpleContextIdentity;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ContextTests {
+class ContextTests {
 
     @Test
-    void testUnnamedContextFirst() {
+    void unnamedContextFirst() {
         Context context = new TestContext();
         Context child = new TestContext();
 
@@ -39,12 +40,12 @@ public class ContextTests {
 
         ContextIdentity<TestContext> key = new SimpleContextIdentity<>(TestContext.class);
         Option<TestContext> first = context.firstContext(key);
-        Assertions.assertTrue(first.present());
-        Assertions.assertSame(child, first.get());
+        assertThat(first.present()).isTrue();
+        assertThat(first.get()).isSameAs(child);
     }
 
     @Test
-    void testUnnamedContextAll() {
+    void unnamedContextAll() {
         Context context = new TestContext();
         Context child = new TestContext();
 
@@ -52,12 +53,12 @@ public class ContextTests {
 
         ContextIdentity<TestContext> key = new SimpleContextIdentity<>(TestContext.class);
         List<TestContext> all = context.contexts(key);
-        Assertions.assertNotNull(all);
-        Assertions.assertEquals(1, all.size());
+        assertThat(all)
+                .hasSize(1);
     }
 
     @Test
-    void testNamedContextFirstByName() {
+    void namedContextFirstByName() {
         Context context = new TestContext();
         NamedTestContext named = new NamedTestContext();
 
@@ -66,12 +67,12 @@ public class ContextTests {
         ContextIdentity<ContextView> key =
             new SimpleContextIdentity<>(ContextView.class, NamedTestContext.NAME);
         Option<ContextView> first = context.firstContext(key);
-        Assertions.assertTrue(first.present());
-        Assertions.assertSame(named, first.get());
+        assertThat(first.present()).isTrue();
+        assertThat(first.get()).isSameAs(named);
     }
 
     @Test
-    void testNamedContextFirstByNameAndType() {
+    void namedContextFirstByNameAndType() {
         Context context = new TestContext();
         NamedTestContext named = new NamedTestContext();
 
@@ -80,12 +81,12 @@ public class ContextTests {
         ContextIdentity<NamedTestContext> key =
             new SimpleContextIdentity<>(NamedTestContext.class, NamedTestContext.NAME);
         Option<NamedTestContext> first = context.firstContext(key);
-        Assertions.assertTrue(first.present());
-        Assertions.assertSame(named, first.get());
+        assertThat(first.present()).isTrue();
+        assertThat(first.get()).isSameAs(named);
     }
 
     @Test
-    void testManuallyNamedContextFirstByName() {
+    void manuallyNamedContextFirstByName() {
         Context context = new TestContext();
         ContextView child = new TestContext();
 
@@ -94,12 +95,12 @@ public class ContextTests {
         ContextIdentity<ContextView> key =
             new SimpleContextIdentity<>(ContextView.class, NamedTestContext.NAME);
         Option<ContextView> first = context.firstContext(key);
-        Assertions.assertTrue(first.present());
-        Assertions.assertSame(child, first.get());
+        assertThat(first.present()).isTrue();
+        assertThat(first.get()).isSameAs(child);
     }
 
     @Test
-    void testNamedContextAllByName() {
+    void namedContextAllByName() {
         Context context = new TestContext();
         NamedTestContext named = new NamedTestContext();
 
@@ -108,12 +109,12 @@ public class ContextTests {
         ContextIdentity<ContextView> key =
             new SimpleContextIdentity<>(ContextView.class, NamedTestContext.NAME);
         List<ContextView> all = context.contexts(key);
-        Assertions.assertNotNull(all);
-        Assertions.assertEquals(1, all.size());
+        assertThat(all)
+                .hasSize(1);
     }
 
     @Test
-    void testNamedContextAllByNameAndType() {
+    void namedContextAllByNameAndType() {
         Context context = new TestContext();
         NamedTestContext named = new NamedTestContext();
 
@@ -122,12 +123,12 @@ public class ContextTests {
         ContextIdentity<NamedTestContext> key =
             new SimpleContextIdentity<>(NamedTestContext.class, NamedTestContext.NAME);
         List<NamedTestContext> all = context.contexts(key);
-        Assertions.assertNotNull(all);
-        Assertions.assertEquals(1, all.size());
+        assertThat(all)
+                .hasSize(1);
     }
 
     @Test
-    void testManuallyNamedContextAllByName() {
+    void manuallyNamedContextAllByName() {
         Context context = new TestContext();
         ContextView child = new TestContext();
 
@@ -136,8 +137,8 @@ public class ContextTests {
         ContextIdentity<ContextView> key =
             new SimpleContextIdentity<>(ContextView.class, NamedTestContext.NAME);
         List<ContextView> all = context.contexts(key);
-        Assertions.assertNotNull(all);
-        Assertions.assertEquals(1, all.size());
+        assertThat(all)
+                .hasSize(1);
     }
 
     public static class TestContext extends DefaultContext {

--- a/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/GenericTypeTests.java
+++ b/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/GenericTypeTests.java
@@ -16,63 +16,63 @@
 
 package test.org.dockbox.hartshorn.util;
 
-import org.dockbox.hartshorn.util.types.GenericType;
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
+import org.dockbox.hartshorn.util.types.GenericType;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
 
-public class GenericTypeTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class GenericTypeTests {
 
     @Test
-    void testGenericTypeOfSimpleTypeIsCorrect() {
+    void genericTypeOfSimpleTypeIsCorrect() {
         GenericType<String> genericType = new GenericType<>() {
         };
         Type type = genericType.type();
-        Assertions.assertTrue(type instanceof Class<?>);
-        Assertions.assertEquals(String.class, type);
+        assertThat(type).isEqualTo(String.class);
 
         Option<Class<String>> classOption = genericType.asClass();
-        Assertions.assertTrue(classOption.present());
-        Assertions.assertSame(String.class, classOption.get());
+        assertThat(classOption.present()).isTrue();
+        assertThat(classOption.get()).isSameAs(String.class);
     }
 
     @Test
-    void testGenericTypeOfParameterizedTypeIsCorrect() {
+    void genericTypeOfParameterizedTypeIsCorrect() {
         GenericType<List<String>> genericType = new GenericType<>() {
         };
         Type type = genericType.type();
-        Assertions.assertTrue(type instanceof ParameterizedType);
+        assertThat(type).isInstanceOf(ParameterizedType.class);
 
         ParameterizedType parameterizedType = (ParameterizedType) type;
         Type[] typeArguments = parameterizedType.getActualTypeArguments();
-        Assertions.assertEquals(1, typeArguments.length);
-        Assertions.assertEquals(String.class, typeArguments[0]);
+        assertThat(typeArguments.length).isOne();
+        assertThat(typeArguments[0]).isEqualTo(String.class);
 
         Option<Class<List<String>>> classOption = genericType.asClass();
         // ParameterizedType should not yield a class
-        Assertions.assertTrue(classOption.absent());
+        assertThat(classOption.absent()).isTrue();
     }
 
     @Test
-    void testWildcardTypeYieldsObject() {
+    void wildcardTypeYieldsObject() {
         GenericType<?> genericType = new GenericType<>() {
         };
         Type type = genericType.type();
-        Assertions.assertTrue(type instanceof Class<?>);
-        Assertions.assertEquals(Object.class, type);
+        assertThat(type).isEqualTo(Object.class);
 
         Option<? extends Class<?>> classOption = genericType.asClass();
-        Assertions.assertTrue(classOption.present());
-        Assertions.assertEquals(Object.class, classOption.get());
+        assertThat(classOption.present()).isTrue();
+        assertThat(classOption.get()).isEqualTo(Object.class);
     }
 
     @Test
-    void testRawGenericTypeFails() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new GenericType() {
+    void rawGenericTypeFails() {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new GenericType() {
         });
     }
 }

--- a/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/IOUtilitiesTests.java
+++ b/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/IOUtilitiesTests.java
@@ -17,54 +17,54 @@
 package test.org.dockbox.hartshorn.util;
 
 import org.dockbox.hartshorn.util.IOUtilities;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
-public class IOUtilitiesTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IOUtilitiesTests {
 
     @TempDir
     private Path testDirectory;
 
     @Test
-    void testHasFileExtensionForPresentExtension() {
+    void hasFileExtensionForPresentExtension() {
         Path path = this.testDirectory.resolve("file.txt");
-        Assertions.assertTrue(IOUtilities.hasFileExtension(path));
+        assertThat(IOUtilities.hasFileExtension(path)).isTrue();
     }
 
     @Test
-    void testHasFileExtensionForAbsentExtension() {
+    void hasFileExtensionForAbsentExtension() {
         Path path = this.testDirectory.resolve("file");
-        Assertions.assertFalse(IOUtilities.hasFileExtension(path));
+        assertThat(IOUtilities.hasFileExtension(path)).isFalse();
     }
 
     @Test
-    void testGetFileExtensionForPresentExtension() {
+    void getFileExtensionForPresentExtension() {
         Path path = this.testDirectory.resolve("file.txt");
         String extension = IOUtilities.getFileExtension(path);
-        Assertions.assertEquals("txt", extension);
+        assertThat(extension).isEqualTo("txt");
     }
 
     @Test
-    void testGetFileExtensionForAbsentExtension() {
+    void getFileExtensionForAbsentExtension() {
         Path path = this.testDirectory.resolve("file");
         String extension = IOUtilities.getFileExtension(path);
-        Assertions.assertNull(extension);
+        assertThat(extension).isNull();
     }
 
     @Test
-    void testExistsForExistingFile() throws IOException {
+    void existsForExistingFile() throws Exception {
         Path path = this.testDirectory.resolve("file");
-        Assertions.assertTrue(path.toFile().createNewFile());
-        Assertions.assertTrue(IOUtilities.exists(path));
+        assertThat(path.toFile().createNewFile()).isTrue();
+        assertThat(IOUtilities.exists(path)).isTrue();
     }
 
     @Test
-    void testExistsForNotExistingFile() {
+    void existsForNotExistingFile() {
         Path path = this.testDirectory.resolve("doesnotexist");
-        Assertions.assertFalse(IOUtilities.exists(path));
+        assertThat(IOUtilities.exists(path)).isFalse();
     }
 }

--- a/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/MultimapTests.java
+++ b/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/MultimapTests.java
@@ -20,6 +20,9 @@ import java.util.Collection;
 import java.util.stream.Stream;
 
 import org.dockbox.hartshorn.util.collections.CollectionUtilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.dockbox.hartshorn.util.collections.ArrayListMultiMap;
 import org.dockbox.hartshorn.util.collections.ConcurrentSetMultiMap;
 import org.dockbox.hartshorn.util.collections.ConcurrentSetTreeMultiMap;
@@ -28,7 +31,6 @@ import org.dockbox.hartshorn.util.collections.HashSetMultiMap;
 import org.dockbox.hartshorn.util.collections.MultiMap;
 import org.dockbox.hartshorn.util.collections.SynchronizedArrayListMultiMap;
 import org.dockbox.hartshorn.util.collections.SynchronizedHashSetMultiMap;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -49,168 +51,166 @@ public class MultimapTests {
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testAllValuesIsNonNull(MultiMap<String, String> map) {
-        Assertions.assertNotNull(map.allValues());
-        Assertions.assertTrue(map.allValues().isEmpty());
+    void allValuesIsNonNull(MultiMap<String, String> map) {
+        assertThat(map.allValues()).isNotNull();
+        assertThat(map.allValues()).isEmpty();
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testGetReturnsEmptyCollectionIfAbsent(MultiMap<String, String> map) {
+    void getReturnsEmptyCollectionIfAbsent(MultiMap<String, String> map) {
         Collection<String> collection = map.get("test");
-        Assertions.assertNotNull(collection);
-        Assertions.assertTrue(collection.isEmpty());
+        assertThat(collection).isNotNull();
+        assertThat(collection).isEmpty();
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testPutCreatesCollection(MultiMap<String, String> map) {
+    void putCreatesCollection(MultiMap<String, String> map) {
         map.put("test", "test");
 
         Collection<String> collection = map.get("test");
-        Assertions.assertNotNull(collection);
-        Assertions.assertFalse(collection.isEmpty());
-        Assertions.assertEquals(1, collection.size());
+        assertThat(collection)
+                .isNotEmpty()
+                .hasSize(1);
 
         String value = CollectionUtilities.first(collection);
-        Assertions.assertEquals("test", value);
+        assertThat(value).isEqualTo("test");
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testPutMultipleAddsToCollection(MultiMap<String, String> map) {
+    void putMultipleAddsToCollection(MultiMap<String, String> map) {
         map.put("test", "test");
         map.put("test", "test2");
 
         Collection<String> collection = map.get("test");
-        Assertions.assertNotNull(collection);
-        Assertions.assertFalse(collection.isEmpty());
-        Assertions.assertEquals(2, collection.size());
-
-        Assertions.assertTrue(collection.contains("test"));
-        Assertions.assertTrue(collection.contains("test2"));
+        assertThat(collection)
+                .isNotEmpty()
+                .hasSize(2)
+                .contains("test")
+                .contains("test2");
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testPutIfAbsentDoesNotAddDuplicate(MultiMap<String, String> map) {
+    void putIfAbsentDoesNotAddDuplicate(MultiMap<String, String> map) {
         map.put("test", "test");
         map.putIfAbsent("test", "test");
 
         Collection<String> collection = map.get("test");
-        Assertions.assertNotNull(collection);
-        Assertions.assertFalse(collection.isEmpty());
-        Assertions.assertEquals(1, collection.size());
+        assertThat(collection)
+                .isNotEmpty()
+                .hasSize(1);
 
         String value = CollectionUtilities.first(collection);
-        Assertions.assertEquals("test", value);
+        assertThat(value).isEqualTo("test");
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testPutIfAbsentAddsIfAbsent(MultiMap<String, String> map) {
+    void putIfAbsentAddsIfAbsent(MultiMap<String, String> map) {
         map.put("test", "test");
         map.putIfAbsent("test", "test2");
 
-        Assertions.assertEquals(2, map.size());
-        Assertions.assertEquals(2, map.allValues().size());
+        assertThat(map.size()).isEqualTo(2);
+        assertThat(map.allValues()).hasSize(2);
 
         Collection<String> collection = map.get("test");
-        Assertions.assertNotNull(collection);
-        Assertions.assertFalse(collection.isEmpty());
-        Assertions.assertEquals(2, collection.size());
-
-        Assertions.assertTrue(collection.contains("test"));
-        Assertions.assertTrue(collection.contains("test2"));
+        assertThat(collection)
+                .isNotEmpty()
+                .hasSize(2)
+                .contains("test")
+                .contains("test2");
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testKeySetIsNonNull(MultiMap<String, String> map) {
-        Assertions.assertNotNull(map.keySet());
-        Assertions.assertTrue(map.keySet().isEmpty());
+    void keySetIsNonNull(MultiMap<String, String> map) {
+        assertThat(map.keySet()).isNotNull();
+        assertThat(map.keySet()).isEmpty();
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testKeySetContainsKey(MultiMap<String, String> map) {
+    void keySetContainsKey(MultiMap<String, String> map) {
         map.put("test", "test");
-        Assertions.assertTrue(map.keySet().contains("test"));
+        assertThat(map.keySet()).contains("test");
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testKeySetDoesNotContainKeyIfEmpty(MultiMap<String, String> map) {
-        Assertions.assertFalse(map.keySet().contains("test"));
+    void keySetDoesNotContainKeyIfEmpty(MultiMap<String, String> map) {
+        assertThat(map.keySet()).doesNotContain("test");
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testContainsKeyReturnsTrueIfKeyExists(MultiMap<String, String> map) {
+    void containsKeyReturnsTrueIfKeyExists(MultiMap<String, String> map) {
         map.put("test", "test");
-        Assertions.assertTrue(map.containsKey("test"));
+        assertThat(map.containsKey("test")).isTrue();
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testContainsKeyReturnsFalseIfKeyDoesNotExist(MultiMap<String, String> map) {
-        Assertions.assertFalse(map.containsKey("test"));
+    void containsKeyReturnsFalseIfKeyDoesNotExist(MultiMap<String, String> map) {
+        assertThat(map.containsKey("test")).isFalse();
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testContainsValueReturnsTrueIfValueExists(MultiMap<String, String> map) {
+    void containsValueReturnsTrueIfValueExists(MultiMap<String, String> map) {
         map.put("test", "test");
-        Assertions.assertTrue(map.containsValue("test"));
+        assertThat(map.containsValue("test")).isTrue();
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testContainsValueReturnsFalseIfValueDoesNotExist(MultiMap<String, String> map) {
-        Assertions.assertFalse(map.containsValue("test"));
+    void containsValueReturnsFalseIfValueDoesNotExist(MultiMap<String, String> map) {
+        assertThat(map.containsValue("test")).isFalse();
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testContainsEntryReturnsTrueIfEntryExists(MultiMap<String, String> map) {
+    void containsEntryReturnsTrueIfEntryExists(MultiMap<String, String> map) {
         map.put("test", "test");
-        Assertions.assertTrue(map.containsEntry("test", "test"));
+        assertThat(map.containsEntry("test", "test")).isTrue();
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testContainsEntryReturnsFalseIfEntryDoesNotExist(MultiMap<String, String> map) {
-        Assertions.assertFalse(map.containsEntry("test", "test"));
+    void containsEntryReturnsFalseIfEntryDoesNotExist(MultiMap<String, String> map) {
+        assertThat(map.containsEntry("test", "test")).isFalse();
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testRemoveRemovesAllEntries(MultiMap<String, String> map) {
+    void removeRemovesAllEntries(MultiMap<String, String> map) {
         map.put("test", "test");
-        Assertions.assertTrue(map.containsEntry("test", "test"));
+        assertThat(map.containsEntry("test", "test")).isTrue();
 
         map.remove("test", "test");
-        Assertions.assertFalse(map.containsEntry("test", "test"));
+        assertThat(map.containsEntry("test", "test")).isFalse();
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testRemoveKeyRemovesKey(MultiMap<String, String> map) {
+    void removeKeyRemovesKey(MultiMap<String, String> map) {
         map.put("test", "test");
-        Assertions.assertTrue(map.containsKey("test"));
+        assertThat(map.containsKey("test")).isTrue();
 
         map.remove("test");
-        Assertions.assertFalse(map.containsKey("test"));
+        assertThat(map.containsKey("test")).isFalse();
     }
 
     @ParameterizedTest
     @MethodSource("multiMapImplementations")
-    void testReplaceReplacesMatchingEntries(MultiMap<String, String> map) {
+    void replaceReplacesMatchingEntries(MultiMap<String, String> map) {
         map.put("test", "test");
-        Assertions.assertTrue(map.containsEntry("test", "test"));
+        assertThat(map.containsEntry("test", "test")).isTrue();
 
         map.replace("test", "test", "test2");
-        Assertions.assertFalse(map.containsEntry("test", "test"));
-        Assertions.assertTrue(map.containsEntry("test", "test2"));
+        assertThat(map.containsEntry("test", "test")).isFalse();
+        assertThat(map.containsEntry("test", "test2")).isTrue();
     }
 }

--- a/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/NodeTests.java
+++ b/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/NodeTests.java
@@ -21,119 +21,121 @@ import org.dockbox.hartshorn.util.properties.GroupNode;
 import org.dockbox.hartshorn.util.properties.Node;
 import org.dockbox.hartshorn.util.properties.NodeVisitor;
 import org.dockbox.hartshorn.util.properties.SimpleNode;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class NodeTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+class NodeTests {
 
     @Test
-    void testSimpleNodeCanHaveNullValue() {
+    void simpleNodeCanHaveNullValue() {
         Node<Object> node = new SimpleNode<>("node", null);
-        Assertions.assertNull(node.value());
+        assertThat(node.value()).isNull();
     }
 
     @Test
-    void testArrayNodeIsNonNull() {
+    void arrayNodeIsNonNull() {
         Node<List<Object>> node = new ArrayNode<>("node");
-        Assertions.assertNotNull(node.value());
-        Assertions.assertTrue(node.value().isEmpty());
+        assertThat(node.value()).isNotNull();
+        assertThat(node.value()).isEmpty();
     }
 
     @Test
-    void testArrayNodeUsesInsertionOrder() {
+    void arrayNodeUsesInsertionOrder() {
         Node<List<Object>> node = new ArrayNode<>("node", "a", "b", "c");
-        Assertions.assertEquals("a", node.value().get(0));
-        Assertions.assertEquals("b", node.value().get(1));
-        Assertions.assertEquals("c", node.value().get(2));
+        assertThat(node.value().get(0)).isEqualTo("a");
+        assertThat(node.value().get(1)).isEqualTo("b");
+        assertThat(node.value().get(2)).isEqualTo("c");
     }
 
     @Test
-    void testGroupNodeIsNonNull() {
+    void groupNodeIsNonNull() {
         Node<List<Node<?>>> node = new GroupNode("node");
-        Assertions.assertNotNull(node.value());
-        Assertions.assertTrue(node.value().isEmpty());
+        assertThat(node.value()).isNotNull();
+        assertThat(node.value()).isEmpty();
     }
 
     @Test
-    void testGroupNodeUsesInsertionOrder() {
+    void groupNodeUsesInsertionOrder() {
         GroupNode node = new GroupNode("node");
         node.add(new SimpleNode<>("a", "a"));
         node.add(new SimpleNode<>("b", "b"));
         node.add(new SimpleNode<>("c", "c"));
-        Assertions.assertEquals("a", node.value().get(0).value());
-        Assertions.assertEquals("b", node.value().get(1).value());
-        Assertions.assertEquals("c", node.value().get(2).value());
+        assertThat(node.value().get(0).value()).isEqualTo("a");
+        assertThat(node.value().get(1).value()).isEqualTo("b");
+        assertThat(node.value().get(2).value()).isEqualTo("c");
     }
 
     @Test
-    void testSimpleNodeValueVisitor() {
+    void simpleNodeValueVisitor() {
         Node<Integer> node = new SimpleNode<>("node", 12);
         node.accept(new NodeVisitor<Void>() {
             @Override
             public Void visit(Node<?> node) {
-                Assertions.assertEquals(12, node.value());
+                assertThat(node.value()).isEqualTo(12);
                 return null;
             }
 
             @Override
             public Void visit(GroupNode node) {
-                Assertions.fail("GroupNode should not be visited");
+                fail("GroupNode should not be visited");
                 return null;
             }
 
             @Override
             public Void visit(ArrayNode<?> node) {
-                Assertions.fail("ArrayNode should not be visited");
+                fail("ArrayNode should not be visited");
                 return null;
             }
         });
     }
 
     @Test
-    void testGroupNodeValueVisitor() {
+    void groupNodeValueVisitor() {
         GroupNode node = new GroupNode("node");
         node.accept(new NodeVisitor<Void>() {
             @Override
             public Void visit(Node<?> node) {
-                Assertions.fail("Node should not be visited");
+                fail("Node should not be visited");
                 return null;
             }
 
             @Override
             public Void visit(GroupNode node) {
-                Assertions.assertEquals("node", node.name());
+                assertThat(node.name()).isEqualTo("node");
                 return null;
             }
 
             @Override
             public Void visit(ArrayNode<?> node) {
-                Assertions.fail("ArrayNode should not be visited");
+                fail("ArrayNode should not be visited");
                 return null;
             }
         });
     }
 
     @Test
-    void testArrayNodeValueVisitor() {
+    void arrayNodeValueVisitor() {
         ArrayNode<Integer> node = new ArrayNode<>("node");
         node.accept(new NodeVisitor<Void>() {
             @Override
             public Void visit(Node<?> node) {
-                Assertions.fail("Node should not be visited");
+                fail("Node should not be visited");
                 return null;
             }
 
             @Override
             public Void visit(GroupNode node) {
-                Assertions.fail("GroupNode should not be visited");
+                fail("GroupNode should not be visited");
                 return null;
             }
 
             @Override
             public Void visit(ArrayNode<?> node) {
-                Assertions.assertEquals("node", node.name());
+                assertThat(node.name()).isEqualTo("node");
                 return null;
             }
         });

--- a/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/ObjectDescriberTest.java
+++ b/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/ObjectDescriberTest.java
@@ -18,25 +18,26 @@ package test.org.dockbox.hartshorn.util;
 
 import org.dockbox.hartshorn.util.describe.ObjectDescriber;
 import org.dockbox.hartshorn.util.describe.ObjectDescriptionStyle;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ObjectDescriberTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObjectDescriberTest {
 
     @Test
-    void testStyle() {
+    void style() {
         String description = ObjectDescriber.of(new Object(), new TestObjectDescriptionStyle())
             .field("field1", "value1")
             .field("field2", "value2")
             .describe();
 
         String[] descriptionElements = description.split("\\+");
-        Assertions.assertEquals(5, descriptionElements.length);
-        Assertions.assertEquals(TestObjectDescriptionStyle.START, descriptionElements[0]);
-        Assertions.assertEquals("FIELD:field1:value1", descriptionElements[1]);
-        Assertions.assertEquals(TestObjectDescriptionStyle.FIELD_SEPARATOR, descriptionElements[2]);
-        Assertions.assertEquals("FIELD:field2:value2", descriptionElements[3]);
-        Assertions.assertEquals(TestObjectDescriptionStyle.END, descriptionElements[4]);
+        assertThat(descriptionElements.length).isEqualTo(5);
+        assertThat(descriptionElements[0]).isEqualTo(TestObjectDescriptionStyle.START);
+        assertThat(descriptionElements[1]).isEqualTo("FIELD:field1:value1");
+        assertThat(descriptionElements[2]).isEqualTo(TestObjectDescriptionStyle.FIELD_SEPARATOR);
+        assertThat(descriptionElements[3]).isEqualTo("FIELD:field2:value2");
+        assertThat(descriptionElements[4]).isEqualTo(TestObjectDescriptionStyle.END);
     }
 
     private static class TestObjectDescriptionStyle implements ObjectDescriptionStyle {

--- a/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/OptionTests.java
+++ b/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/OptionTests.java
@@ -22,270 +22,271 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 import org.junit.jupiter.api.Test;
 
-public class OptionTests {
+class OptionTests {
 
     @Test
-    void testOfNonNull() {
+    void ofNonNull() {
         Option<String> option = Option.of("test");
-        Assertions.assertTrue(option.present());
-        Assertions.assertFalse(option.absent());
-        Assertions.assertEquals("test", option.get());
+        assertThat(option.present()).isTrue();
+        assertThat(option.absent()).isFalse();
+        assertThat(option.get()).isEqualTo("test");
     }
 
     @Test
-    void testOfNull() {
+    void ofNull() {
         Option<String> option = Option.of((String) null);
-        Assertions.assertFalse(option.present());
-        Assertions.assertTrue(option.absent());
-        Assertions.assertThrows(NoSuchElementException.class, option::get);
+        assertThat(option.present()).isFalse();
+        assertThat(option.absent()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(option::get);
     }
 
     @Test
-    void testOfOptional() {
+    void ofOptional() {
         Option<String> option = Option.of(Optional.of("test"));
-        Assertions.assertTrue(option.present());
-        Assertions.assertFalse(option.absent());
-        Assertions.assertEquals("test", option.get());
+        assertThat(option.present()).isTrue();
+        assertThat(option.absent()).isFalse();
+        assertThat(option.get()).isEqualTo("test");
     }
 
     @Test
-    void testOfOptionalEmpty() {
+    void ofOptionalEmpty() {
         Option<String> option = Option.of(Optional.empty());
-        Assertions.assertFalse(option.present());
-        Assertions.assertTrue(option.absent());
-        Assertions.assertThrows(NoSuchElementException.class, option::get);
+        assertThat(option.present()).isFalse();
+        assertThat(option.absent()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(option::get);
     }
 
     @Test
-    void testOfSupplier() {
+    void ofSupplier() {
         Option<String> option = Option.of(() -> "test");
-        Assertions.assertTrue(option.present());
-        Assertions.assertFalse(option.absent());
-        Assertions.assertEquals("test", option.get());
+        assertThat(option.present()).isTrue();
+        assertThat(option.absent()).isFalse();
+        assertThat(option.get()).isEqualTo("test");
     }
 
     @Test
-    void testOfSupplierNull() {
+    void ofSupplierNull() {
         Option<String> option = Option.of(() -> null);
-        Assertions.assertFalse(option.present());
-        Assertions.assertTrue(option.absent());
-        Assertions.assertThrows(NoSuchElementException.class, option::get);
+        assertThat(option.present()).isFalse();
+        assertThat(option.absent()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(option::get);
     }
 
     @Test
-    void testEmpty() {
+    void empty() {
         Option<String> option = Option.empty();
-        Assertions.assertFalse(option.present());
-        Assertions.assertTrue(option.absent());
-        Assertions.assertThrows(NoSuchElementException.class, option::get);
+        assertThat(option.present()).isFalse();
+        assertThat(option.absent()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(option::get);
     }
 
     @Test
-    void testPeekWhenPresent() {
+    void peekWhenPresent() {
         Option<String> option = Option.of("test");
         AtomicBoolean called = new AtomicBoolean(false);
         option.peek(value -> {
-            Assertions.assertEquals("test", value);
+            assertThat(value).isEqualTo("test");
             called.set(true);
         });
-        Assertions.assertTrue(called.get());
+        assertThat(called.get()).isTrue();
     }
 
     @Test
-    void testPeekWhenAbsent() {
+    void peekWhenAbsent() {
         Option<String> option = Option.empty();
         AtomicBoolean called = new AtomicBoolean(false);
         option.peek(value -> {
-            Assertions.fail("Should not be called");
+            fail("Should not be called");
             called.set(true);
         });
-        Assertions.assertFalse(called.get());
+        assertThat(called.get()).isFalse();
     }
 
     @Test
-    void testOnEmptyWhenPresent() {
+    void onEmptyWhenPresent() {
         Option<String> option = Option.of("test");
         AtomicBoolean called = new AtomicBoolean(false);
         option.onEmpty(() -> {
-            Assertions.fail("Should not be called");
+            fail("Should not be called");
             called.set(true);
         });
-        Assertions.assertFalse(called.get());
+        assertThat(called.get()).isFalse();
     }
 
     @Test
-    void testOnEmptyWhenAbsent() {
+    void onEmptyWhenAbsent() {
         Option<String> option = Option.empty();
         AtomicBoolean called = new AtomicBoolean(false);
         option.onEmpty(() -> called.set(true));
-        Assertions.assertTrue(called.get());
+        assertThat(called.get()).isTrue();
     }
 
     @Test
-    void testOrNullWhenPresent() {
+    void orNullWhenPresent() {
         Option<String> option = Option.of("test");
-        Assertions.assertEquals("test", option.orNull());
+        assertThat(option.orNull()).isEqualTo("test");
     }
 
     @Test
-    void testOrNullWhenAbsent() {
+    void orNullWhenAbsent() {
         Option<String> option = Option.empty();
-        Assertions.assertNull(option.orNull());
+        assertThat(option.orNull()).isNull();
     }
 
     @Test
-    void testOrElseWhenPresent() {
+    void orElseWhenPresent() {
         Option<String> option = Option.of("test");
-        Assertions.assertEquals("test", option.orElse("test2"));
+        assertThat(option.orElse("test2")).isEqualTo("test");
     }
 
     @Test
-    void testOrElseWhenAbsent() {
+    void orElseWhenAbsent() {
         Option<String> option = Option.empty();
-        Assertions.assertEquals("test2", option.orElse("test2"));
+        assertThat(option.orElse("test2")).isEqualTo("test2");
     }
 
     @Test
-    void testOrElseGetWhenPresent() {
+    void orElseGetWhenPresent() {
         Option<String> option = Option.of("test");
-        Assertions.assertEquals("test", option.orElseGet(() -> "test2"));
+        assertThat(option.orElseGet(() -> "test2")).isEqualTo("test");
     }
 
     @Test
-    void testOrElseGetWhenAbsent() {
+    void orElseGetWhenAbsent() {
         Option<String> option = Option.empty();
-        Assertions.assertEquals("test2", option.orElseGet(() -> "test2"));
+        assertThat(option.orElseGet(() -> "test2")).isEqualTo("test2");
     }
 
     @Test
-    void testOrElseThrowWhenPresent() {
+    void orElseThrowWhenPresent() {
         Option<String> option = Option.of("test");
-        Assertions.assertEquals("test", option.orElseThrow(IllegalArgumentException::new));
+        assertThat(option.orElseThrow(IllegalArgumentException::new)).isEqualTo("test");
     }
 
     @Test
-    void testOrElseThrowWhenAbsent() {
+    void orElseThrowWhenAbsent() {
         Option<String> option = Option.empty();
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> option.orElseThrow(IllegalArgumentException::new));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> option.orElseThrow(IllegalArgumentException::new));
     }
 
     @Test
-    void testOrComputeWhenPresent() {
+    void orComputeWhenPresent() {
         Option<String> option = Option.of("test");
-        Assertions.assertEquals("test", option.orCompute(() -> "test2").get());
+        assertThat(option.orCompute(() -> "test2").get()).isEqualTo("test");
     }
 
     @Test
-    void testOrComputeWhenAbsent() {
+    void orComputeWhenAbsent() {
         Option<String> option = Option.empty();
-        Assertions.assertEquals("test2", option.orCompute(() -> "test2").get());
+        assertThat(option.orCompute(() -> "test2").get()).isEqualTo("test2");
     }
 
     @Test
-    void testToOptionalWhenPresent() {
+    void toOptionalWhenPresent() {
         Option<String> option = Option.of("test");
         Optional<String> optional = option.optional();
-        Assertions.assertTrue(optional.isPresent());
-        Assertions.assertEquals("test", optional.get());
+        assertThat(optional).hasValue("test");
     }
 
     @Test
-    void testToOptionalWhenAbsent() {
+    void toOptionalWhenAbsent() {
         Option<String> option = Option.empty();
         Optional<String> optional = option.optional();
-        Assertions.assertFalse(optional.isPresent());
+        assertThat(optional).isEmpty();
     }
 
     @Test
-    void testToStreamWhenPresent() {
+    void toStreamWhenPresent() {
         Option<String> option = Option.of("test");
-        Assertions.assertEquals(1, option.stream().count());
+        assertThat(option.stream().count()).isOne();
         Optional<String> optional = option.stream().findFirst();
-        Assertions.assertTrue(optional.isPresent());
-        Assertions.assertEquals("test", optional.get());
+        assertThat(optional).hasValue("test");
     }
 
     @Test
-    void testToStreamWhenAbsent() {
+    void toStreamWhenAbsent() {
         Option<String> option = Option.empty();
         Stream<String> stream = option.stream();
-        Assertions.assertEquals(0, stream.count());
+        assertThat(stream.count()).isZero();
     }
 
     @Test
-    void testMapWhenPresent() {
+    void mapWhenPresent() {
         Option<String> option = Option.of("test");
         Option<Integer> mapped = option.map(String::length);
-        Assertions.assertTrue(mapped.present());
-        Assertions.assertEquals(4, mapped.get());
+        assertThat(mapped.present()).isTrue();
+        assertThat(mapped.get()).isEqualTo(4);
     }
 
     @Test
-    void testMapWhenAbsent() {
+    void mapWhenAbsent() {
         Option<String> option = Option.empty();
         Option<Integer> mapped = option.map(String::length);
-        Assertions.assertTrue(mapped.absent());
+        assertThat(mapped.absent()).isTrue();
     }
 
     @Test
-    void testFlatMapWhenPresent() {
+    void flatMapWhenPresent() {
         Option<String> option = Option.of("test");
         Option<Integer> mapped = option.flatMap(value -> Option.of(value.length()));
-        Assertions.assertTrue(mapped.present());
-        Assertions.assertEquals(4, mapped.get());
+        assertThat(mapped.present()).isTrue();
+        assertThat(mapped.get()).isEqualTo(4);
     }
 
     @Test
-    void testFlatMapWhenAbsent() {
+    void flatMapWhenAbsent() {
         Option<String> option = Option.empty();
         Option<Integer> mapped = option.flatMap(value -> Option.of(value.length()));
-        Assertions.assertTrue(mapped.absent());
+        assertThat(mapped.absent()).isTrue();
     }
 
     @Test
-    void testFilterWhenPresentAndMatches() {
+    void filterWhenPresentAndMatches() {
         Option<String> option = Option.of("test");
         Option<String> filtered = option.filter(value -> value.length() == 4);
-        Assertions.assertTrue(filtered.present());
-        Assertions.assertEquals("test", filtered.get());
+        assertThat(filtered.present()).isTrue();
+        assertThat(filtered.get()).isEqualTo("test");
     }
 
     @Test
-    void testFilterWhenPresentAndDoesNotMatch() {
+    void filterWhenPresentAndDoesNotMatch() {
         Option<String> option = Option.of("test");
         Option<String> filtered = option.filter(value -> value.length() == 5);
-        Assertions.assertTrue(filtered.absent());
+        assertThat(filtered.absent()).isTrue();
     }
 
     @Test
-    void testFilterWhenAbsent() {
+    void filterWhenAbsent() {
         Option<String> option = Option.empty();
         Option<String> filtered = option.filter(value -> {
-            Assertions.fail("Should not be called");
+            fail("Should not be called");
             return true;
         });
-        Assertions.assertTrue(filtered.absent());
+        assertThat(filtered.absent()).isTrue();
     }
 
     @Test
-    void testContainsWhenPresentAndMatches() {
+    void containsWhenPresentAndMatches() {
         Option<String> option = Option.of("test");
-        Assertions.assertTrue(option.contains("test"));
+        assertThat(option.contains("test")).isTrue();
     }
 
     @Test
-    void testContainsWhenPresentAndDoesNotMatch() {
+    void containsWhenPresentAndDoesNotMatch() {
         Option<String> option = Option.of("test");
-        Assertions.assertFalse(option.contains("test2"));
+        assertThat(option.contains("test2")).isFalse();
     }
 
     @Test
-    void testContainsWhenAbsent() {
+    void containsWhenAbsent() {
         Option<String> option = Option.empty();
-        Assertions.assertFalse(option.contains("test"));
+        assertThat(option.contains("test")).isFalse();
     }
 }

--- a/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/TristateTests.java
+++ b/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/TristateTests.java
@@ -17,21 +17,22 @@
 package test.org.dockbox.hartshorn.util;
 
 import org.dockbox.hartshorn.util.Tristate;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TristateTests {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TristateTests {
 
     @Test
-    void testBooleanValues() {
-        Assertions.assertTrue(Tristate.TRUE.booleanValue());
-        Assertions.assertFalse(Tristate.FALSE.booleanValue());
-        Assertions.assertFalse(Tristate.UNDEFINED.booleanValue());
+    void booleanValues() {
+        assertThat(Tristate.TRUE.booleanValue()).isTrue();
+        assertThat(Tristate.FALSE.booleanValue()).isFalse();
+        assertThat(Tristate.UNDEFINED.booleanValue()).isFalse();
     }
 
     @Test
-    void testValueOf() {
-        Assertions.assertEquals(Tristate.TRUE, Tristate.valueOf(true));
-        Assertions.assertEquals(Tristate.FALSE, Tristate.valueOf(false));
+    void valueOf() {
+        assertThat(Tristate.valueOf(true)).isEqualTo(Tristate.TRUE);
+        assertThat(Tristate.valueOf(false)).isEqualTo(Tristate.FALSE);
     }
 }

--- a/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/TupleTests.java
+++ b/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/TupleTests.java
@@ -17,38 +17,41 @@
 package test.org.dockbox.hartshorn.util;
 
 import org.dockbox.hartshorn.util.Tuple;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map.Entry;
 
-public class TupleTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class TupleTests {
 
     @Test
-    public void testFirstValueIsStored() {
+    void firstValueIsStored() {
         Entry<?, ?> tuple = Tuple.of(1, "two");
-        Assertions.assertEquals(1, tuple.getKey());
-        Assertions.assertInstanceOf(Integer.class, tuple.getKey());
+        assertThat(tuple.getKey()).isEqualTo(1);
+        assertThat(tuple.getKey()).isInstanceOf(Integer.class);
     }
 
     @Test
-    public void testSecondValueIsStored() {
+    void secondValueIsStored() {
         Entry<?, ?> tuple = Tuple.of(1, "two");
-        Assertions.assertEquals("two", tuple.getValue());
-        Assertions.assertInstanceOf(String.class, tuple.getValue());
+        assertThat(tuple.getValue()).isEqualTo("two");
+        assertThat(tuple.getValue()).isInstanceOf(String.class);
     }
 
     @Test
-    public void testEqualsUsesValues() {
+    void equalsUsesValues() {
         Entry<?, ?> tuple = Tuple.of(1, "two");
         Entry<?, ?> second = Tuple.of(1, "two");
-        Assertions.assertNotSame(tuple, second);
-        Assertions.assertEquals(tuple, second);
+        assertThat(second)
+                .isNotSameAs(tuple)
+                .isEqualTo(tuple);
     }
 
     @Test
-    void testTupleIsImmutable() {
+    void tupleIsImmutable() {
         Entry<Integer, String> tuple = Tuple.of(1, "two");
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> tuple.setValue("three"));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> tuple.setValue("three"));
     }
 }

--- a/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/TypeUtilitiesTests.java
+++ b/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/TypeUtilitiesTests.java
@@ -17,12 +17,13 @@
 package test.org.dockbox.hartshorn.util;
 
 import org.dockbox.hartshorn.util.types.TypeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeUtilitiesTests {
 
@@ -41,8 +42,8 @@ public class TypeUtilitiesTests {
 
     @ParameterizedTest
     @MethodSource("primitiveStrings")
-    void testPrimitivesFromString(Class<?> primitive, String value, Object real) {
+    void primitivesFromString(Class<?> primitive, String value, Object real) {
         Object out = TypeUtils.toPrimitive(primitive, value);
-        Assertions.assertEquals(real, out);
+        assertThat(out).isEqualTo(real);
     }
 }

--- a/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/UtilitiesTests.java
+++ b/hartshorn-shared/src/test/java/test/org/dockbox/hartshorn/util/UtilitiesTests.java
@@ -16,13 +16,12 @@
 
 package test.org.dockbox.hartshorn.util;
 
-import org.dockbox.hartshorn.util.collections.CollectionUtilities;
 import org.dockbox.hartshorn.util.NotPrimitiveException;
 import org.dockbox.hartshorn.util.StringUtilities;
+import org.dockbox.hartshorn.util.collections.CollectionUtilities;
+import org.dockbox.hartshorn.util.option.Option;
 import org.dockbox.hartshorn.util.types.TypeConversionException;
 import org.dockbox.hartshorn.util.types.TypeUtils;
-import org.dockbox.hartshorn.util.option.Option;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -36,6 +35,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 public class UtilitiesTests {
 
@@ -117,160 +119,168 @@ public class UtilitiesTests {
 
     @ParameterizedTest
     @MethodSource("capitalizeValues")
-    void testCapitalizeChangesOnlyFirstCharacter(String input, String expected) {
+    void capitalizeChangesOnlyFirstCharacter(String input, String expected) {
         String value = StringUtilities.capitalize(input);
-        Assertions.assertNotNull(value);
-        Assertions.assertEquals(expected, value);
+        assertThat(value)
+                .isNotNull()
+                .isEqualTo(expected);
     }
 
     @Test
-    void testCapitalizeAcceptsEmptyValue() {
-        String value = Assertions.assertDoesNotThrow(() -> StringUtilities.capitalize(""));
-        Assertions.assertNotNull(value);
-        Assertions.assertEquals("", value);
+    void capitalizeAcceptsEmptyValue() {
+        String value = StringUtilities.capitalize("");
+        assertThat(value).isNotNull();
+        assertThat(value).isEmpty();
     }
 
     @Test
-    void testIsEmptyStringTrueIfNull() {
-        Assertions.assertTrue(StringUtilities.empty(null));
+    void isEmptyStringTrueIfNull() {
+        assertThat(StringUtilities.empty(null)).isTrue();
     }
 
     @Test
-    void testIsEmptyStringTrueIfEmpty() {
-        Assertions.assertTrue(StringUtilities.empty(""));
+    void isEmptyStringTrueIfEmpty() {
+        assertThat(StringUtilities.empty("")).isTrue();
     }
 
     @Test
-    void testIsEmptyStringFalseIfContent() {
-        Assertions.assertFalse(StringUtilities.empty("value"));
+    void isEmptyStringFalseIfContent() {
+        assertThat(StringUtilities.empty("value")).isFalse();
     }
 
     @Test
-    void testIsNotEmptyStringFalseIfNull() {
-        Assertions.assertFalse(StringUtilities.notEmpty(null));
+    void isNotEmptyStringFalseIfNull() {
+        assertThat(StringUtilities.notEmpty(null)).isFalse();
     }
 
     @Test
-    void testIsNotEmptyStringFalseIfEmpty() {
-        Assertions.assertFalse(StringUtilities.notEmpty(""));
+    void isNotEmptyStringFalseIfEmpty() {
+        assertThat(StringUtilities.notEmpty("")).isFalse();
     }
 
     @Test
-    void testIsNotEmptyStringTrueIfContent() {
-        Assertions.assertTrue(StringUtilities.notEmpty("value"));
+    void isNotEmptyStringTrueIfContent() {
+        assertThat(StringUtilities.notEmpty("value")).isTrue();
     }
 
     @Test
-    void testStripReplacesAllSpaces() {
+    void stripReplacesAllSpaces() {
         String stripped = StringUtilities.strip(" val ue  ");
-        Assertions.assertNotNull(stripped);
-        Assertions.assertEquals("value", stripped);
+        assertThat(stripped)
+                .isNotNull()
+                .isEqualTo("value");
     }
 
     @Test
-    void testStripReplacesAllTabs() {
+    void stripReplacesAllTabs() {
         String stripped = StringUtilities.strip("\tval\tue\t\t");
-        Assertions.assertNotNull(stripped);
-        Assertions.assertEquals("value", stripped);
+        assertThat(stripped)
+                .isNotNull()
+                .isEqualTo("value");
     }
 
     @Test
-    void testStripReplacesAllNewLines() {
+    void stripReplacesAllNewLines() {
         String stripped = StringUtilities.strip("\nval\nue\n\n");
-        Assertions.assertNotNull(stripped);
-        Assertions.assertEquals("value", stripped);
+        assertThat(stripped)
+                .isNotNull()
+                .isEqualTo("value");
     }
 
     @Test
-    void testStripReplacesAllCarriageReturns() {
+    void stripReplacesAllCarriageReturns() {
         String stripped = StringUtilities.strip("\rval\rue\r\r");
-        Assertions.assertNotNull(stripped);
-        Assertions.assertEquals("value", stripped);
+        assertThat(stripped)
+                .isNotNull()
+                .isEqualTo("value");
     }
 
     @Test
-    void testTrimWithSpaces() {
+    void trimWithSpaces() {
         String trimmed = StringUtilities.trimWith(' ', " value  ");
-        Assertions.assertNotNull(trimmed);
-        Assertions.assertEquals("value", trimmed);
+        assertThat(trimmed)
+                .isNotNull()
+                .isEqualTo("value");
     }
 
     @Test
-    void testTrimWithRegExCharacter() {
+    void trimWithRegExCharacter() {
         String trimmed = StringUtilities.trimWith('$', "$value$$");
-        Assertions.assertNotNull(trimmed);
-        Assertions.assertEquals("value", trimmed);
+        assertThat(trimmed)
+                .isNotNull()
+                .isEqualTo("value");
     }
 
     @Test
-    void testCollectionMerge() {
+    void collectionMerge() {
         Collection<Integer> col1 = Arrays.asList(1, 2, 3);
         Collection<Integer> col2 = Arrays.asList(4, 5, 6);
         Collection<Integer> merged = CollectionUtilities.merge(col1, col2);
 
-        Assertions.assertEquals(6, merged.size());
-        Assertions.assertTrue(merged.containsAll(Arrays.asList(1, 2, 3, 4, 5, 6)));
+        assertThat(merged)
+                .hasSize(6)
+                .containsAll(Arrays.asList(1, 2, 3, 4, 5, 6));
     }
 
     @ParameterizedTest
     @MethodSource("durations")
-    void testDurationOf(String in, long expected) {
+    void durationOf(String in, long expected) {
         Option<Duration> duration = StringUtilities.durationOf(in);
-        Assertions.assertTrue(duration.present());
-        Assertions.assertEquals(expected, duration.get().getSeconds());
+        assertThat(duration.present()).isTrue();
+        assertThat(duration.get()).hasSeconds(expected);
     }
 
     @Test
-    void testDurationOfWithInvalidValue() {
+    void durationOfWithInvalidValue() {
         Option<Duration> duration = StringUtilities.durationOf("NotAValidDurationString");
-        Assertions.assertFalse(duration.present());
+        assertThat(duration.present()).isFalse();
     }
 
     @ParameterizedTest
     @MethodSource("differences")
-    void testDifferenceInCollections(
+    void differenceInCollections(
         Collection<String> collectionOne,
         Collection<String> collectionTwo,
         Collection<String> expected
     ) {
         Set<String> difference = CollectionUtilities.difference(collectionOne, collectionTwo);
-        Assertions.assertEquals(difference.size(), expected.size());
-        Assertions.assertTrue(difference.containsAll(expected));
-        Assertions.assertTrue(expected.containsAll(difference));
+        assertThat(expected).hasSameSizeAs(difference);
+        assertThat(difference).containsAll(expected);
+        assertThat(expected).containsAll(difference);
     }
 
     @Test
-    void testSplitCapitals() {
+    void splitCapitals() {
         String input = "ThisIsAString";
         String[] expected = {"This", "Is", "A", "String"};
         String[] actual = StringUtilities.splitCapitals(input);
-        Assertions.assertArrayEquals(expected, actual);
+        assertThat(actual).containsExactly(expected);
     }
 
     @ParameterizedTest
     @MethodSource("stringFormats")
-    void testFormat(String format, String expected, Object... args) {
+    void format(String format, String expected, Object... args) {
         String actual = StringUtilities.format(format, args);
-        Assertions.assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @ParameterizedTest
     @MethodSource("stringMapFormats")
-    void testMapFormat(String format, String expected, Map<String, String> replacements) {
+    void mapFormat(String format, String expected, Map<String, String> replacements) {
         String actual = StringUtilities.format(format, replacements);
-        Assertions.assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @ParameterizedTest
     @MethodSource("stringJoinValues")
-    <T> void testJoin(
+    <T> void join(
         String delimiter,
         Iterable<T> elements,
         Function<T, String> toStringFunction,
         String expected
     ) {
         String joined = StringUtilities.join(delimiter, elements, toStringFunction);
-        Assertions.assertEquals(expected, joined);
+        assertThat(joined).isEqualTo(expected);
     }
 
     public static Stream<Arguments> stringsToPrimitives() {
@@ -307,62 +317,57 @@ public class UtilitiesTests {
     @MethodSource("stringsToPrimitives")
     <T> void testToPrimitive(String input, Class<T> type, T expected) {
         T actual = TypeUtils.toPrimitive(type, input);
-        Assertions.assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
-    void testToPrimitiveDoesNotAcceptObjects() {
-        Assertions.assertThrows(NotPrimitiveException.class,
-            () -> TypeUtils.toPrimitive(Object.class, "value"));
-        Assertions.assertThrows(NotPrimitiveException.class,
-            () -> TypeUtils.toPrimitive(String.class, "value"));
-        Assertions.assertThrows(NotPrimitiveException.class,
-            () -> TypeUtils.toPrimitive(List.class, "value"));
+    void toPrimitiveDoesNotAcceptObjects() {
+        assertThatExceptionOfType(NotPrimitiveException.class).isThrownBy(() -> TypeUtils.toPrimitive(Object.class, "value"));
+        assertThatExceptionOfType(NotPrimitiveException.class).isThrownBy(() -> TypeUtils.toPrimitive(String.class, "value"));
+        assertThatExceptionOfType(NotPrimitiveException.class).isThrownBy(() -> TypeUtils.toPrimitive(List.class, "value"));
     }
 
     @ParameterizedTest
     @MethodSource("invalidStringsToPrimitives")
-    <T> void testToPrimitiveThrowsOnInvalidInput(String input, Class<T> type) {
-        Assertions.assertThrows(TypeConversionException.class,
-            () -> TypeUtils.toPrimitive(type, input));
+    <T> void toPrimitiveThrowsOnInvalidInput(String input, Class<T> type) {
+        assertThatExceptionOfType(TypeConversionException.class).isThrownBy(() -> TypeUtils.toPrimitive(type, input));
     }
 
     @Test
-    void testValidWildcardAdjustment() {
+    void validWildcardAdjustment() {
         List<?> list = Arrays.asList("one", "two", "three");
-        List<String> adjusted =
-            Assertions.assertDoesNotThrow(() -> TypeUtils.unchecked(list, List.class));
-        Assertions.assertNotNull(adjusted);
-        Assertions.assertSame(list, adjusted);
+        List<String> adjusted = TypeUtils.unchecked(list, List.class);
+        assertThat(adjusted)
+                .isNotNull()
+                .isSameAs(list);
     }
 
     @Test
-    void testWildcardAdjustmentDoesAdjustParent() {
+    void wildcardAdjustmentDoesAdjustParent() {
         List<?> list = Arrays.asList("one", "two", "three");
-        List<String> adjusted =
-            Assertions.assertDoesNotThrow(() -> TypeUtils.unchecked(list, Collection.class));
-        Assertions.assertNotNull(adjusted);
-        Assertions.assertSame(list, adjusted);
+        List<String> adjusted = TypeUtils.unchecked(list, Collection.class);
+        assertThat(adjusted)
+                .isNotNull()
+                .isSameAs(list);
     }
 
     @Test
-    void testAnnotationCreatesEmptyAnnotation() {
+    void annotationCreatesEmptyAnnotation() {
         TestAnnotation annotation = TypeUtils.annotation(TestAnnotation.class);
-        Assertions.assertNotNull(annotation);
+        assertThat(annotation).isNotNull();
     }
 
     @Test
-    void testAnnotationCreatesAnnotationWithValues() {
+    void annotationCreatesAnnotationWithValues() {
         TestAnnotationWithValue annotation =
             TypeUtils.annotation(TestAnnotationWithValue.class, Map.of("value", "test"));
-        Assertions.assertNotNull(annotation);
-        Assertions.assertEquals("test", annotation.value());
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.value()).isEqualTo("test");
     }
 
     @Test
-    void testAnnotationValidatesValues() {
-        Assertions.assertThrows(IllegalStateException.class,
-            () -> TypeUtils.annotation(TestAnnotationWithValue.class, Map.of("value", 1)));
+    void annotationValidatesValues() {
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> TypeUtils.annotation(TestAnnotationWithValue.class, Map.of("value", 1)));
     }
 
     private @interface TestAnnotation {

--- a/hartshorn-spi/pom.xml
+++ b/hartshorn-spi/pom.xml
@@ -26,6 +26,12 @@
       <groupId>com.google.testing.compile</groupId>
       <artifactId>compile-testing</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/hartshorn-spi/src/test/java/org/dockbox/hartshorn/spi/DiscoveryServiceTests.java
+++ b/hartshorn-spi/src/test/java/org/dockbox/hartshorn/spi/DiscoveryServiceTests.java
@@ -25,7 +25,6 @@ import org.dockbox.hartshorn.util.collections.CollectionUtilities;
 import org.dockbox.hartshorn.util.collections.MultiMap;
 import org.dockbox.hartshorn.util.collections.MultiMapCollector;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.tools.JavaFileObject;
@@ -38,7 +37,11 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-public class DiscoveryServiceTests {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class
+DiscoveryServiceTests {
 
     private static final String IMPLEMENTATION_NAME = "HelloWorldSupplierImplementation";
     private static final String IMPLEMENTATION_QUALIFIED_NAME =
@@ -67,16 +70,17 @@ public class DiscoveryServiceTests {
     }
 
     @Test
-    void testDiscoveryServiceWithOverride() throws IOException, ServiceDiscoveryException {
+    void discoveryServiceWithOverride() throws Exception {
         ByteClassLoader classLoader = createImplementationAwareClassLoader();
 
         DiscoveryService.instance().addClassLoader(classLoader);
         DiscoveryService.instance()
             .override(HelloWorldSupplier.class, IMPLEMENTATION_QUALIFIED_NAME);
 
-        HelloWorldSupplier helloWorldSupplier =
-            DiscoveryService.instance().discover(HelloWorldSupplier.class);
-        Assertions.assertEquals(HELLO_WORLD_MESSAGE, helloWorldSupplier.getHelloWorld());
+        HelloWorldSupplier helloWorldSupplier = DiscoveryService.instance()
+                .discover(HelloWorldSupplier.class);
+        assertThat(helloWorldSupplier.getHelloWorld())
+                .isEqualTo(HELLO_WORLD_MESSAGE);
     }
 
     @NonNull
@@ -92,89 +96,103 @@ public class DiscoveryServiceTests {
     }
 
     @Test
-    void testRegistryContainsTypeAfterRegistration() throws IOException {
+    void registryContainsTypeAfterRegistration() throws Exception {
         ByteClassLoader classLoader = createImplementationAwareClassLoader();
         DiscoveryService.instance().addClassLoader(classLoader);
 
-        Assertions.assertFalse(DiscoveryService.instance().contains(HelloWorldSupplier.class));
+        assertThat(
+                DiscoveryService.instance().contains(HelloWorldSupplier.class)
+        ).isFalse();
 
         DiscoveryService.instance()
             .override(HelloWorldSupplier.class, IMPLEMENTATION_QUALIFIED_NAME);
-        Assertions.assertTrue(DiscoveryService.instance().contains(HelloWorldSupplier.class));
+
+        assertThat(
+                DiscoveryService.instance().contains(HelloWorldSupplier.class)
+        ).isTrue();
     }
 
     @Test
-    void testDiscoveryFailsIfNoImplementationExists() {
-        Assertions.assertThrows(ServiceDiscoveryException.class,
-            () -> DiscoveryService.instance().discover(HelloWorldSupplier.class));
-    }
-
-    @Test
-    void testDiscoveryFailsIfImplementationClassDoesNotExist() {
-        Assertions.assertThrows(ServiceDiscoveryException.class, () -> {
-            DiscoveryService.instance()
-                .override(HelloWorldSupplier.class, "org.dockbox.hartshorn.spi.DoesNotExist");
+    void discoveryFailsIfNoImplementationExists() {
+        assertThatThrownBy(() -> {
             DiscoveryService.instance().discover(HelloWorldSupplier.class);
-        });
+        }).isInstanceOf(ServiceDiscoveryException.class);
     }
 
     @Test
-    void testOverrideFailsIfImplementationNotAssignable() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> DiscoveryService.instance()
-                .override(HelloWorldSupplier.class, DiscoveryServiceTests.class));
-    }
-
-    @Test
-    void testDiscoveryFailsIfImplementationHasNoDefaultConstructor() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+    void discoveryFailsIfImplementationClassDoesNotExist() {
+        assertThatThrownBy(() -> {
             DiscoveryService.instance()
-                .override(HelloWorldSupplier.class,
-                    HelloWorldSupplierImplementationWithNoDefaultConstructor.class);
+                    .override(HelloWorldSupplier.class, "org.dockbox.hartshorn.spi.DoesNotExist");
             DiscoveryService.instance().discover(HelloWorldSupplier.class);
-        });
+        }).isInstanceOf(ServiceDiscoveryException.class);
     }
 
     @Test
-    void testDiscoveryForMultipleImplementations() throws ServiceDiscoveryException {
+    void overrideFailsIfImplementationNotAssignable() {
+        assertThatThrownBy(() -> {
+            DiscoveryService.instance().override(
+                    HelloWorldSupplier.class,
+                    DiscoveryServiceTests.class
+            );
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void discoveryFailsIfImplementationHasNoDefaultConstructor() {
+        assertThatThrownBy(() -> {
+            DiscoveryService.instance().override(
+                    HelloWorldSupplier.class,
+                    HelloWorldSupplierImplementationWithNoDefaultConstructor.class
+            );
+            DiscoveryService.instance().discover(HelloWorldSupplier.class);
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void discoveryForMultipleImplementations() throws Exception {
         DiscoveryService.instance()
             .override(HelloWorldSupplier.class, HelloWorldSupplierImplementationA.class);
         DiscoveryService.instance()
             .override(HelloWorldSupplier.class, HelloWorldSupplierImplementationB.class);
 
-        Assertions.assertThrows(ServiceDiscoveryException.class,
-            () -> DiscoveryService.instance().discover(HelloWorldSupplier.class));
+        assertThatThrownBy(() -> {
+            DiscoveryService.instance().discover(HelloWorldSupplier.class);
+        }).isInstanceOf(ServiceDiscoveryException.class);
+
         Set<HelloWorldSupplier> suppliers =
             DiscoveryService.instance().discoverAll(HelloWorldSupplier.class);
-        Assertions.assertEquals(2, suppliers.size());
-        Assertions.assertTrue(suppliers.stream()
-            .anyMatch(HelloWorldSupplierImplementationA.class::isInstance));
-        Assertions.assertTrue(suppliers.stream()
-            .anyMatch(HelloWorldSupplierImplementationB.class::isInstance));
+        assertThat(suppliers)
+                .hasSize(2)
+                .anyMatch(HelloWorldSupplierImplementationA.class::isInstance)
+                .anyMatch(HelloWorldSupplierImplementationB.class::isInstance);
     }
 
     @Test
-    void testDiscoveryFailsIfImplementationConstructorFails() {
-        DiscoveryService.instance()
-            .override(HelloWorldSupplier.class,
-                HelloWorldSupplierImplementationWithErrorInConstructor.class);
-        Assertions.assertThrows(ServiceDiscoveryException.class,
-            () -> DiscoveryService.instance().discover(HelloWorldSupplier.class));
+    void discoveryFailsIfImplementationConstructorFails() {
+        DiscoveryService.instance().override(
+                HelloWorldSupplier.class,
+                HelloWorldSupplierImplementationWithErrorInConstructor.class
+        );
+        assertThatThrownBy(() -> {
+            DiscoveryService.instance().discover(HelloWorldSupplier.class);
+        }).isInstanceOf(ServiceDiscoveryException.class);
     }
 
     private static JavaFileObject compileAndGetRuntimeImplementation() {
         Compilation compilation = Compiler.javac()
             .compile(JavaFileObjects.forSourceString(IMPLEMENTATION_NAME,
                 HELLO_WORLD_SUPPLIER_IMPLEMENTATION_SOURCE));
-        Assertions.assertTrue(compilation.errors().isEmpty());
+
+        assertThat(compilation.errors()).isEmpty();
 
         ImmutableList<JavaFileObject> generatedFiles = compilation.generatedFiles();
-        Assertions.assertEquals(1, generatedFiles.size());
+        assertThat(generatedFiles).hasSize(1);
 
         MultiMap<Kind, JavaFileObject> generatedByKind = generatedFiles.stream()
             .collect(MultiMapCollector.groupingBy(JavaFileObject::getKind));
-        Assertions.assertEquals(1,
-            generatedByKind.get(Kind.CLASS).size()); // HelloWorldSupplierImplementation.class
+        assertThat(generatedByKind.get(Kind.CLASS))
+                        .hasSize(1); // HelloWorldSupplierImplementation.class
 
         return CollectionUtilities.first(generatedByKind.get(Kind.CLASS));
     }


### PR DESCRIPTION
### Type of Change
- [x] Chore (changes to the build process or auxiliary tools)

### Description
Mass-migrates tests to use AssertJ instead of JUnit's default assertions. To do so, this sets up OpenRewrite. OR will remain in the build configuration, to ensure consistency in future tests. To aid this configuration, the Checkstyle rules have been updated to reject JUnit's Assertions class from being imported.

### Checklist

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added documentation that describes my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch
