### PR TITLE
Set up automated scaffolding of new internal modules

### DIFF
--- a/hartshorn-archetype/GenerateModule.ps1
+++ b/hartshorn-archetype/GenerateModule.ps1
@@ -1,0 +1,74 @@
+param (
+    [Parameter(Mandatory=$true)][string]$Module,
+    [Parameter(Mandatory=$true)][string]$Name,
+    [Parameter(Mandatory=$true)][string]$Description,
+    [Parameter(Mandatory=$false)][switch]$NoDocs
+)
+
+### Module Imports ###
+Import-Module "$PSScriptRoot\psm\AddModuleToPlaybook.psm1"
+Import-Module "$PSScriptRoot\psm\UpdateAssemblyDependencies.psm1"
+Import-Module "$PSScriptRoot\psm\NewModuleFromArchetype.psm1"
+
+### Preconditions ###
+# No uncommitted changes
+$gitStatus = git status --porcelain
+if ($gitStatus) {
+    Write-Host "You have uncommitted changes in your working directory. Please commit or stash them before running this script." -ForegroundColor Red
+    exit 1
+}
+
+# Module name validation
+if ($Module -notmatch '^[a-z\-]*$') {
+    Write-Host "Invalid module name '$Module'. Module names must start with a lowercase letter and can only contain lowercase letters and hyphens." -ForegroundColor Red
+    exit 1
+}
+
+# Directory existence check, performed in NewModuleFromArchetype.psm1
+
+### Module Generation ###
+New-ModuleFromArchetype -Module $Module -Name $Name -Description $Description -NoDocs $NoDocs
+
+### Antora Playbook Update ###
+if (-NOT $NoDocs) {
+    Write-Host "`nUpdating Antora playbook to include new module..." -ForegroundColor Green
+    Add-ModuleToPlaybook -playBook "local" -moduleId $Module
+    Add-ModuleToPlaybook -playBook "release" -moduleId $Module
+}
+
+### POM Updates ###
+Write-Host "`nUpdating hartshorn-assembly POM to include new module dependency..." -ForegroundColor Green
+
+$parentPomPath = "..\hartshorn-assembly\pom.assembly.xml"
+$groupId = "org.dockbox.hartshorn"
+$artifactId = "hartshorn-$Module"
+
+Update-AssemblyDependencies -FilePath $parentPomPath -GroupId $groupId -ArtifactId $artifactId
+
+### Completion Message ###
+Write-Host "`nModule 'hartshorn-$Module' generation and integration complete! Actions performed:" -ForegroundColor Green
+Write-Host "- Generated module at '../hartshorn-$Module'"
+if (-NOT $NoDocs) {
+    Write-Host "- Updated Antora playbooks 'local' and 'release'"
+}
+Write-Host "- Updated hartshorn-assembly POM with new module dependency"
+
+### Next Steps ###
+Write-Host "`nDue to formatting and custom ordering requirements, some manual steps are required to finalize the integration of the new module." -ForegroundColor DarkYellow
+Write-Host "- Add org.dockbox.hartshorn:hartshorn-$Module to pom.xml <modules>" -ForegroundColor Yellow
+Write-Host "  <module>hartshorn-$Module</module>" -ForegroundColor DarkGray
+Write-Host "- Add org.dockbox.hartshorn:hartshorn-$Module to hartshorn-bom/pom.xml <dependencyManagement>" -ForegroundColor Yellow
+Write-Host "  <dependency>" -ForegroundColor DarkGray
+Write-Host "    <groupId>org.dockbox.hartshorn</group>" -ForegroundColor DarkGray
+Write-Host "    <artifactId>hartshorn-$Module</artifactId>" -ForegroundColor DarkGray
+Write-Host "    <version>`${revision}</version>" -ForegroundColor DarkGray
+Write-Host "  </dependency>" -ForegroundColor DarkGray
+
+Write-Host "`nAfter completing the above manual steps, please:" -ForegroundColor DarkYellow
+Write-Host "- Review the generated module at 'hartshorn-$Module' and make any necessary adjustments." -ForegroundColor Yellow
+Write-Host "- Build the project to ensure everything is set up correctly." -ForegroundColor Yellow
+Write-Host "  `$ mvn clean install -DskipTests -P ci" -ForegroundColor DarkGray
+if (-NOT $NoDocs) {
+    Write-Host "- Verify that the documentation for the new module is correctly integrated into the Antora site." -ForegroundColor Yellow
+    Write-Host "  `$ mvn clean install -DskipTests -P ci,local -Dantora.skip=false -Dantora.playbook=playbook-local.yml" -ForegroundColor DarkGray
+}

--- a/hartshorn-archetype/README.md
+++ b/hartshorn-archetype/README.md
@@ -1,0 +1,46 @@
+# Hartshorn Archetype
+This project provides a Maven archetype for creating new framework modules within the Hartshorn framework. It
+sets up basic project structure and configurations to aid the development of new modules.
+
+Note that this archetype is intended for internal use by Hartshorn developers and is not suitable for
+general-purpose module development.
+
+## Usage
+To create a new Hartshorn module using this archetype, run the following Maven command:
+```bash
+GenerateModule.ps1
+```
+
+The script prompts for the following parameters:
+- `Module`: The name of the new module (e.g. `inject`)
+- `Name`: The display name of the new module (e.g. `Hartshorn Inject`)
+- `Description`: A brief description of the new module (e.g. `A dependency injection framework for Hartshorn`)
+
+Optionally, if you do not want to generate documentation for the new module (e.g. for test fixtures or similar
+internal modules), you can pass the `-NoDocs` flag to skip documentation generation.
+
+### Automated Steps
+Module generation includes:
+- Creating a new Maven project with the appropriate `groupId`, `artifactId`, and `version`.
+- Setting up the basic directory structure for:
+  - Source code and resources
+  - Test code and resources
+  - Antora documentation
+- Registers the new module in the assembly POM
+- Registers the new module in the documentation indexes (local and release)
+
+### Manual Steps
+Module generation does not include:
+- Registering the new module in the BOM, this must be done manually.
+- Registering the new module in the parent POM, this must be done manually.
+
+## Prerequisites
+### Maven
+As module generation is performed outside of the main project (and thus cannot use the integrated Maven runner
+in your IDE), you should have Maven installed and configured on your system, please refer to the
+[Maven installation guide](https://maven.apache.org/install.html) for instructions.
+
+### PowerShell (Linux/Mac)
+The module generation script is written in PowerShell. If you are using Linux or Mac, ensure that you have
+PowerShell installed. You can find installation instructions on the 
+[PowerShell Learn page](https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell).

--- a/hartshorn-archetype/pom.xml
+++ b/hartshorn-archetype/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.dockbox.hartshorn</groupId>
+  <artifactId>hartshorn-archetype</artifactId>
+  <version>1.0.0</version>
+  <name>Hartshorn module archetype</name>
+</project>

--- a/hartshorn-archetype/psm/AddModuleToPlaybook.psm1
+++ b/hartshorn-archetype/psm/AddModuleToPlaybook.psm1
@@ -1,0 +1,18 @@
+function Add-ModuleToPlaybook
+{
+    param (
+        [string]$PlayBook,
+        [string]$ModuleId
+    )
+
+    Write-Host "Updating playbook '$PlayBook' with module 'hartshorn-$ModuleId'..."
+
+    $antoraPlaybookPath = "..\hartshorn-assembly\antora\playbook-$PlayBook.yml"
+    $lines = Get-Content $antoraPlaybookPath
+
+    # Manual line insertion, as powershell-yaml does not preserve comments
+    $lastIndex = ($lines | ForEach-Object { $_ } | Select-String '\s*-\s.*src\/main\/docs' | Select-Object -Last 1).LineNumber - 1
+    $newLine = "        - hartshorn-$ModuleId/src/main/docs"
+    $lines = $lines[0..$lastIndex] + $newLine
+    $lines | Set-Content $antoraPlaybookPath
+}

--- a/hartshorn-archetype/psm/NewModuleFromArchetype.psm1
+++ b/hartshorn-archetype/psm/NewModuleFromArchetype.psm1
@@ -1,0 +1,92 @@
+function New-ModuleFromArchetype
+{
+    param (
+        [Parameter(Mandatory = $true)][string]$Module,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Description,
+        [Parameter(Mandatory = $true)][boolean]$NoDocs
+    )
+
+    $tmpDir = "tmp"
+    $targetDir = Join-Path -Path "..\.." -ChildPath "hartshorn-$Module"
+
+    # Clean up if previous run left temp files
+    if (Test-Path $tmpDir)
+    {
+        Remove-Item -Recurse -Force $tmpDir
+    }
+
+    # Ensure target directory does not already exist
+    if (Test-Path $targetDir)
+    {
+        Write-Host "Target directory '$targetDir' already exists. Please remove it before generating a new module." -ForegroundColor Red
+        exit 1
+    }
+
+    # Ensure latest archetype is installed
+    try
+    {
+        Write-Host "`nInstalling latest archetype to local Maven repository..." -ForegroundColor Green
+        # Quietly install the archetype to the local Maven repository, disable output
+        mvn clean install -f pom.xml -q
+        Write-Host "Archetype installed successfully."
+    }
+    catch
+    {
+        Write-Error "Failed to install the latest archetype: $_"
+        exit 1
+    }
+
+    ### Maven Archetype Generation ###
+    Write-Host "`nGenerating module 'hartshorn-$Module'..." -ForegroundColor Green
+
+    # Create working directory, to avoid running inside existing Maven module
+    New-Item -ItemType Directory -Path $tmpDir | Out-Null
+    Set-Location $tmpDir
+    Write-Host "Changed working directory to temporary path '$tmpDir'."
+
+    # Prepare Maven archetype
+    $mvnArgs = @(
+        "archetype:generate",
+        "-DarchetypeGroupId=org.dockbox.hartshorn",
+        "-DarchetypeArtifactId=hartshorn-archetype",
+        "-DarchetypeVersion=1.0.0",
+        "-DinteractiveMode=false",
+        "-DgroupId=org.dockbox.hartshorn",
+        "-DartifactId=hartshorn-$Module",
+        "-Dname=$Name",
+        "-Ddescription=$Description",
+        "-DmoduleId=$Module"
+    )
+
+    try
+    {
+        Write-Host "Generating module using Maven archetype..."
+        mvn @mvnArgs -q
+
+        if ($NoDocs)
+        {
+            # Delete docs directory if NoDocs flag is set
+            $docsPath = Join-Path -Path "hartshorn-$Module" -ChildPath "src\main\docs"
+            if (Test-Path $docsPath)
+            {
+                Remove-Item -Recurse -Force $docsPath
+            }
+        }
+
+        Write-Host "Moving generated module to target directory..."
+        Move-Item -Path "hartshorn-$Module" -Destination $targetDir
+        Write-Host "Module 'hartshorn-$Module' generated successfully at '$targetDir'."
+    }
+    catch
+    {
+        Write-Error "Maven archetype generation failed: $_"
+        exit 1
+    }
+    finally
+    {
+        # Return to original directory and clean up temp directory
+        Set-Location ..
+        Remove-Item -Recurse -Force $tmpDir
+    }
+}

--- a/hartshorn-archetype/psm/UpdateAssemblyDependencies.psm1
+++ b/hartshorn-archetype/psm/UpdateAssemblyDependencies.psm1
@@ -1,0 +1,64 @@
+function Update-AssemblyDependencies
+{
+    param (
+        [Parameter(Mandatory)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory)]
+        [string]$GroupId,
+
+        [Parameter(Mandatory)]
+        [string]$ArtifactId
+    )
+
+    $pomLines = Get-Content $FilePath
+
+    # Find the last line of the <dependencies> block that is a direct child of <project>
+    # Match the <dependencies> that is not inside <dependencyManagement>
+    $inProjectDependencies = $false
+    $lastIndex = -1
+
+    for ($i = 0; $i -lt $pomLines.Count; $i++) {
+        $line = $pomLines[$i].Trim()
+
+        if ($line -match '<dependencyManagement>')
+        {
+            $inProjectDependencies = $false
+        }
+
+        if ($line -match '<dependencies>')
+        {
+            # If not inside dependencyManagement, enable flag
+            if (-not ($i -gt 0 -and ($pomLines[$i - 1] -match '<dependencyManagement>')))
+            {
+                $inProjectDependencies = $true
+            }
+        }
+
+        if ($line -match '</dependencies>' -and $inProjectDependencies)
+        {
+            $lastIndex = $i - 1  # insert before the closing </dependencies>
+            break
+        }
+    }
+
+    if ($lastIndex -lt 0)
+    {
+        Write-Error "Could not find a <dependencies> block under <project>."
+        return
+    }
+
+    $indent = "    "
+    $newDependency = @(
+        "$indent<dependency>"
+        "$indent  <groupId>$GroupId</groupId>"
+        "$indent  <artifactId>$ArtifactId</artifactId>"
+        "$indent</dependency>"
+    )
+
+    # Insert the new dependency before </dependencies>
+    $pomLines = $pomLines[0..$lastIndex] + $newDependency + $pomLines[($lastIndex + 1)..($pomLines.Count - 1)]
+    $pomLines | Set-Content $FilePath
+
+    Write-Host "Added dependency '${GroupId}:${ArtifactId}' to '$FilePath'."
+}

--- a/hartshorn-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/hartshorn-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,24 @@
+<archetype-descriptor xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.2.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.2.0 https://maven.apache.org/xsd/archetype-descriptor-1.2.0.xsd"
+                      name="hartshorn-archetype">
+  <requiredProperties>
+    <requiredProperty key="name"/>
+    <requiredProperty key="description"/>
+    <requiredProperty key="moduleId"/>
+  </requiredProperties>
+  <fileSets>
+    <fileSet filtered="true">
+      <directory>src</directory>
+      <includes>
+        <include>**/*.*</include>
+      </includes>
+    </fileSet>
+    <fileSet filtered="true">
+      <directory/>
+      <includes>
+        <include>pom.xml</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</archetype-descriptor>

--- a/hartshorn-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/hartshorn-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.dockbox.hartshorn</groupId>
+    <artifactId>hartshorn-platform-support</artifactId>
+    <version>${revision}</version>
+    <relativePath>../hartshorn-assembly/pom.platform.support.xml</relativePath>
+  </parent>
+
+  <name>${name}</name>
+  <description>${description}</description>
+  <artifactId>${artifactId}</artifactId>
+  <packaging>jar</packaging>
+</project>

--- a/hartshorn-archetype/src/main/resources/archetype-resources/src/main/docs/antora.yml
+++ b/hartshorn-archetype/src/main/resources/archetype-resources/src/main/docs/antora.yml
@@ -1,0 +1,4 @@
+name: ${moduleId}
+title: ${name}
+nav:
+  - modules/ROOT/nav.adoc

--- a/hartshorn-archetype/src/main/resources/archetype-resources/src/main/docs/modules/ROOT/nav.adoc
+++ b/hartshorn-archetype/src/main/resources/archetype-resources/src/main/docs/modules/ROOT/nav.adoc
@@ -1,0 +1,1 @@
+* xref:index.adoc[Introduction]

--- a/hartshorn-archetype/src/main/resources/archetype-resources/src/main/docs/modules/ROOT/pages/index.adoc
+++ b/hartshorn-archetype/src/main/resources/archetype-resources/src/main/docs/modules/ROOT/pages/index.adoc
@@ -1,0 +1,5 @@
+= ${name}
+Guus Lieben
+:description: ${description}
+
+To be written

--- a/hartshorn-archetype/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/__moduleId__/Main.java
+++ b/hartshorn-archetype/src/main/resources/archetype-resources/src/main/java/__packageInPathFormat__/__moduleId__/Main.java
@@ -1,0 +1,8 @@
+package ${package}.${moduleId};
+
+public class Main {
+
+    void main() {
+        System.out.println("Hello, ${name}!");
+    }
+}

--- a/hartshorn-archetype/src/main/resources/archetype-resources/src/test/java/test/__packageInPathFormat__/__moduleId__/MainTests.java
+++ b/hartshorn-archetype/src/main/resources/archetype-resources/src/test/java/test/__packageInPathFormat__/__moduleId__/MainTests.java
@@ -1,0 +1,13 @@
+package test.${package}.${moduleId};
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MainTests {
+
+    @Test
+    void sampleAssertion() {
+        assertThat("Hello, ${name}!").isNotEmpty();
+    }
+}


### PR DESCRIPTION
### Type of Change
- [x] Chore (changes to the build process or auxiliary tools)
- [x] Feature (non-breaking change that adds functionality)

### Description
Minor side quest, to introduce automated scaffolding of new (internal) modules, as over time the complexity of adding new modules has increased.

This includes:
- Creating a new Maven project with the appropriate `groupId`, `artifactId`, and `version`.
- Setting up the basic directory structure for:
  - Source code and resources
  - Test code and resources
  - Antora documentation
- Registers the new module in the assembly POM
- Registers the new module in the documentation indexes (local and release)
- Reminding of required manual steps (which cannot be automated due to ordering/formatting conventions)

### How the Changes Have Been Tested
Generated various modules locally to verify correct behavior, both with and without documentation setup.

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have added documentation that describes my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch