### PR TITLE
Set up utility assertions for Hartshorn types

### DIFF
--- a/hartshorn-assembly/pom.assembly.xml
+++ b/hartshorn-assembly/pom.assembly.xml
@@ -109,6 +109,10 @@
     </dependency>
     <dependency>
       <groupId>org.dockbox.hartshorn</groupId>
+      <artifactId>hartshorn-test-assertions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dockbox.hartshorn</groupId>
       <artifactId>hartshorn-testsuite</artifactId>
     </dependency>
   </dependencies>

--- a/hartshorn-bom/pom.xml
+++ b/hartshorn-bom/pom.xml
@@ -121,6 +121,12 @@
       </dependency>
       <dependency>
         <groupId>org.dockbox.hartshorn</groupId>
+        <artifactId>hartshorn-test-assertions</artifactId>
+        <version>${revision}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.dockbox.hartshorn</groupId>
         <artifactId>hartshorn-testsuite</artifactId>
         <version>${revision}</version>
         <scope>test</scope>

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/FunctionStatementInterpreterTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ast/statement/FunctionStatementInterpreterTests.java
@@ -29,6 +29,7 @@ import org.dockbox.hartshorn.hsl.parser.statement.ReturnStatementParser;
 import org.dockbox.hartshorn.hsl.runtime.DiagnosticMessage;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
+import org.dockbox.hartshorn.test.HartshornAssertions;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.option.Option;
 import org.junit.jupiter.api.Test;
