### PR TITLE
#1153 Add SPI wrappers for Jackson registry loaders

### DIFF
--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonJavaPropsSpiPropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonJavaPropsSpiPropertyRegistryLoader.java
@@ -19,11 +19,13 @@ package org.dockbox.hartshorn.properties.loader.support;
 import org.dockbox.hartshorn.properties.PropertyRegistry;
 import org.dockbox.hartshorn.properties.loader.FilePropertyRegistryLoader;
 import org.dockbox.hartshorn.properties.loader.PredicatePropertyRegistryLoader;
+import org.dockbox.hartshorn.util.IOUtilities;
 import org.dockbox.hartshorn.util.types.TypeUtils;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.Set;
+
 /**
  * An SPI wrapper for {@link JacksonJavaPropsPropertyRegistryLoader}, to safely allow for safe
  * runtime interactions, even if required dependencies are missing.
@@ -49,15 +51,16 @@ public class JacksonJavaPropsSpiPropertyRegistryLoader
 
     @Override
     public boolean isCompatible(URI path) {
-        return CAN_LOAD;
+        return CAN_LOAD && JacksonJavaPropsPropertyRegistryLoader.DEFAULT_EXTENSIONS.contains(
+                IOUtilities.getFileExtension(path)
+        );
     }
 
     @Override
     public void loadRegistry(PropertyRegistry registry, URI path) throws IOException {
         if (CAN_LOAD) {
             DelegateHolder.INSTANCE.loadRegistry(registry, path);
-        }
-        else {
+        } else {
             throw new IllegalStateException(
                     "Jackson JavaProps support is not available" +
                             " (missing jackson-dataformat-properties)"

--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonJavaPropsSpiPropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonJavaPropsSpiPropertyRegistryLoader.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.properties.loader.support;
+
+import org.dockbox.hartshorn.properties.PropertyRegistry;
+import org.dockbox.hartshorn.properties.loader.FilePropertyRegistryLoader;
+import org.dockbox.hartshorn.properties.loader.PredicatePropertyRegistryLoader;
+import org.dockbox.hartshorn.util.types.TypeUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Set;
+/**
+ * An SPI wrapper for {@link JacksonJavaPropsPropertyRegistryLoader}, to safely allow for safe
+ * runtime interactions, even if required dependencies are missing.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
+public class JacksonJavaPropsSpiPropertyRegistryLoader
+        implements PredicatePropertyRegistryLoader, FilePropertyRegistryLoader {
+
+    public static final boolean CAN_LOAD =
+            TypeUtils.exists("tools.jackson.dataformat.javaprop.JavaPropsMapper");
+
+    @Override
+    public Set<String> supportedExtensions() {
+        // If Jackson JavaProps is absent, the loader cannot support any extension.
+        if (CAN_LOAD) {
+            return JacksonJavaPropsPropertyRegistryLoader.DEFAULT_EXTENSIONS;
+        }
+        return Set.of();
+    }
+
+    @Override
+    public boolean isCompatible(URI path) {
+        return CAN_LOAD;
+    }
+
+    @Override
+    public void loadRegistry(PropertyRegistry registry, URI path) throws IOException {
+        if (CAN_LOAD) {
+            DelegateHolder.INSTANCE.loadRegistry(registry, path);
+        }
+        else {
+            throw new IllegalStateException(
+                    "Jackson JavaProps support is not available" +
+                            " (missing jackson-dataformat-properties)"
+            );
+        }
+    }
+
+    private static final class DelegateHolder {
+        static final JacksonJavaPropsPropertyRegistryLoader INSTANCE =
+                new JacksonJavaPropsPropertyRegistryLoader();
+    }
+}

--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonYamlSpiPropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonYamlSpiPropertyRegistryLoader.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.properties.loader.support;
+
+import org.dockbox.hartshorn.properties.PropertyRegistry;
+import org.dockbox.hartshorn.properties.loader.FilePropertyRegistryLoader;
+import org.dockbox.hartshorn.properties.loader.PredicatePropertyRegistryLoader;
+import org.dockbox.hartshorn.util.types.TypeUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Set;
+
+/**
+ * An SPI wrapper for {@link JacksonYamlPropertyRegistryLoader}, to safely allow for safe runtime
+ * interactions, even if required dependencies are missing.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
+public class JacksonYamlSpiPropertyRegistryLoader
+        implements PredicatePropertyRegistryLoader, FilePropertyRegistryLoader {
+
+    public static final boolean CAN_LOAD =
+            TypeUtils.exists("tools.jackson.dataformat.yaml.YAMLMapper");
+
+    @Override
+    public Set<String> supportedExtensions() {
+        // If Jackson YAML is absent, the loader cannot support any extension.
+        if (CAN_LOAD) {
+            return JacksonYamlPropertyRegistryLoader.DEFAULT_EXTENSIONS;
+        }
+        return Set.of();
+    }
+
+    @Override
+    public boolean isCompatible(URI path) {
+        return CAN_LOAD;
+    }
+
+    @Override
+    public void loadRegistry(PropertyRegistry registry, URI path) throws IOException {
+        if (CAN_LOAD) {
+            DelegateHolder.INSTANCE.loadRegistry(registry, path);
+        }
+        else {
+            throw new IllegalStateException(
+                    "Jackson YAML support is not available (missing jackson-dataformat-yaml)"
+            );
+        }
+    }
+
+    private static final class DelegateHolder {
+        static final JacksonYamlPropertyRegistryLoader INSTANCE =
+                new JacksonYamlPropertyRegistryLoader();
+    }
+}

--- a/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonYamlSpiPropertyRegistryLoader.java
+++ b/hartshorn-properties/src/main/java/org/dockbox/hartshorn/properties/loader/support/JacksonYamlSpiPropertyRegistryLoader.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.properties.loader.support;
 import org.dockbox.hartshorn.properties.PropertyRegistry;
 import org.dockbox.hartshorn.properties.loader.FilePropertyRegistryLoader;
 import org.dockbox.hartshorn.properties.loader.PredicatePropertyRegistryLoader;
+import org.dockbox.hartshorn.util.IOUtilities;
 import org.dockbox.hartshorn.util.types.TypeUtils;
 
 import java.io.IOException;
@@ -50,7 +51,9 @@ public class JacksonYamlSpiPropertyRegistryLoader
 
     @Override
     public boolean isCompatible(URI path) {
-        return CAN_LOAD;
+        return CAN_LOAD && JacksonYamlPropertyRegistryLoader.DEFAULT_EXTENSIONS.contains(
+                IOUtilities.getFileExtension(path)
+        );
     }
 
     @Override

--- a/hartshorn-properties/src/main/resources/META-INF/services/org.dockbox.hartshorn.properties.loader.PropertyRegistryPathLoader
+++ b/hartshorn-properties/src/main/resources/META-INF/services/org.dockbox.hartshorn.properties.loader.PropertyRegistryPathLoader
@@ -1,2 +1,2 @@
-org.dockbox.hartshorn.properties.loader.support.JacksonYamlPropertyRegistryLoader
-org.dockbox.hartshorn.properties.loader.support.JacksonJavaPropsPropertyRegistryLoader
+org.dockbox.hartshorn.properties.loader.support.JacksonYamlSpiPropertyRegistryLoader
+org.dockbox.hartshorn.properties.loader.support.JacksonJavaPropsSpiPropertyRegistryLoader

--- a/hartshorn-properties/src/test/java/test/org/dockbox/hartshorn/properties/loader/JacksonPropertyRegistryPathLoaderTests.java
+++ b/hartshorn-properties/src/test/java/test/org/dockbox/hartshorn/properties/loader/JacksonPropertyRegistryPathLoaderTests.java
@@ -20,7 +20,6 @@ import org.dockbox.hartshorn.properties.ConfiguredProperty;
 import org.dockbox.hartshorn.properties.MapPropertyRegistry;
 import org.dockbox.hartshorn.properties.PropertyRegistry;
 import org.dockbox.hartshorn.properties.loader.PropertyRegistryPathLoader;
-import org.dockbox.hartshorn.properties.loader.StylePropertyPathFormatter;
 import org.dockbox.hartshorn.properties.loader.support.JacksonYamlPropertyRegistryLoader;
 import org.dockbox.hartshorn.properties.value.StandardValuePropertyParsers;
 import org.junit.jupiter.api.Test;
@@ -36,8 +35,7 @@ class JacksonPropertyRegistryPathLoaderTests {
     @Test
     void complexYamlConfigurationCanBeLoaded() throws Exception {
         // Given
-        PropertyRegistryPathLoader loader =
-            new JacksonYamlPropertyRegistryLoader(new StylePropertyPathFormatter());
+        PropertyRegistryPathLoader loader = new JacksonYamlPropertyRegistryLoader();
         Path path = Path.of("src/test/resources/complex-configuration.yml");
 
         // When: Loading registry

--- a/hartshorn-properties/src/test/java/test/org/dockbox/hartshorn/properties/loader/JacksonPropertyRegistryPathLoaderTests.java
+++ b/hartshorn-properties/src/test/java/test/org/dockbox/hartshorn/properties/loader/JacksonPropertyRegistryPathLoaderTests.java
@@ -43,7 +43,7 @@ class JacksonPropertyRegistryPathLoaderTests {
         loader.loadRegistry(registry, path.toUri());
 
         // Then: Should contain all expected keys
-        List<ConfiguredProperty> properties = registry.find(property -> true);
+        List<ConfiguredProperty> properties = registry.find(_ -> true);
         assertThat(properties).hasSize(12);
 
         // Then: Keys should be ordered

--- a/hartshorn-properties/src/test/java/test/org/dockbox/hartshorn/properties/loader/SpiPropertyRegistryLoaderTests.java
+++ b/hartshorn-properties/src/test/java/test/org/dockbox/hartshorn/properties/loader/SpiPropertyRegistryLoaderTests.java
@@ -1,0 +1,69 @@
+package test.org.dockbox.hartshorn.properties.loader;
+
+import org.assertj.core.api.Assertions;
+import org.dockbox.hartshorn.properties.loader.FilePropertyRegistryLoader;
+import org.dockbox.hartshorn.properties.loader.PredicatePropertyRegistryLoader;
+import org.dockbox.hartshorn.properties.loader.support.JacksonJavaPropsPropertyRegistryLoader;
+import org.dockbox.hartshorn.properties.loader.support.JacksonJavaPropsSpiPropertyRegistryLoader;
+import org.dockbox.hartshorn.properties.loader.support.JacksonYamlPropertyRegistryLoader;
+import org.dockbox.hartshorn.properties.loader.support.JacksonYamlSpiPropertyRegistryLoader;
+import org.dockbox.hartshorn.util.types.TypeUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.net.URI;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public class SpiPropertyRegistryLoaderTests {
+
+    // checkstyle:off LineLength
+    public static Stream<Arguments> spiLoaderArguments() {
+        Stream<Arguments> yaml = JacksonYamlPropertyRegistryLoader.DEFAULT_EXTENSIONS.stream()
+                .map(extension -> Arguments.of(
+                        "tools.jackson.dataformat.yaml.YAMLMapper",
+                        extension,
+                        (Supplier<PredicatePropertyRegistryLoader>) JacksonYamlSpiPropertyRegistryLoader::new
+                ));
+        Stream<Arguments> javaProps = JacksonJavaPropsPropertyRegistryLoader.DEFAULT_EXTENSIONS.stream()
+                .map(extension -> Arguments.of(
+                        "tools.jackson.dataformat.javaprop.JavaPropsMapper",
+                        extension,
+                        (Supplier<PredicatePropertyRegistryLoader>) JacksonJavaPropsSpiPropertyRegistryLoader::new
+                ));
+        return Stream.concat(yaml, javaProps);
+    }
+    // checkstyle:on LineLength
+
+    @ParameterizedTest
+    @MethodSource("spiLoaderArguments")
+    void spiLoaderIsDisabledIfRequiredClassIsAbsent(
+            String requiredClass,
+            String extension,
+            Supplier<PredicatePropertyRegistryLoader> loaderSupplier
+    ) {
+        MockedStatic<TypeUtils> typeUtils = Mockito.mockStatic(TypeUtils.class);
+        typeUtils.when(() -> TypeUtils.exists(requiredClass))
+                .thenReturn(false);
+
+        PredicatePropertyRegistryLoader loader = loaderSupplier.get();
+        // URI's that are typically compatible, should now be incompatible as they cannot be parsed
+        Assertions.assertThat(loader.isCompatible(
+                URI.create("noop://properties.%s".formatted(extension))
+        )).isFalse();
+
+        // As files cannot be parsed, none of the extensions are supported
+        Assertions.assertThat(((FilePropertyRegistryLoader) loader).supportedExtensions())
+                .isEmpty();
+
+        // Should never call loadRegistry on a non-compatible loader
+        Assertions.assertThatThrownBy(() -> loader.loadRegistry(null, null))
+                .isInstanceOf(IllegalStateException.class);
+
+        // Release for next mock invocation
+        typeUtils.close();
+    }
+}

--- a/hartshorn-spi/src/main/java/org/dockbox/hartshorn/spi/DiscoveryService.java
+++ b/hartshorn-spi/src/main/java/org/dockbox/hartshorn/spi/DiscoveryService.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
@@ -293,17 +292,8 @@ public final class DiscoveryService {
         Set<T> instances = new HashSet<>();
         for (ClassLoader classLoader : this.classLoaders) {
             ServiceLoader<T> serviceLoader = this.getServiceLoader(type, classLoader);
-            Iterator<T> it = serviceLoader.iterator();
-            while (true) {
-                try {
-                    if (!it.hasNext()) {
-                        break;
-                    }
-                    instances.add(it.next());
-                } catch (NoClassDefFoundError ignored) {
-                    // Ignored, class is either not compatible, or is missing dependencies. In both
-                    // cases we don't want to make further attempts to load it further.
-                }
+            for (T instance : serviceLoader) {
+                instances.add(instance);
             }
         }
         return instances;


### PR DESCRIPTION
### Type of Change
- [x] Enhancement (non-breaking change that affects existing code)

### Description
In #1152 I temporarily captured `NoClassDefFoundError` due to eager class loading issues with Jackson-dependent property registry loaders. This PR fixes these issues by wrapping these loaders in SPI-safe implementations. As such, the temporary bypass in the `DiscoveryService` has also been removed.

### Checklist
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] I have added documentation that describes my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue
Closes #1153