@@ -120,11 +121,16 @@ class FunctionStatementInterpreterTests {
         assertThat(functionStatement.parameters()).hasSize(1);
         assertThat(functionStatement.parameters().getFirst().name().lexeme()).isEqualTo("name");
 
-        Option<FunctionParserContext> functionParserContext = helper.context().parser()
-            .firstContext(FunctionParserContext.class);
-        assertThat(functionParserContext.present()).isTrue();
-        FunctionParserContext context = functionParserContext.get();
-        assertThat(context.prefixFunctions()).contains("greet");
+        Option<FunctionParserContext> functionParserContext = helper.context()
+                .parser()
+                .firstContext(FunctionParserContext.class);
+
+        HartshornAssertions.assertThat(functionParserContext)
+                .value()
+                .extracting(
+                        FunctionParserContext::prefixFunctions,
+                        InstanceOfAssertFactories.collection(String.class)
+                ).contains("greet");
     }
 
     @Test

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/collection/CollectionScopeTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/collection/CollectionScopeTests.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dockbox.hartshorn.test.HartshornAssertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 class CollectionScopeTests {
@@ -62,7 +63,7 @@ class CollectionScopeTests {
         int highestPriority = hierarchy.highestPriority();
         Option<InstantiationStrategy<ComponentCollection<String>>> candidateProvider =
             hierarchy.get(highestPriority);
-        assertThat(candidateProvider.present()).isTrue();
+        assertThat(candidateProvider).present();
 
         InstantiationStrategy<ComponentCollection<String>> strategy = candidateProvider.get();
         assertThat(strategy)

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/populate/ContextConfiguringComponentProcessorTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/populate/ContextConfiguringComponentProcessorTests.java
@@ -16,8 +16,8 @@
 
 package test.org.dockbox.hartshorn.inject.populate;
 
-import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.inject.ContextKey;
+import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.proxy.Proxy;
 import org.dockbox.hartshorn.proxy.ProxyOrchestrator;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
@@ -26,6 +26,7 @@ import org.dockbox.hartshorn.util.option.Option;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dockbox.hartshorn.test.HartshornAssertions.assertThat;
 
 @HartshornIntegrationTest(
     includeBasePackages = false,
@@ -43,10 +44,11 @@ class ContextConfiguringComponentProcessorTests {
         assertThat(proxyOrchestrator.isProxy(emptyComponent)).isTrue();
 
         Proxy<EmptyComponent> component = (Proxy<EmptyComponent>) emptyComponent;
-        Option<SimpleContext> context =
-            component.manager().firstContext(ContextKey.of(SimpleContext.class));
-        assertThat(context.present()).isTrue();
-        assertThat(context.get().value()).isEqualTo("Foo");
+        Option<SimpleContext> context = component.manager()
+                .firstContext(ContextKey.of(SimpleContext.class));
+        assertThat(context).value()
+                .extracting(SimpleContext::value)
+                .isEqualTo("Foo");
     }
 
     @Test
@@ -58,9 +60,10 @@ class ContextConfiguringComponentProcessorTests {
         assertThat(contextComponent).isNotNull();
         assertThat(proxyOrchestrator.isProxy(contextComponent)).isFalse();
 
-        Option<SimpleContext> context =
-            contextComponent.firstContext(ContextKey.of(SimpleContext.class));
-        assertThat(context.present()).isTrue();
-        assertThat(context.get().value()).isEqualTo("Foo");
+        Option<SimpleContext> context = contextComponent
+                .firstContext(ContextKey.of(SimpleContext.class));
+        assertThat(context).value()
+                .extracting(SimpleContext::value)
+                .isEqualTo("Foo");
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/properties/ProfilePropertiesTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/properties/ProfilePropertiesTests.java
@@ -23,12 +23,14 @@ import org.dockbox.hartshorn.profiles.ProfilePropertyRegistry;
 import org.dockbox.hartshorn.profiles.ProfileRegistry;
 import org.dockbox.hartshorn.properties.PropertyRegistry;
 import org.dockbox.hartshorn.properties.ValueProperty;
+import org.dockbox.hartshorn.test.HartshornAssertions;
 import org.dockbox.hartshorn.test.annotations.TestProfiles;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.option.Option;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dockbox.hartshorn.test.HartshornAssertions.assertThat;
 
 @TestProfiles("ProfilePropertiesTests")
 @HartshornIntegrationTest(includeBasePackages = false)
@@ -45,18 +47,19 @@ class ProfilePropertiesTests {
         ProfileRegistry profileRegistry = registry.profileRegistry();
         assertThat(profileRegistry.profiles()).hasSize(2);
 
-        assertThat(profileRegistry.profile(ConfigurationProfileRegistryFactory.DEFAULT_PROFILE_NAME)
-            .present()).isTrue();
-        assertThat(profileRegistry.profile("ProfilePropertiesTests").present()).isTrue();
+        assertThat(profileRegistry.profile(
+                ConfigurationProfileRegistryFactory.DEFAULT_PROFILE_NAME
+        )).present();
+        assertThat(profileRegistry.profile("ProfilePropertiesTests")).present();
     }
 
     @Test
     void profilePropertiesLoadInIntegrationTest() {
         Option<ValueProperty> propertyOption = this.propertyRegistry.get("test.property");
-        assertThat(propertyOption.present()).isTrue();
-        assertThat(propertyOption.flatMap(ValueProperty::value).present()).isTrue();
-
-        ValueProperty property = propertyOption.get();
-        assertThat(property.value().get()).isEqualTo("This is a profile-specific property value.");
+        assertThat(propertyOption)
+                .value()
+                .extracting(ValueProperty::value, HartshornAssertions.option(String.class))
+                .value()
+                .isEqualTo("This is a profile-specific property value.");
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/properties/PropertiesBootstrapTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/properties/PropertiesBootstrapTests.java
@@ -16,17 +16,20 @@
 
 package test.org.dockbox.hartshorn.properties;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.inject.annotations.PropertyValue;
 import org.dockbox.hartshorn.launchpad.properties.PropertiesSource;
 import org.dockbox.hartshorn.properties.PropertyRegistry;
 import org.dockbox.hartshorn.properties.ValueProperty;
 import org.dockbox.hartshorn.properties.value.StandardValuePropertyParsers;
+import org.dockbox.hartshorn.test.HartshornAssertions;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.option.Option;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dockbox.hartshorn.test.HartshornAssertions.assertThat;
 
 @PropertiesSource("classpath:it-additional-config.yml")
 @HartshornIntegrationTest(includeBasePackages = false)
@@ -40,7 +43,9 @@ class PropertiesBootstrapTests {
             "hartshorn.test.additional-config",
             StandardValuePropertyParsers.BOOLEAN
         );
-        assertThat(isAdditionalConfigPresent.test(Boolean::booleanValue)).isTrue();
+        assertThat(isAdditionalConfigPresent)
+                .value(InstanceOfAssertFactories.BOOLEAN)
+                .isTrue();
     }
 
     @Test
@@ -54,10 +59,9 @@ class PropertiesBootstrapTests {
     void configurationPropertyWasLoadedAccessedByInjector(
         @PropertyValue(name = "hartshorn.test.additional-config") ValueProperty property
     ) {
-        assertThat(property).isNotNull();
-
-        Option<String> value = property.value();
-        assertThat(value.present()).isTrue();
-        assertThat(value.get()).isEqualTo("true");
+        assertThat(property)
+                .extracting(ValueProperty::value, HartshornAssertions.option(String.class))
+                .value()
+                .isEqualTo("true");
     }
 }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/proxy/delegate/ApplicationContextCarrierDelegationTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/proxy/delegate/ApplicationContextCarrierDelegationTests.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dockbox.hartshorn.test.HartshornAssertions.assertThat;
 
 @HartshornIntegrationTest(includeBasePackages = false)
 class ApplicationContextCarrierDelegationTests {
@@ -36,24 +37,16 @@ class ApplicationContextCarrierDelegationTests {
     @Test
     @TestComponents(ContextCarrierComponent.class)
     void contextCarrierDelegation(@Inject ContextCarrierComponent component) throws Exception {
-        Option<ApplicationContextCarrier> delegate = findTypeDelegate(component);
-        assertThat(delegate.present()).isTrue();
-
-        Option<?> methodDelegate = findMethodDelegate(component);
-        assertThat(methodDelegate.absent()).isTrue();
-
+        assertThat(findTypeDelegate(component)).present();
+        assertThat(findMethodDelegate(component)).present();
         assertThat(component.applicationContext()).isNotNull();
     }
 
     @Test
     @TestComponents(OverrideContextCarrierComponentInterface.class)
     void defaultCarrierDelegation(@Inject OverrideContextCarrierComponentInterface component) throws Exception {
-        Option<ApplicationContextCarrier> delegate = findTypeDelegate(component);
-        assertThat(delegate.absent()).isTrue();
-
-        Option<?> methodDelegate = findMethodDelegate(component);
-        assertThat(methodDelegate.absent()).isTrue();
-
+        assertThat(findTypeDelegate(component)).absent();
+        assertThat(findMethodDelegate(component)).absent();
         // Default method, should return null (see OverrideContextCarrierComponentInterface)
         assertThat(component.applicationContext()).isNull();
     }
@@ -71,8 +64,7 @@ class ApplicationContextCarrierDelegationTests {
             .resolver()
             .method(method)
             .delegate();
-        assertThat(methodDelegate.present()).isTrue();
-
+        assertThat(methodDelegate).absent();
         assertThat(component.applicationContext()).isNotNull();
         assertThat(applicationContext).isSameAs(component.applicationContext());
     }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/proxy/delegate/ApplicationContextCarrierDelegationTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/proxy/delegate/ApplicationContextCarrierDelegationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ class ApplicationContextCarrierDelegationTests {
     @TestComponents(ContextCarrierComponent.class)
     void contextCarrierDelegation(@Inject ContextCarrierComponent component) throws Exception {
         assertThat(findTypeDelegate(component)).present();
-        assertThat(findMethodDelegate(component)).present();
+        assertThat(findMethodDelegate(component)).absent();
         assertThat(component.applicationContext()).isNotNull();
     }
 
@@ -64,7 +64,7 @@ class ApplicationContextCarrierDelegationTests {
             .resolver()
             .method(method)
             .delegate();
-        assertThat(methodDelegate).absent();
+        assertThat(methodDelegate).present();
         assertThat(component.applicationContext()).isNotNull();
         assertThat(applicationContext).isSameAs(component.applicationContext());
     }

--- a/hartshorn-test-assertions/pom.xml
+++ b/hartshorn-test-assertions/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.dockbox.hartshorn</groupId>
+    <artifactId>hartshorn-platform-support</artifactId>
+    <version>${revision}</version>
+    <relativePath>../hartshorn-assembly/pom.platform.support.xml</relativePath>
+  </parent>
+
+  <name>Hartshorn Test Assertions</name>
+  <artifactId>hartshorn-test-assertions</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.dockbox.hartshorn</groupId>
+      <artifactId>hartshorn-shared</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/hartshorn-test-assertions/src/main/java/org/dockbox/hartshorn/test/HartshornAssertions.java
+++ b/hartshorn-test-assertions/src/main/java/org/dockbox/hartshorn/test/HartshornAssertions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.test;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.dockbox.hartshorn.util.option.Option;
+
+import java.util.function.Function;
+
+/**
+ * Assertion extensions for Hartshorn specific types.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
+public class HartshornAssertions {
+
+    /**
+     * {@link InstanceOfAssertFactory} to allow {@link Option} instances to be used inline with
+     * {@link AbstractObjectAssert#extracting(Function, InstanceOfAssertFactory)}, yielding a
+     * {@link OptionAssert} instance which is type-checked for the given element type.
+     *
+     * @param element the element type inside the {@link Option}
+     * @param <E> the element type
+     *
+     * @return a new {@link InstanceOfAssertFactory} for {@link Option} types
+     */
+    public static <E> InstanceOfAssertFactory<Option, OptionAssert<E>> option(Class<E> element) {
+        return new InstanceOfAssertFactory<>(
+                Option.class,
+                new Class[] {element},
+                e -> assertThat(e).cast(element)
+        );
+    }
+
+    /**
+     * Creates a new assertion for the given non-null {@link Option}.
+     *
+     * @param option the non-null {@link Option}
+     * @param <E> the element type
+     *
+     * @return a new {@link OptionAssert}
+     */
+    public static <E> OptionAssert<E> assertThat(Option<E> option) {
+        Assertions.assertThat(option).isNotNull();
+        return new OptionAssert<>(option);
+    }
+}

--- a/hartshorn-test-assertions/src/main/java/org/dockbox/hartshorn/test/OptionAssert.java
+++ b/hartshorn-test-assertions/src/main/java/org/dockbox/hartshorn/test/OptionAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public class OptionAssert<E> extends AbstractAssert<OptionAssert<E>, Option<E>> 
      * @see Option#absent()
      */
     public OptionAssert<E> absent() {
-        return this.matches(Option::absent);
+        return this.matches(Option::absent, "is absent");
     }
 
     /**
@@ -57,7 +57,7 @@ public class OptionAssert<E> extends AbstractAssert<OptionAssert<E>, Option<E>> 
      * @see Option#present()
      */
     public OptionAssert<E> present() {
-        return this.matches(Option::present);
+        return this.matches(Option::present, "is present");
     }
 
     /**
@@ -94,7 +94,8 @@ public class OptionAssert<E> extends AbstractAssert<OptionAssert<E>, Option<E>> 
      * @see Option#contains(Object)
      */
     public OptionAssert<E> contains(E expected) {
-        return this.matches(option -> option.contains(expected));
+        this.present().value().isEqualTo(expected);
+        return this;
     }
 
     /**
@@ -109,6 +110,7 @@ public class OptionAssert<E> extends AbstractAssert<OptionAssert<E>, Option<E>> 
      * @see Option#cast(Class)
      */
     public <U> OptionAssert<U> cast(Class<U> type) {
+        this.present().value().isInstanceOf(type);
         return this.extracting(option -> option.cast(type), OptionAssert::new);
     }
 

--- a/hartshorn-test-assertions/src/main/java/org/dockbox/hartshorn/test/OptionAssert.java
+++ b/hartshorn-test-assertions/src/main/java/org/dockbox/hartshorn/test/OptionAssert.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.test;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AssertFactory;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.OptionalAssert;
+import org.dockbox.hartshorn.util.option.Option;
+
+/**
+ * Custom assertions for {@link Option} instances.
+ *
+ * @param <E> the element type of the {@link Option}
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
+public class OptionAssert<E> extends AbstractAssert<OptionAssert<E>, Option<E>> {
+
+    protected OptionAssert(Option<E> option) {
+        super(option, OptionAssert.class);
+    }
+
+    /**
+     * Asserts the {@link Option} does not contain any value.
+     *
+     * @return the current assertion, for fluent expressions
+     *
+     * @see Option#absent()
+     */
+    public OptionAssert<E> absent() {
+        return this.matches(Option::absent);
+    }
+
+    /**
+     * Asserts the {@link Option} contains a value.
+     *
+     * @return the current assertion, for fluent expressions
+     *
+     * @see Option#present()
+     */
+    public OptionAssert<E> present() {
+        return this.matches(Option::present);
+    }
+
+    /**
+     * Extracts the value contained in the {@link Option} and returns an {@link ObjectAssert} for
+     * further assertions on the value.
+     *
+     * @return an {@link ObjectAssert} for the value contained in the {@link Option}
+     */
+    public ObjectAssert<E> value() {
+        return this.present().extracting(Option::get, Assertions::assertThat);
+    }
+
+    /**
+     * Extracts the value contained in the {@link Option} and returns an {@link AbstractAssert} of
+     * the specified type for further assertions on the value.
+     *
+     * @param assertFactory the factory to create the specific assert type
+     * @param <A> the type of the specific assert
+     *
+     * @return an {@link AbstractAssert} of the specified type for the value contained in the
+     * {@link Option}
+     */
+    public <A extends AbstractAssert<?, E>> A value(AssertFactory<Object, A> assertFactory) {
+        return this.present().extracting(Option::get, assertFactory);
+    }
+
+    /**
+     * Asserts the {@link Option} contains the expected value.
+     *
+     * @param expected the expected value
+     *
+     * @return the current assertion, for fluent expressions
+     *
+     * @see Option#contains(Object)
+     */
+    public OptionAssert<E> contains(E expected) {
+        return this.matches(option -> option.contains(expected));
+    }
+
+    /**
+     * Casts the value contained in the {@link Option} to the specified type and returns a new
+     * {@link OptionAssert} for further assertions.
+     *
+     * @param type the type to cast the value to
+     * @param <U> the type of the value after casting
+     *
+     * @return a new {@link OptionAssert} for the casted value
+     *
+     * @see Option#cast(Class)
+     */
+    public <U> OptionAssert<U> cast(Class<U> type) {
+        return this.extracting(option -> option.cast(type), OptionAssert::new);
+    }
+
+    /**
+     * Converts the {@link Option} to an {@link OptionalAssert} for further assertions using
+     * AssertJ's built-in optional assertions.
+     *
+     * @return an {@link OptionalAssert} for the {@link Option}
+     *
+     * @see Option#optional()
+     */
+    public OptionalAssert<E> asOptional() {
+        return this.extracting(Option::optional, Assertions::assertThat);
+    }
+}

--- a/hartshorn-testsuite/pom.xml
+++ b/hartshorn-testsuite/pom.xml
@@ -20,6 +20,11 @@
       <groupId>org.dockbox.hartshorn</groupId>
       <artifactId>hartshorn-launchpad</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.dockbox.hartshorn</groupId>
+      <artifactId>hartshorn-test-assertions</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- Logical defaults -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <module>hartshorn-launchpad</module>
     <module>hartshorn-reporting</module>
     <module>hartshorn-hsl</module>
+    <module>hartshorn-test-assertions</module>
     <module>hartshorn-testsuite</module>
     <module>hartshorn-launchpad-kotlin-extensions</module>
     <module>hartshorn-launchpad-starter</module>


### PR DESCRIPTION
### Type of Change
- [x] Feature (non-breaking change that adds functionality)

### Description
With the recent migration to AssertJ, we can now add more fluent support for custom assertions. As such, this PR adds initial custom assertions for `Option` instances. Going forward, we can opt to add additional assertions when needed. 

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added documentation that describes my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch