### PR TITLE
#932 Support conditions for type reference metadata

### DIFF
--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ExpressionCondition.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ExpressionCondition.java
@@ -17,18 +17,19 @@
 package org.dockbox.hartshorn.hsl.condition;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.dockbox.hartshorn.hsl.ScriptEvaluationError;
 import org.dockbox.hartshorn.hsl.StandardScriptComponentFactory;
 import org.dockbox.hartshorn.hsl.customizer.DefaultScriptStatementsParserCustomizer;
-import org.dockbox.hartshorn.inject.InjectionCapableApplication;
-import org.dockbox.hartshorn.inject.condition.Condition;
-import org.dockbox.hartshorn.inject.condition.ConditionContext;
-import org.dockbox.hartshorn.inject.condition.ConditionResult;
-import org.dockbox.hartshorn.inject.condition.ProvidedParameterContext;
-import org.dockbox.hartshorn.launchpad.ApplicationContext;
-import org.dockbox.hartshorn.hsl.ScriptEvaluationError;
 import org.dockbox.hartshorn.hsl.customizer.ScriptContext;
 import org.dockbox.hartshorn.hsl.runtime.ScriptRuntime;
 import org.dockbox.hartshorn.hsl.runtime.ValidateExpressionRuntime;
+import org.dockbox.hartshorn.inject.InjectionCapableApplication;
+import org.dockbox.hartshorn.inject.condition.ConditionContext;
+import org.dockbox.hartshorn.inject.condition.ConditionResult;
+import org.dockbox.hartshorn.inject.condition.IntrospectedConditionContext;
+import org.dockbox.hartshorn.inject.condition.IntrospectionCondition;
+import org.dockbox.hartshorn.inject.condition.ProvidedParameterContext;
+import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +62,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Guus Lieben
  */
-public class ExpressionCondition implements Condition {
+public class ExpressionCondition implements IntrospectionCondition {
 
     private static final Logger LOG = LoggerFactory.getLogger(ExpressionCondition.class);
 
@@ -73,7 +74,7 @@ public class ExpressionCondition implements Condition {
     public static final String GLOBAL_APPLICATION_CONTEXT_NAME = "applicationContext";
 
     @Override
-    public ConditionResult matches(ConditionContext context) {
+    public ConditionResult matches(IntrospectedConditionContext context) {
         return context.annotatedElement().annotations().get(RequiresExpression.class)
             .map(condition -> this.calculateResult(context, condition))
             .orElse(ConditionResult.invalidCondition("expression"));

--- a/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ExpressionCondition.java
+++ b/hartshorn-hsl/src/main/java/org/dockbox/hartshorn/hsl/condition/ExpressionCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import org.dockbox.hartshorn.hsl.customizer.DefaultScriptStatementsParserCustomi
 import org.dockbox.hartshorn.hsl.customizer.ScriptContext;
 import org.dockbox.hartshorn.hsl.runtime.ScriptRuntime;
 import org.dockbox.hartshorn.hsl.runtime.ValidateExpressionRuntime;
+import org.dockbox.hartshorn.inject.InjectionApplicationAwareContext;
 import org.dockbox.hartshorn.inject.InjectionCapableApplication;
-import org.dockbox.hartshorn.inject.condition.ConditionContext;
 import org.dockbox.hartshorn.inject.condition.ConditionResult;
 import org.dockbox.hartshorn.inject.condition.IntrospectedConditionContext;
 import org.dockbox.hartshorn.inject.condition.IntrospectionCondition;
@@ -82,7 +82,7 @@ public class ExpressionCondition implements IntrospectionCondition {
 
     @NonNull
     private ConditionResult calculateResult(
-        ConditionContext context,
+        IntrospectedConditionContext context,
         RequiresExpression condition
     ) {
         String expression = condition.value();
@@ -108,7 +108,7 @@ public class ExpressionCondition implements IntrospectionCondition {
      *
      * @return a new runtime
      */
-    protected ValidateExpressionRuntime createRuntime(ConditionContext context) {
+    protected ValidateExpressionRuntime createRuntime(IntrospectedConditionContext context) {
         InjectionCapableApplication application = context.application();
         ValidateExpressionRuntime runtime;
         if (application instanceof ApplicationContext applicationContext) {
@@ -154,7 +154,7 @@ public class ExpressionCondition implements IntrospectionCondition {
      */
     protected ValidateExpressionRuntime enhance(
         ValidateExpressionRuntime runtime,
-        ConditionContext context
+        InjectionApplicationAwareContext context
     ) {
         // Load parameters first, so they can be overwritten by the customizers and imports.
         context.firstContext(ProvidedParameterContext.class).peek(parameterContext -> {

--- a/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ExpressionConditionTests.java
+++ b/hartshorn-hsl/src/test/java/test/org/dockbox/hartshorn/hsl/ExpressionConditionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.dockbox.hartshorn.hsl.condition.RequiresExpression;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.inject.condition.ConditionContext;
 import org.dockbox.hartshorn.inject.condition.ConditionResult;
+import org.dockbox.hartshorn.inject.condition.IntrospectedConditionContext;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
 import org.dockbox.hartshorn.util.introspect.ElementAnnotationsIntrospector;
@@ -85,7 +86,11 @@ public class ExpressionConditionTests {
     ConditionResult match(String expression, ContextView... contexts) {
         ExpressionCondition condition = this.applicationContext.get(ExpressionCondition.class);
         AnnotatedElementView element = this.createAnnotatedElement(expression);
-        ConditionContext context = new ConditionContext(this.applicationContext, element, null);
+        ConditionContext context = new IntrospectedConditionContext(
+            this.applicationContext,
+            element,
+            null
+        );
         for (ContextView child : contexts) {
             context.addContext(child);
         }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/AnnotationConditionDeclaration.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/AnnotationConditionDeclaration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.inject.condition;
 
-import org.dockbox.hartshorn.inject.InjectionCapableApplication;
+import org.dockbox.hartshorn.inject.ObjectFactory;
 
 /**
  * Represents an annotation-based condition declaration. This may represent a direct use of the
@@ -38,8 +38,8 @@ public class AnnotationConditionDeclaration implements ConditionDeclaration {
     }
 
     @Override
-    public Condition condition(InjectionCapableApplication application) {
-        return application.defaultProvider().get(this.annotation.condition());
+    public Condition condition(ObjectFactory objectFactory) {
+        return objectFactory.create(this.annotation.condition());
     }
 
     @Override

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/Condition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/Condition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/Condition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/Condition.java
@@ -27,7 +27,7 @@ package org.dockbox.hartshorn.inject.condition;
  * 
  * @author Guus Lieben
  */
-public sealed interface Condition permits IntrospectionCondition, TypeReferenceCondition {
+public sealed interface Condition permits IntrospectionCondition, ReferenceCondition {
 
     /**
      * Returns a {@link ConditionResult} that describes whether the condition is matched.

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionContext.java
@@ -31,7 +31,7 @@ import org.dockbox.hartshorn.context.DefaultContext;
  * @author Guus Lieben
  */
 public sealed class ConditionContext extends DefaultContext
-permits IntrospectedConditionContext, TypeReferenceConditionContext {
+permits IntrospectedConditionContext, ReferenceConditionContext {
 
     private final ConditionDeclaration condition;
 

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 
 package org.dockbox.hartshorn.inject.condition;
 
-import org.dockbox.hartshorn.inject.DefaultInjectionApplicationAwareContext;
-import org.dockbox.hartshorn.inject.InjectionCapableApplication;
+import org.dockbox.hartshorn.context.DefaultContext;
 
 /**
  * A context that is used during the evaluation of a condition. This includes the annotated element
@@ -31,15 +30,12 @@ import org.dockbox.hartshorn.inject.InjectionCapableApplication;
  *
  * @author Guus Lieben
  */
-public class ConditionContext extends DefaultInjectionApplicationAwareContext {
+public sealed class ConditionContext extends DefaultContext
+permits IntrospectedConditionContext, TypeReferenceConditionContext {
 
     private final ConditionDeclaration condition;
 
-    public ConditionContext(
-        InjectionCapableApplication application,
-        ConditionDeclaration condition
-    ) {
-        super(application);
+    public ConditionContext(ConditionDeclaration condition) {
         this.condition = condition;
     }
 

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionDeclaration.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionDeclaration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.inject.condition;
 
-import org.dockbox.hartshorn.inject.InjectionCapableApplication;
+import org.dockbox.hartshorn.inject.ObjectFactory;
 
 /**
  * Represents a condition declaration, which may put constraints on the usage of a component or
@@ -30,14 +30,13 @@ import org.dockbox.hartshorn.inject.InjectionCapableApplication;
 public interface ConditionDeclaration {
 
     /**
-     * Returns the condition that is declared by this instance. The condition may use any context
-     * that is provided by the application context.
+     * Returns the condition that is declared by this instance.
      *
-     * @param application The application context that is used to resolve the condition
+     * @param objectFactory The application context that is used to resolve the condition
      *
      * @return The condition that is declared by this instance
      */
-    Condition condition(InjectionCapableApplication application);
+    Condition condition(ObjectFactory objectFactory);
 
     /**
      * Indicates whether the {@link ConditionMatcher} should fail when the condition does not match.

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionMatcher.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionMatcher.java
@@ -16,16 +16,6 @@
 
 package org.dockbox.hartshorn.inject.condition;
 
-import java.lang.classfile.Annotation;
-import java.lang.classfile.ClassModel;
-import java.util.ArrayDeque;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Queue;
-import java.util.SequencedCollection;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import org.dockbox.hartshorn.context.ContextView;
 import org.dockbox.hartshorn.context.DefaultContext;
 import org.dockbox.hartshorn.inject.ComponentProviderObjectFactoryAdapter;
@@ -41,6 +31,17 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 import org.dockbox.hartshorn.util.types.ClassFileUtilities;
 
+import java.lang.classfile.Annotation;
+import java.lang.classfile.ClassModel;
+import java.util.ArrayDeque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.SequencedCollection;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 /**
  * A matcher that can be used to match {@link RequiresCondition} annotations against a given set of
  * contexts. This matcher will use the {@link InjectionCapableApplication} to resolve the
@@ -50,12 +51,14 @@ import org.dockbox.hartshorn.util.types.ClassFileUtilities;
  * determine whether a component should be registered, a binding method should be invoked, or an
  * event should be dispatched.
  *
- * @author Guus Lieben
  * @see RequiresCondition
  * @see Condition
  * @see ConditionContext
  * @see ConditionResult
+ *
  * @since 0.4.12
+ *
+ * @author Guus Lieben
  */
 public final class ConditionMatcher extends DefaultContext
     implements InjectionApplicationAwareContext {

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionMatcher.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,8 @@
 
 package org.dockbox.hartshorn.inject.condition;
 
-import org.dockbox.hartshorn.context.ContextView;
-import org.dockbox.hartshorn.context.DefaultContext;
-import org.dockbox.hartshorn.inject.InjectionApplicationAwareContext;
-import org.dockbox.hartshorn.inject.InjectionCapableApplication;
-import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
-import org.dockbox.hartshorn.util.introspect.view.EnclosableView;
-import org.dockbox.hartshorn.util.option.Option;
-
+import java.lang.classfile.Annotation;
+import java.lang.classfile.ClassModel;
 import java.util.ArrayDeque;
 import java.util.LinkedList;
 import java.util.List;
@@ -32,6 +26,20 @@ import java.util.SequencedCollection;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.dockbox.hartshorn.context.ContextView;
+import org.dockbox.hartshorn.context.DefaultContext;
+import org.dockbox.hartshorn.inject.ComponentProviderObjectFactoryAdapter;
+import org.dockbox.hartshorn.inject.InjectionApplicationAwareContext;
+import org.dockbox.hartshorn.inject.InjectionCapableApplication;
+import org.dockbox.hartshorn.inject.ObjectFactory;
+import org.dockbox.hartshorn.inject.ReflectionObjectFactory;
+import org.dockbox.hartshorn.util.introspect.scan.ClassReference;
+import org.dockbox.hartshorn.util.introspect.scan.TypeReference;
+import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
+import org.dockbox.hartshorn.util.introspect.view.EnclosableView;
+import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.option.Option;
+import org.dockbox.hartshorn.util.types.ClassFileUtilities;
 
 /**
  * A matcher that can be used to match {@link RequiresCondition} annotations against a given set of
@@ -39,18 +47,15 @@ import java.util.stream.Collectors;
  * {@link Condition} instances that are referenced by the {@link RequiresCondition} annotations.
  *
  * <p>Condition matching can be used for a variety of purposes. For example, it can be used to
- * determine whether
- * a component should be registered, a binding method should be invoked, or an event should be
- * dispatched.
+ * determine whether a component should be registered, a binding method should be invoked, or an
+ * event should be dispatched.
  *
+ * @author Guus Lieben
  * @see RequiresCondition
  * @see Condition
  * @see ConditionContext
  * @see ConditionResult
- *
  * @since 0.4.12
- *
- * @author Guus Lieben
  */
 public final class ConditionMatcher extends DefaultContext
     implements InjectionApplicationAwareContext {
@@ -93,16 +98,27 @@ public final class ConditionMatcher extends DefaultContext
     }
 
     /**
-     * Matches the {@link RequiresCondition} annotations of the given {@link AnnotatedElementView},
-     * providing any additional {@link ContextView} instances to the {@link ConditionContext} that
-     * is used to match the {@link Condition condition implementations}. If any of the conditions
-     * does not match, this method will return {@code false}. If all conditions match, this method
-     * will return {@code true}.
+     * Matches the {@link RequiresCondition} and {@link RequiresReferenceCondition} annotations of
+     * the given {@link AnnotatedElementView}, providing any additional {@link ContextView}
+     * instances to the {@link ConditionContext} that is used to match the
+     * {@link Condition condition implementations}. If any of the conditions does not match, this
+     * method will return {@code false}. If all conditions match, this method will return
+     * {@code true}.
      *
-     * <p>If enabled, this method will also match any enclosing conditions of the given element. For
-     * example,
-     * if the given element is a method, this method will also match any conditions that are
-     * declared on the class that declares the method.
+     * <p>If enabled, this method will also match any enclosing conditions of the given element.
+     * For
+     * example, if the given element is a method, this method will also match any conditions that
+     * are declared on the class that declares the method.
+     *
+     * <p>Note that when matching enclosing conditions, the order of evaluation is from the least
+     * enclosed element to the most enclosed element (the given element). This means that
+     * class-level conditions are evaluated before method-level conditions.
+     *
+     * <p>{@link TypeReferenceCondition reference conditions} are also matched for any type views
+     * encountered during the matching process. Note that this may cause issues with class loading
+     * if the type references point to classes that are not available at runtime. In such cases,
+     * {@link #match(TypeReference, ContextView...)} should be used directly to avoid class
+     * loading.
      *
      * @param annotatedElementContext the annotated element to match against
      * @param contexts the additional contexts to provide to the condition context
@@ -126,7 +142,50 @@ public final class ConditionMatcher extends DefaultContext
                 .map(AnnotationConditionDeclaration::new)
                 .collect(Collectors.toSet());
 
-            if (!this.match(elementView, declarations, contexts)) {
+            if (!this.matchAnnotatedElement(elementView, declarations, contexts)) {
+                return false;
+            }
+
+            if (elementView instanceof TypeView<?> typeView
+                && !this.match(new ClassReference(typeView.type()), contexts)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Matches the {@link RequiresReferenceCondition} annotations of the given
+     * {@link TypeReference}, providing any additional {@link ContextView} instances to the
+     * {@link ConditionContext} that is used to match the
+     * {@link Condition condition implementations}. If any of the conditions do not match, this
+     * method will return {@code false}. If all conditions match, this method will return
+     * {@code true}.
+     *
+     * @param typeReference the type reference to match against
+     * @param contexts the additional contexts to provide to the condition context
+     *
+     * @return {@code true} if all conditions match, {@code false} otherwise
+     */
+    public boolean match(TypeReference typeReference, ContextView... contexts) {
+        ClassModel classModel = ClassFileUtilities.getClassModel(
+            typeReference.qualifiedName()
+        ).orElseThrow(() -> new IllegalStateException(
+            "Could not load class model for type reference: " + typeReference
+        ));
+        List<Annotation> annotations = ClassFileUtilities.getMetaAnnotations(
+            classModel,
+            RequiresReferenceCondition.class
+        );
+        for (Annotation annotation : annotations) {
+            var declaration = ReferenceConditionDeclaration.createFromMetaAnnotation(annotation);
+            TypeReferenceConditionContext conditionContext =
+                new TypeReferenceConditionContext(
+                    declaration,
+                    typeReference,
+                    classModel
+                );
+            if (!this.matchConditionContext(conditionContext, declaration, contexts)) {
                 return false;
             }
         }
@@ -148,13 +207,18 @@ public final class ConditionMatcher extends DefaultContext
      *
      * @return {@code true} if all conditions match, {@code false} otherwise
      */
-    public boolean match(
+    private boolean matchAnnotatedElement(
         AnnotatedElementView annotatedElementContext,
         Set<ConditionDeclaration> declarationContexts,
         ContextView... contexts
     ) {
         for (ConditionDeclaration declarationContext : declarationContexts) {
-            if (!this.match(annotatedElementContext, declarationContext, contexts)) {
+            ConditionContext context = new IntrospectedConditionContext(
+                this.application(),
+                annotatedElementContext,
+                declarationContext
+            );
+            if (!this.matchConditionContext(context, declarationContext, contexts)) {
                 return false;
             }
         }
@@ -168,21 +232,36 @@ public final class ConditionMatcher extends DefaultContext
      * {@link Condition condition implementations}. If the condition does not match, this method
      * will return {@code false}. If the condition matches, this method will return {@code true}.
      *
-     * @param element the annotated element to match against
+     * @param context the condition context to use for matching
      * @param declarationContext the {@link ConditionDeclaration declaration of the condition} to
      * match
      * @param contexts the additional contexts to provide to the condition context
      *
      * @return {@code true} if the condition matches, {@code false} otherwise
      */
-    public boolean match(
-        AnnotatedElementView element,
+    private boolean matchConditionContext(
+        ConditionContext context,
         ConditionDeclaration declarationContext,
         ContextView... contexts
     ) {
-        Condition condition = declarationContext.condition(this.application());
-        ConditionContext context =
-            new ConditionContext(this.application(), element, declarationContext);
+        InjectionCapableApplication application = this.application();
+        // Application may still be starting, thus fallback should be used.
+        final ObjectFactory objectFactory;
+        if (application == null) {
+            assert context instanceof TypeReferenceConditionContext : """
+                Expected type reference condition context when application is starting.
+                Introspection-capable condition contexts require at least a partially
+                initialized application.
+                """;
+            objectFactory = new ReflectionObjectFactory();
+        }
+        else {
+            objectFactory = new ComponentProviderObjectFactoryAdapter(
+                application.defaultProvider()
+            );
+        }
+
+        Condition condition = declarationContext.condition(objectFactory);
         for (ContextView child : contexts) {
             context.addContext(child);
         }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionMatcher.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ConditionMatcher.java
@@ -23,16 +23,13 @@ import org.dockbox.hartshorn.inject.InjectionApplicationAwareContext;
 import org.dockbox.hartshorn.inject.InjectionCapableApplication;
 import org.dockbox.hartshorn.inject.ObjectFactory;
 import org.dockbox.hartshorn.inject.ReflectionObjectFactory;
-import org.dockbox.hartshorn.util.introspect.scan.ClassReference;
-import org.dockbox.hartshorn.util.introspect.scan.TypeReference;
 import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 import org.dockbox.hartshorn.util.introspect.view.EnclosableView;
-import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 import org.dockbox.hartshorn.util.types.ClassFileUtilities;
 
 import java.lang.classfile.Annotation;
-import java.lang.classfile.ClassModel;
+import java.lang.classfile.AttributedElement;
 import java.util.ArrayDeque;
 import java.util.LinkedList;
 import java.util.List;
@@ -117,10 +114,10 @@ public final class ConditionMatcher extends DefaultContext
      * enclosed element to the most enclosed element (the given element). This means that
      * class-level conditions are evaluated before method-level conditions.
      *
-     * <p>{@link TypeReferenceCondition reference conditions} are also matched for any type views
-     * encountered during the matching process. Note that this may cause issues with class loading
-     * if the type references point to classes that are not available at runtime. In such cases,
-     * {@link #match(TypeReference, ContextView...)} should be used directly to avoid class
+     * <p>{@link ReferenceCondition reference conditions} are also matched for any reference
+     * views encountered during the matching process. Note that this may cause issues with class
+     * loading if the references point to classes that are not available at runtime. In such cases,
+     * {@link #match(AttributedElement, ContextView...)} should be used directly to avoid class
      * loading.
      *
      * @param annotatedElementContext the annotated element to match against
@@ -149,8 +146,9 @@ public final class ConditionMatcher extends DefaultContext
                 return false;
             }
 
-            if (elementView instanceof TypeView<?> typeView
-                && !this.match(new ClassReference(typeView.type()), contexts)) {
+            if (!elementView.classFileElement()
+                    .ofType(AttributedElement.class)
+                    .test(element -> this.match(element, contexts), true)) {
                 return false;
             }
         }
@@ -159,35 +157,28 @@ public final class ConditionMatcher extends DefaultContext
 
     /**
      * Matches the {@link RequiresReferenceCondition} annotations of the given
-     * {@link TypeReference}, providing any additional {@link ContextView} instances to the
+     * {@link AttributedElement}, providing any additional {@link ContextView} instances to the
      * {@link ConditionContext} that is used to match the
      * {@link Condition condition implementations}. If any of the conditions do not match, this
      * method will return {@code false}. If all conditions match, this method will return
      * {@code true}.
      *
-     * @param typeReference the type reference to match against
+     * @param element the attributed element to match against
      * @param contexts the additional contexts to provide to the condition context
-     *
      * @return {@code true} if all conditions match, {@code false} otherwise
      */
-    public boolean match(TypeReference typeReference, ContextView... contexts) {
-        ClassModel classModel = ClassFileUtilities.getClassModel(
-            typeReference.qualifiedName()
-        ).orElseThrow(() -> new IllegalStateException(
-            "Could not load class model for type reference: " + typeReference
-        ));
+    public boolean match(AttributedElement element, ContextView... contexts) {
         List<Annotation> annotations = ClassFileUtilities.getMetaAnnotations(
-            classModel,
-            RequiresReferenceCondition.class
+                element,
+                RequiresReferenceCondition.class
         );
         for (Annotation annotation : annotations) {
             var declaration = ReferenceConditionDeclaration.createFromMetaAnnotation(annotation);
-            TypeReferenceConditionContext conditionContext =
-                new TypeReferenceConditionContext(
-                    declaration,
-                    typeReference,
-                    classModel
-                );
+            ReferenceConditionContext conditionContext =
+                    new ReferenceConditionContext(
+                            declaration,
+                            element
+                    );
             if (!this.matchConditionContext(conditionContext, declaration, contexts)) {
                 return false;
             }
@@ -251,7 +242,7 @@ public final class ConditionMatcher extends DefaultContext
         // Application may still be starting, thus fallback should be used.
         final ObjectFactory objectFactory;
         if (application == null) {
-            assert context instanceof TypeReferenceConditionContext : """
+            assert context instanceof ReferenceConditionContext : """
                 Expected type reference condition context when application is starting.
                 Introspection-capable condition contexts require at least a partially
                 initialized application.

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/IntrospectedConditionContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/IntrospectedConditionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.inject.condition;
 
+import org.dockbox.hartshorn.inject.InjectionApplicationAwareContext;
 import org.dockbox.hartshorn.inject.InjectionCapableApplication;
 import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 
@@ -31,8 +32,10 @@ import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
  *
  * @author Guus Lieben
  */
-public class IntrospectedConditionContext extends ConditionContext {
+public non-sealed class IntrospectedConditionContext extends ConditionContext
+    implements InjectionApplicationAwareContext {
 
+    private final InjectionCapableApplication application;
     private final AnnotatedElementView annotatedElement;
 
     public IntrospectedConditionContext(
@@ -40,7 +43,8 @@ public class IntrospectedConditionContext extends ConditionContext {
         AnnotatedElementView annotatedElement,
         ConditionDeclaration condition
     ) {
-        super(application, condition);
+        super(condition);
+        this.application = application;
         this.annotatedElement = annotatedElement;
     }
 
@@ -51,5 +55,10 @@ public class IntrospectedConditionContext extends ConditionContext {
      */
     public AnnotatedElementView annotatedElement() {
         return this.annotatedElement;
+    }
+
+    @Override
+    public InjectionCapableApplication application() {
+        return this.application;
     }
 }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/IntrospectedConditionContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/IntrospectedConditionContext.java
@@ -16,8 +16,8 @@
 
 package org.dockbox.hartshorn.inject.condition;
 
-import org.dockbox.hartshorn.inject.DefaultInjectionApplicationAwareContext;
 import org.dockbox.hartshorn.inject.InjectionCapableApplication;
+import org.dockbox.hartshorn.util.introspect.view.AnnotatedElementView;
 
 /**
  * A context that is used during the evaluation of a condition. This includes the annotated element
@@ -31,24 +31,25 @@ import org.dockbox.hartshorn.inject.InjectionCapableApplication;
  *
  * @author Guus Lieben
  */
-public class ConditionContext extends DefaultInjectionApplicationAwareContext {
+public class IntrospectedConditionContext extends ConditionContext {
 
-    private final ConditionDeclaration condition;
+    private final AnnotatedElementView annotatedElement;
 
-    public ConditionContext(
+    public IntrospectedConditionContext(
         InjectionCapableApplication application,
+        AnnotatedElementView annotatedElement,
         ConditionDeclaration condition
     ) {
-        super(application);
-        this.condition = condition;
+        super(application, condition);
+        this.annotatedElement = annotatedElement;
     }
 
     /**
-     * Returns the {@link ConditionDeclaration declaration} that is used to evaluate the condition.
+     * Returns the annotated element that is being evaluated.
      *
-     * @return the {@link ConditionDeclaration declaration} that is used to evaluate the condition
+     * @return the annotated element that is being evaluated
      */
-    public ConditionDeclaration condition() {
-        return this.condition;
+    public AnnotatedElementView annotatedElement() {
+        return this.annotatedElement;
     }
 }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/IntrospectionCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/IntrospectionCondition.java
@@ -17,17 +17,19 @@
 package org.dockbox.hartshorn.inject.condition;
 
 /**
- * A condition that may be used by a {@link ConditionMatcher} to determine whether a certain
- * operation should be executed. Conditions are expected to be stateless, and may be reused for
- * multiple matches.
+ * A condition that requires introspection of the annotated element being evaluated. This condition
+ * receives an {@link IntrospectedConditionContext} when being matched. As a result, all tested
+ * views will have been introspected, and therefore will already be loaded on the classpath.
  *
  * @see ConditionMatcher
+ * @see Condition
  * 
- * @since 0.4.12
+ * @since 0.7.0
  * 
  * @author Guus Lieben
  */
-public sealed interface Condition permits IntrospectionCondition, TypeReferenceCondition {
+@FunctionalInterface
+public non-sealed interface IntrospectionCondition extends Condition {
 
     /**
      * Returns a {@link ConditionResult} that describes whether the condition is matched.
@@ -36,5 +38,15 @@ public sealed interface Condition permits IntrospectionCondition, TypeReferenceC
      *
      * @return a {@link ConditionResult} that describes whether the condition is matched
      */
-    ConditionResult matches(ConditionContext context);
+    @Override
+    default ConditionResult matches(ConditionContext context) {
+        if (context instanceof IntrospectedConditionContext introspectedConditionContext) {
+            return this.matches(introspectedConditionContext);
+        }
+        return ConditionResult.notMatched(
+                "ConditionContext is not an instance of IntrospectedConditionContext"
+        );
+    }
+
+    ConditionResult matches(IntrospectedConditionContext context);
 }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ReferenceCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ReferenceCondition.java
@@ -17,10 +17,10 @@
 package org.dockbox.hartshorn.inject.condition;
 
 /**
- * A {@link Condition} that matches based on a type reference, without requiring the type to be
+ * A {@link Condition} that matches based on a reference, without requiring the element to be
  * loaded. This has the benefit of being able to evaluate conditions without causing class loading
  * early in the application lifecycle. The drawback is that the condition implementation must work
- * with type references with limited information (compared to loaded classes, which support full
+ * with references with limited information (compared to loaded elements, which support full
  * introspection).
  *
  * @since 0.7.0
@@ -28,7 +28,7 @@ package org.dockbox.hartshorn.inject.condition;
  * @author Guus Lieben
  */
 @FunctionalInterface
-public non-sealed interface TypeReferenceCondition extends Condition {
+public non-sealed interface ReferenceCondition extends Condition {
 
     /**
      * Returns a {@link ConditionResult} that describes whether the condition is matched.
@@ -39,11 +39,11 @@ public non-sealed interface TypeReferenceCondition extends Condition {
      */
     @Override
     default ConditionResult matches(ConditionContext context) {
-        if (context instanceof TypeReferenceConditionContext referenceConditionContext) {
+        if (context instanceof ReferenceConditionContext referenceConditionContext) {
             return this.matches(referenceConditionContext);
         }
         return ConditionResult.notMatched(
-                "ConditionContext is not an instance of TypeReferenceConditionContext"
+                "ConditionContext is not an instance of ReferenceConditionContext"
         );
     }
 
@@ -53,5 +53,5 @@ public non-sealed interface TypeReferenceCondition extends Condition {
      * @param context the type reference condition context
      * @return the condition result
      */
-    ConditionResult matches(TypeReferenceConditionContext context);
+    ConditionResult matches(ReferenceConditionContext context);
 }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ReferenceConditionContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ReferenceConditionContext.java
@@ -17,12 +17,12 @@
 package org.dockbox.hartshorn.inject.condition;
 
 import java.lang.classfile.AttributedElement;
-import org.dockbox.hartshorn.util.introspect.scan.TypeReference;
 
 /**
- * A context that is used during the evaluation of a condition. This includes the type reference
- * that is being evaluated, and the {@link RequiresReferenceCondition} annotation that is used to
- * evaluate the condition.
+ * A context that is used during the evaluation of a condition. This context provides access to the
+ * {@link AttributedElement class file element} being evaluated. Unlike the
+ * {@link IntrospectedConditionContext}, this context does not ensure that the element is fully
+ * loaded by the JVM, and may therefore be used in earlier stages of the injection process.
  *
  * @see RequiresReferenceCondition
  *
@@ -30,30 +30,16 @@ import org.dockbox.hartshorn.util.introspect.scan.TypeReference;
  *
  * @author Guus Lieben
  */
-public non-sealed class TypeReferenceConditionContext extends ConditionContext {
+public non-sealed class ReferenceConditionContext extends ConditionContext {
 
-    private final TypeReference typeReference;
     private final AttributedElement element;
 
-    public TypeReferenceConditionContext(
+    public ReferenceConditionContext(
             ConditionDeclaration condition,
-            TypeReference typeReference,
             AttributedElement element
     ) {
         super(condition);
-        this.typeReference = typeReference;
         this.element = element;
-    }
-
-    /**
-     * Returns the type reference in which the condition is being evaluated. This may match the
-     * {@link #element()} if the element is a type, but may also represent a member or other
-     * annotated element within the type.
-     *
-     * @return the type reference being evaluated
-     */
-    public TypeReference typeReference() {
-        return this.typeReference;
     }
 
     /**

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ReferenceConditionDeclaration.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/ReferenceConditionDeclaration.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.condition;
+
+import java.lang.classfile.Annotation;
+import java.lang.classfile.AnnotationValue;
+import java.lang.classfile.ClassModel;
+import org.dockbox.hartshorn.inject.ObjectFactory;
+import org.dockbox.hartshorn.util.option.Option;
+import org.dockbox.hartshorn.util.types.ClassFileUtilities;
+import org.dockbox.hartshorn.util.types.TypeUtils;
+
+/**
+ * Represents a condition declaration that is based on an annotation reference. The type on which
+ * the annotation is declared is not ensured to be loaded, and should not be loaded during the
+ * evaluation of the condition.
+ *
+ * @see RequiresReferenceCondition
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
+public class ReferenceConditionDeclaration implements ConditionDeclaration {
+
+    private final Annotation annotation;
+
+    public ReferenceConditionDeclaration(Annotation annotation) {
+        this.annotation = annotation;
+    }
+
+    /**
+     * Creates a new {@link ReferenceConditionDeclaration} from a meta-annotation. Only the
+     * {@link RequiresReferenceCondition} annotation is retained, while the original meta-annotation
+     * is discarded.
+     *
+     * @param metaAnnotation the meta-annotation to create the declaration from
+     * @return the created reference condition declaration
+     */
+    public static ReferenceConditionDeclaration createFromMetaAnnotation(
+        Annotation metaAnnotation
+    ) {
+        ClassModel model = ClassFileUtilities.getClassModel(metaAnnotation.classSymbol());
+        Option<Annotation> declaration = ClassFileUtilities.getAnnotation(
+            model,
+            RequiresReferenceCondition.class
+        );
+        return new ReferenceConditionDeclaration(declaration.orElseThrow(() -> {
+            return new IllegalStateException(
+                "Could not create ReferenceConditionDeclaration from "
+                    + "non-ReferenceCondition annotation"
+            );
+        }));
+    }
+
+    @Override
+    public Condition condition(ObjectFactory objectFactory) {
+        return ClassFileUtilities.getAnnotationValue(
+                this.annotation,
+                "condition",
+                AnnotationValue.OfClass.class
+            )
+            .map(AnnotationValue.OfClass::className)
+            .map(ClassFileUtilities::constantPoolNameToQualifiedName)
+            .flatMap(TypeUtils::forName)
+            .map(objectFactory::create)
+            .ofType(Condition.class)
+            .orElseThrow(() -> new IllegalStateException(
+                "Could not instantiate condition for reference condition declaration"
+            ));
+    }
+
+    @Override
+    public boolean failOnNoMatch() {
+        // Default to false if the value is not explicitly set (matching default
+        // value of annotation).
+        return ClassFileUtilities.getAnnotationValue(
+            this.annotation,
+            "failOnNoMatch",
+            AnnotationValue.OfBoolean.class
+        ).test(AnnotationValue.OfBoolean::booleanValue, false);
+    }
+}

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/RequiresCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/RequiresCondition.java
@@ -16,12 +16,12 @@
 
 package org.dockbox.hartshorn.inject.condition;
 
+import org.dockbox.hartshorn.inject.condition.support.RequiresClass;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import org.dockbox.hartshorn.inject.condition.support.RequiresClass;
 
 /**
  * A generic condition that requires a specific condition to be met. The condition is defined by the
@@ -58,7 +58,7 @@ public @interface RequiresCondition {
      *
      * @return the condition that is required to be met
      */
-    Class<? extends Condition> condition();
+    Class<? extends IntrospectionCondition> condition();
 
     /**
      * Whether to fail on no match. If set to {@code true}, the operation will fail if the condition

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/RequiresReferenceCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/RequiresReferenceCondition.java
@@ -24,20 +24,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A condition that requires conditions to be met based on type references. Unlike
- * {@link RequiresCondition}, this annotation is specifically designed to work with conditions that
- * evaluate type references, such as classes or interfaces, without needing to load the classes into
- * the JVM.
+ * A condition that requires conditions to be met based on
+ * {@link java.lang.classfile.AttributedElement class file elements}.
  *
- * <p>This approach has the benefit of avoiding class loading issues, such as
- * {@link ClassNotFoundException ClassNotFoundExceptions}, when checking for the presence of
- * classes that may not be available at runtime. By using type references, conditions can be
- * evaluated based on metadata alone, allowing for safer and more flexible condition checks. The
- * drawback is that the condition implementations cannot rely on loaded classes, and must
- * instead work with type metadata.
+ * <p>By using type references, conditions can be evaluated based on metadata alone, allowing for
+ * safer and more flexible condition checks. The drawback is that the condition implementations
+ * cannot rely on loaded classes, and must instead work with type metadata.
  *
- * <p>Due to the nature of type references, meta annotations of this annotation are supported, but
- * lack hierarchy support (i.e. meta-meta annotations and attribute aliases are not supported).
+ * <p>Due to the nature of type references, only meta annotations of this annotation are supported,
+ * but these lack hierarchy support (i.e. meta-meta annotations and attribute aliases are not
+ * supported).
  *
  * <pre>{@code
  * @RequiresReferenceCondition(condition  = SampleCondition.class)
@@ -62,7 +58,7 @@ public @interface RequiresReferenceCondition {
      *
      * @return the condition that is required to be met
      */
-    Class<? extends TypeReferenceCondition> condition();
+    Class<? extends ReferenceCondition> condition();
 
     /**
      * Whether to fail on no match. If set to {@code true}, the operation will fail if the condition

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/RequiresReferenceCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/RequiresReferenceCondition.java
@@ -24,33 +24,37 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A generic condition that requires a specific condition to be met. The condition is defined by the
- * {@link #condition()} attribute. If the condition is not met, the annotated element is not
- * processed.
+ * A condition that requires conditions to be met based on type references. Unlike
+ * {@link RequiresCondition}, this annotation is specifically designed to work with conditions that
+ * evaluate type references, such as classes or interfaces, without needing to load the classes into
+ * the JVM.
  *
- * <p>In most cases, it is recommended to create a custom annotation that extends this annotation,
- * and
- * use that annotation instead. This allows for a more readable code base. A basic example is shown
- * below.
+ * <p>This approach has the benefit of avoiding class loading issues, such as
+ * {@link ClassNotFoundException ClassNotFoundExceptions}, when checking for the presence of
+ * classes that may not be available at runtime. By using type references, conditions can be
+ * evaluated based on metadata alone, allowing for safer and more flexible condition checks. The
+ * drawback is that the condition implementations cannot rely on loaded classes, and must
+ * instead work with type metadata.
+ *
+ * <p>Due to the nature of type references, meta annotations of this annotation are supported, but
+ * lack hierarchy support (i.e. meta-meta annotations and attribute aliases are not supported).
  *
  * <pre>{@code
- * @Extends(RequiresCondition.class)
- * @RequiresCondition(condition  = SampleCondition.class)
+ * @RequiresReferenceCondition(condition  = SampleCondition.class)
  * public @interface RequiresClass {
  *    ... additional attributes for your condition ...
- *    boolean failOnNoMatch() default false;
  * }
  * }</pre>
  *
- * @author Guus Lieben
  * @see RequiresClass
- * @see Condition
- * @see ConditionMatcher
- * @since 0.4.12
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface RequiresCondition {
+public @interface RequiresReferenceCondition {
 
     /**
      * The condition that is required to be met. The condition should be a stateless class that
@@ -58,7 +62,7 @@ public @interface RequiresCondition {
      *
      * @return the condition that is required to be met
      */
-    Class<? extends IntrospectionCondition> condition();
+    Class<? extends TypeReferenceCondition> condition();
 
     /**
      * Whether to fail on no match. If set to {@code true}, the operation will fail if the condition

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/TypeReferenceCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/TypeReferenceCondition.java
@@ -17,19 +17,18 @@
 package org.dockbox.hartshorn.inject.condition;
 
 /**
- * A condition that requires introspection of the annotated element being evaluated. This condition
- * receives an {@link IntrospectedConditionContext} when being matched. As a result, all tested
- * views will have been introspected, and therefore will already be loaded on the classpath.
+ * A {@link Condition} that matches based on a type reference, without requiring the type to be
+ * loaded. This has the benefit of being able to evaluate conditions without causing class loading
+ * early in the application lifecycle. The drawback is that the condition implementation must work
+ * with type references with limited information (compared to loaded classes, which support full
+ * introspection).
  *
- * @see ConditionMatcher
- * @see Condition
- * 
  * @since 0.7.0
- * 
+ *
  * @author Guus Lieben
  */
 @FunctionalInterface
-public non-sealed interface IntrospectionCondition extends Condition {
+public non-sealed interface TypeReferenceCondition extends Condition {
 
     /**
      * Returns a {@link ConditionResult} that describes whether the condition is matched.
@@ -40,19 +39,19 @@ public non-sealed interface IntrospectionCondition extends Condition {
      */
     @Override
     default ConditionResult matches(ConditionContext context) {
-        if (context instanceof IntrospectedConditionContext introspectedConditionContext) {
-            return this.matches(introspectedConditionContext);
+        if (context instanceof TypeReferenceConditionContext referenceConditionContext) {
+            return this.matches(referenceConditionContext);
         }
         return ConditionResult.notMatched(
-                "ConditionContext is not an instance of IntrospectedConditionContext"
+                "ConditionContext is not an instance of TypeReferenceConditionContext"
         );
     }
 
     /**
      * Matches the condition against the given context.
      *
-     * @param context the introspected condition context
+     * @param context the type reference condition context
      * @return the condition result
      */
-    ConditionResult matches(IntrospectedConditionContext context);
+    ConditionResult matches(TypeReferenceConditionContext context);
 }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/TypeReferenceConditionContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/TypeReferenceConditionContext.java
@@ -16,15 +16,13 @@
 
 package org.dockbox.hartshorn.inject.condition;
 
+import java.lang.classfile.AttributedElement;
 import org.dockbox.hartshorn.util.introspect.scan.TypeReference;
-
-import java.lang.classfile.ClassModel;
 
 /**
  * A context that is used during the evaluation of a condition. This includes the type reference
  * that is being evaluated, and the {@link RequiresReferenceCondition} annotation that is used to
- * evaluate the condition. Note that this annotation is not necessarily present on the annotated
- * element, but may be composed from extending annotations.
+ * evaluate the condition.
  *
  * @see RequiresReferenceCondition
  *
@@ -35,33 +33,36 @@ import java.lang.classfile.ClassModel;
 public non-sealed class TypeReferenceConditionContext extends ConditionContext {
 
     private final TypeReference typeReference;
-    private final ClassModel classModel;
+    private final AttributedElement element;
 
     public TypeReferenceConditionContext(
             ConditionDeclaration condition,
             TypeReference typeReference,
-            ClassModel classModel
+            AttributedElement element
     ) {
         super(condition);
         this.typeReference = typeReference;
-        this.classModel = classModel;
+        this.element = element;
     }
 
     /**
-     * Returns the annotated element that is being evaluated.
+     * Returns the type reference in which the condition is being evaluated. This may match the
+     * {@link #element()} if the element is a type, but may also represent a member or other
+     * annotated element within the type.
      *
-     * @return the annotated element that is being evaluated
+     * @return the type reference being evaluated
      */
     public TypeReference typeReference() {
         return this.typeReference;
     }
 
     /**
-     * Returns the class model of the type reference being evaluated.
+     * Returns the element being evaluated. This may be the type itself, but may also be a member or
+     * other annotated element within the type.
      *
-     * @return the class model of the type reference being evaluated
+     * @return the element being evaluated
      */
-    public ClassModel classModel() {
-        return this.classModel;
+    public AttributedElement element() {
+        return this.element;
     }
 }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/TypeReferenceConditionContext.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/TypeReferenceConditionContext.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject.condition;
+
+import org.dockbox.hartshorn.util.introspect.scan.TypeReference;
+
+import java.lang.classfile.ClassModel;
+
+/**
+ * A context that is used during the evaluation of a condition. This includes the type reference
+ * that is being evaluated, and the {@link RequiresReferenceCondition} annotation that is used to
+ * evaluate the condition. Note that this annotation is not necessarily present on the annotated
+ * element, but may be composed from extending annotations.
+ *
+ * @see RequiresReferenceCondition
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
+public non-sealed class TypeReferenceConditionContext extends ConditionContext {
+
+    private final TypeReference typeReference;
+    private final ClassModel classModel;
+
+    public TypeReferenceConditionContext(
+            ConditionDeclaration condition,
+            TypeReference typeReference,
+            ClassModel classModel
+    ) {
+        super(condition);
+        this.typeReference = typeReference;
+        this.classModel = classModel;
+    }
+
+    /**
+     * Returns the annotated element that is being evaluated.
+     *
+     * @return the annotated element that is being evaluated
+     */
+    public TypeReference typeReference() {
+        return this.typeReference;
+    }
+
+    /**
+     * Returns the class model of the type reference being evaluated.
+     *
+     * @return the class model of the type reference being evaluated
+     */
+    public ClassModel classModel() {
+        return this.classModel;
+    }
+}

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/AbsentBindingCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/AbsentBindingCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/AbsentBindingCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/AbsentBindingCondition.java
@@ -16,15 +16,16 @@
 
 package org.dockbox.hartshorn.inject.condition.support;
 
-import java.util.List;
-import java.util.stream.Stream;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
-import org.dockbox.hartshorn.inject.condition.Condition;
-import org.dockbox.hartshorn.inject.condition.ConditionContext;
 import org.dockbox.hartshorn.inject.condition.ConditionResult;
+import org.dockbox.hartshorn.inject.condition.IntrospectedConditionContext;
+import org.dockbox.hartshorn.inject.condition.IntrospectionCondition;
 import org.dockbox.hartshorn.inject.graph.ConditionalDependencyContext;
 import org.dockbox.hartshorn.inject.graph.ConditionalDependencyContextsHolder;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * A condition that matches when a binding is absent. This does not require an instance of the
@@ -37,10 +38,10 @@ import org.dockbox.hartshorn.inject.graph.ConditionalDependencyContextsHolder;
  * 
  * @author Guus Lieben
  */
-public class AbsentBindingCondition implements Condition {
+public class AbsentBindingCondition implements IntrospectionCondition {
 
     @Override
-    public ConditionResult matches(ConditionContext context) {
+    public ConditionResult matches(IntrospectedConditionContext context) {
         return context.annotatedElement()
             .annotations()
             .get(RequiresAbsentBinding.class)
@@ -70,7 +71,8 @@ public class AbsentBindingCondition implements Condition {
 
     private static Stream<ConditionalDependencyContext<?>> matchedConditionalContextsExceptCurrent(
         ConditionalDependencyContextsHolder contextsHolder,
-        ConditionContext context, ComponentKey<?> key
+        IntrospectedConditionContext context,
+        ComponentKey<?> key
     ) {
         return contextsHolder.conditionalDependencyContexts().get(key).stream()
             .filter(conditionalDependencyContext -> !conditionalDependencyContext

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/ClassCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/ClassCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,33 +16,70 @@
 
 package org.dockbox.hartshorn.inject.condition.support;
 
-import org.dockbox.hartshorn.inject.condition.Condition;
-import org.dockbox.hartshorn.inject.condition.ConditionContext;
 import org.dockbox.hartshorn.inject.condition.ConditionResult;
+import org.dockbox.hartshorn.inject.condition.TypeReferenceCondition;
+import org.dockbox.hartshorn.inject.condition.TypeReferenceConditionContext;
+import org.dockbox.hartshorn.util.types.ClassFileUtilities;
 import org.dockbox.hartshorn.util.types.TypeUtils;
 
+import java.lang.classfile.Annotation;
+import java.lang.classfile.AnnotationValue;
+import java.lang.classfile.ClassModel;
+import java.util.List;
+
 /**
- * A condition that matches when a class is present on the classpath. Due to the nature of this
- * condition, it is required to provide the class name as a string.
+ * A condition that matches when a class is present on the classpath.
  *
  * @see RequiresClass
- * @see Class#forName(String)
- * 
+ *
  * @since 0.4.12
- * 
+ *
  * @author Guus Lieben
  */
-public class ClassCondition implements Condition {
+public class ClassCondition implements TypeReferenceCondition {
 
     @Override
-    public ConditionResult matches(ConditionContext context) {
-        return context.annotatedElement().annotations().get(RequiresClass.class).map(condition -> {
-            for (String name : condition.value()) {
-                if (!TypeUtils.exists(name)) {
-                    return ConditionResult.notFound("class", name);
-                }
+    public ConditionResult matches(TypeReferenceConditionContext context) {
+        ClassModel classModel = context.classModel();
+        Annotation annotation = ClassFileUtilities.getAnnotation(
+                classModel,
+                RequiresClass.class
+        ).orElseThrow(() -> new IllegalStateException(
+                "ClassModel does not represent a type annotated with RequiresClass"
+        ));
+
+        List<String> classes = ClassFileUtilities.getAnnotationValues(
+                        annotation,
+                        "classes",
+                        AnnotationValue.OfClass.class
+                ).stream()
+                .map(AnnotationValue.OfClass::className)
+                .map(ClassFileUtilities::constantPoolNameToQualifiedName)
+                .toList();
+        // Potentially return early if a class is not found
+        ConditionResult result = matchRequiredClasses(classes);
+        if (result != null) return result;
+
+        List<String> classNames = ClassFileUtilities.getAnnotationValues(
+                        annotation,
+                        "classNames",
+                        AnnotationValue.OfString.class
+                ).stream()
+                .map(AnnotationValue.OfString::stringValue)
+                .toList();
+        result = matchRequiredClasses(classNames);
+        if (result != null) return result;
+
+        return ConditionResult.matched();
+    }
+
+    private static ConditionResult matchRequiredClasses(List<String> classNames) {
+        for (String requiredClassName : classNames) {
+            if (TypeUtils.exists(requiredClassName)) {
+                continue;
             }
-            return ConditionResult.matched();
-        }).orElse(ConditionResult.invalidCondition("class"));
+            return ConditionResult.notFound("class", requiredClassName);
+        }
+        return null;
     }
 }

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/ClassCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/ClassCondition.java
@@ -16,15 +16,16 @@
 
 package org.dockbox.hartshorn.inject.condition.support;
 
+import org.dockbox.hartshorn.inject.condition.ReferenceConditionContext;
+import org.dockbox.hartshorn.inject.condition.ConditionResult;
+import org.dockbox.hartshorn.inject.condition.ReferenceCondition;
+import org.dockbox.hartshorn.util.types.ClassFileUtilities;
+import org.dockbox.hartshorn.util.types.TypeUtils;
+
 import java.lang.classfile.Annotation;
 import java.lang.classfile.AnnotationValue;
 import java.lang.classfile.AttributedElement;
 import java.util.List;
-import org.dockbox.hartshorn.inject.condition.ConditionResult;
-import org.dockbox.hartshorn.inject.condition.TypeReferenceCondition;
-import org.dockbox.hartshorn.inject.condition.TypeReferenceConditionContext;
-import org.dockbox.hartshorn.util.types.ClassFileUtilities;
-import org.dockbox.hartshorn.util.types.TypeUtils;
 
 /**
  * A condition that matches when a class is present on the classpath.
@@ -35,10 +36,10 @@ import org.dockbox.hartshorn.util.types.TypeUtils;
  *
  * @author Guus Lieben
  */
-public class ClassCondition implements TypeReferenceCondition {
+public class ClassCondition implements ReferenceCondition {
 
     @Override
-    public ConditionResult matches(TypeReferenceConditionContext context) {
+    public ConditionResult matches(ReferenceConditionContext context) {
         AttributedElement element = context.element();
         Annotation annotation = ClassFileUtilities.getAnnotation(
                 element,

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/ClassCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/ClassCondition.java
@@ -16,16 +16,15 @@
 
 package org.dockbox.hartshorn.inject.condition.support;
 
+import java.lang.classfile.Annotation;
+import java.lang.classfile.AnnotationValue;
+import java.lang.classfile.AttributedElement;
+import java.util.List;
 import org.dockbox.hartshorn.inject.condition.ConditionResult;
 import org.dockbox.hartshorn.inject.condition.TypeReferenceCondition;
 import org.dockbox.hartshorn.inject.condition.TypeReferenceConditionContext;
 import org.dockbox.hartshorn.util.types.ClassFileUtilities;
 import org.dockbox.hartshorn.util.types.TypeUtils;
-
-import java.lang.classfile.Annotation;
-import java.lang.classfile.AnnotationValue;
-import java.lang.classfile.ClassModel;
-import java.util.List;
 
 /**
  * A condition that matches when a class is present on the classpath.
@@ -40,9 +39,9 @@ public class ClassCondition implements TypeReferenceCondition {
 
     @Override
     public ConditionResult matches(TypeReferenceConditionContext context) {
-        ClassModel classModel = context.classModel();
+        AttributedElement element = context.element();
         Annotation annotation = ClassFileUtilities.getAnnotation(
-                classModel,
+                element,
                 RequiresClass.class
         ).orElseThrow(() -> new IllegalStateException(
                 "ClassModel does not represent a type annotated with RequiresClass"

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/PropertyCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/PropertyCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/PropertyCondition.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/PropertyCondition.java
@@ -17,8 +17,9 @@
 package org.dockbox.hartshorn.inject.condition.support;
 
 import org.dockbox.hartshorn.inject.condition.Condition;
-import org.dockbox.hartshorn.inject.condition.ConditionContext;
 import org.dockbox.hartshorn.inject.condition.ConditionResult;
+import org.dockbox.hartshorn.inject.condition.IntrospectedConditionContext;
+import org.dockbox.hartshorn.inject.condition.IntrospectionCondition;
 import org.dockbox.hartshorn.properties.ValueProperty;
 import org.dockbox.hartshorn.util.option.Option;
 
@@ -35,10 +36,10 @@ import org.dockbox.hartshorn.util.option.Option;
  * 
  * @author Guus Lieben
  */
-public class PropertyCondition implements Condition {
+public class PropertyCondition implements IntrospectionCondition {
 
     @Override
-    public ConditionResult matches(ConditionContext context) {
+    public ConditionResult matches(IntrospectedConditionContext context) {
         return context.annotatedElement()
             .annotations()
             .get(RequiresProperty.class)

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/RequiresClass.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/RequiresClass.java
@@ -16,14 +16,23 @@
 
 package org.dockbox.hartshorn.inject.condition.support;
 
+import org.dockbox.hartshorn.inject.condition.RequiresReferenceCondition;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.dockbox.hartshorn.inject.condition.RequiresReferenceCondition;
 
 /**
- * A condition that requires classes to be present in the classpath.
+ * A condition that requires classes to be present in the classpath. As this condition is evaluated
+ * early during the injection process, it does not require the classes to be loaded by the JVM, and
+ * can therefore be used to conditionally load configurations based on optional dependencies.
+ *
+ * <p><b>Note, for binding methods</b>, take into account that the JVM will have loaded the
+ * enclosing class, as well as the return type and any method references, before evaluating this
+ * condition. As such, this condition is best applied to configuration classes. If used on binding
+ * methods, ensure the return type and references do not depend on the checked classes. For such
+ * cases, use separate conditionally loaded configuration classes.
  *
  * @see ClassCondition
  * 

--- a/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/RequiresClass.java
+++ b/hartshorn-inject-configurations/src/main/java/org/dockbox/hartshorn/inject/condition/support/RequiresClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import org.dockbox.hartshorn.inject.condition.RequiresCondition;
-import org.dockbox.hartshorn.util.introspect.annotations.AttributeAlias;
-import org.dockbox.hartshorn.util.introspect.annotations.Extends;
+import org.dockbox.hartshorn.inject.condition.RequiresReferenceCondition;
 
 /**
  * A condition that requires classes to be present in the classpath.
@@ -36,23 +33,20 @@ import org.dockbox.hartshorn.util.introspect.annotations.Extends;
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@Extends(RequiresCondition.class)
-@RequiresCondition(condition = ClassCondition.class)
+@RequiresReferenceCondition(condition = ClassCondition.class)
 public @interface RequiresClass {
+
+    /**
+     * The classes that are required to be present.
+     *
+     * @return the classes that are required to be present
+     */
+    Class<?>[] classes() default {};
 
     /**
      * The fully qualified name of the classes that are required to be present.
      *
      * @return the fully qualified name of the classes that are required to be present
      */
-    @AttributeAlias(value = "failOnNoMatch", target = RequiresCondition.class)
-    String[] value();
-
-    /**
-     * @return whether to fail on no match
-     *
-     * @see RequiresCondition#failOnNoMatch()
-     */
-    @AttributeAlias(value = "failsOnNoMatch", target = RequiresCondition.class)
-    boolean failOnNoMatch() default false;
+    String[] classNames() default {};
 }

--- a/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/ComponentProviderObjectFactoryAdapter.java
+++ b/hartshorn-inject/src/main/java/org/dockbox/hartshorn/inject/ComponentProviderObjectFactoryAdapter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.inject;
+
+import org.dockbox.hartshorn.inject.provider.ComponentProvider;
+
+/**
+ * An {@link ObjectFactory} implementation that delegates object creation to a
+ * {@link ComponentProvider}.
+ *
+ * @param componentProvider the component provider to delegate to
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
+public record ComponentProviderObjectFactoryAdapter(ComponentProvider componentProvider)
+    implements ObjectFactory {
+
+    @Override
+    public <T> T create(Class<T> type) {
+        return this.componentProvider.get(type);
+    }
+}

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/conditions/ConditionTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/conditions/ConditionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.dockbox.hartshorn.inject.condition.Condition;
 import org.dockbox.hartshorn.inject.condition.ConditionContext;
 import org.dockbox.hartshorn.inject.condition.ConditionMatcher;
 import org.dockbox.hartshorn.inject.condition.ConditionResult;
+import org.dockbox.hartshorn.inject.condition.IntrospectedConditionContext;
 import org.dockbox.hartshorn.inject.condition.RequiresCondition;
 import org.dockbox.hartshorn.inject.condition.support.ClassCondition;
 import org.dockbox.hartshorn.inject.condition.support.RequiresClass;
@@ -100,7 +101,7 @@ public class ConditionTests {
         RequiresCondition annotation = method.annotations().get(RequiresCondition.class).get();
         AnnotationConditionDeclaration declaration = new AnnotationConditionDeclaration(annotation);
         ConditionContext context =
-            new ConditionContext(this.applicationContext, method, declaration);
+            new IntrospectedConditionContext(this.applicationContext, method, declaration);
         Condition condition = new ActivatorCondition();
 
         ConditionResult result = condition.matches(context);
@@ -120,7 +121,7 @@ public class ConditionTests {
         MethodView<ConditionTests, ?> requiresClass = type.methods().named("requiresClass").get();
         RequiresCondition annotationForPresent =
             requiresClass.annotations().get(RequiresCondition.class).get();
-        ConditionContext contextForPresent = new ConditionContext(this.applicationContext,
+        ConditionContext contextForPresent = new IntrospectedConditionContext(this.applicationContext,
             requiresClass,
             new AnnotationConditionDeclaration(annotationForPresent));
         assertThat(condition.matches(contextForPresent).matches()).isTrue();
@@ -129,17 +130,17 @@ public class ConditionTests {
             type.methods().named("requiresAbsentClass").get();
         RequiresCondition annotationForAbsent =
             requiresAbsentClass.annotations().get(RequiresCondition.class).get();
-        ConditionContext contextForAbsent = new ConditionContext(this.applicationContext,
+        ConditionContext contextForAbsent = new IntrospectedConditionContext(this.applicationContext,
             requiresAbsentClass,
             new AnnotationConditionDeclaration(annotationForAbsent));
         assertThat(condition.matches(contextForAbsent).matches()).isFalse();
     }
 
-    @RequiresClass("java.lang.String")
+    @RequiresClass(classes = String.class)
     private void requiresClass() {
     }
 
-    @RequiresClass("java.gnal.String")
+    @RequiresClass(classNames = "java.gnal.String")
     private void requiresAbsentClass() {
     }
 
@@ -158,9 +159,9 @@ public class ConditionTests {
         assertThat(matcher.match(methodView)).isFalse();
     }
 
-    @RequiresClass("java.gnal.String")
+    @RequiresClass(classNames = "java.gnal.String")
     public static class ParentClass {
-        @RequiresClass("java.lang.String")
+        @RequiresClass(classes = String.class)
         public void requiresClass() {
         }
     }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/conditions/ConditionTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/conditions/ConditionTests.java
@@ -16,6 +16,10 @@
 
 package test.org.dockbox.hartshorn.inject.conditions;
 
+import java.lang.classfile.Annotation;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.util.stream.Stream;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
@@ -25,7 +29,9 @@ import org.dockbox.hartshorn.inject.condition.ConditionContext;
 import org.dockbox.hartshorn.inject.condition.ConditionMatcher;
 import org.dockbox.hartshorn.inject.condition.ConditionResult;
 import org.dockbox.hartshorn.inject.condition.IntrospectedConditionContext;
+import org.dockbox.hartshorn.inject.condition.ReferenceConditionDeclaration;
 import org.dockbox.hartshorn.inject.condition.RequiresCondition;
+import org.dockbox.hartshorn.inject.condition.TypeReferenceConditionContext;
 import org.dockbox.hartshorn.inject.condition.support.ClassCondition;
 import org.dockbox.hartshorn.inject.condition.support.RequiresClass;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
@@ -34,14 +40,14 @@ import org.dockbox.hartshorn.launchpad.condition.RequiresActivator;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.annotations.TestProperties;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
+import org.dockbox.hartshorn.util.introspect.scan.ClassReference;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.types.ClassFileUtilities;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -113,26 +119,45 @@ public class ConditionTests {
     }
 
     @Test
-    void classConditions() {
-        TypeView<ConditionTests> type =
-            this.applicationContext.environment().introspector().introspect(ConditionTests.class);
+    void classConditionOnPresentClass() {
+        ClassModel model = ClassFileUtilities.getClassModel(ConditionTests.class).get();
         Condition condition = new ClassCondition();
 
-        MethodView<ConditionTests, ?> requiresClass = type.methods().named("requiresClass").get();
-        RequiresCondition annotationForPresent =
-            requiresClass.annotations().get(RequiresCondition.class).get();
-        ConditionContext contextForPresent = new IntrospectedConditionContext(this.applicationContext,
+        MethodModel requiresClass = ClassFileUtilities.getMethod(model, "requiresClass").get();
+        Annotation annotationForPresent = ClassFileUtilities.getAnnotation(
             requiresClass,
-            new AnnotationConditionDeclaration(annotationForPresent));
+            RequiresClass.class
+        ).get();
+        ReferenceConditionDeclaration declarationForPresent =
+            ReferenceConditionDeclaration.createFromMetaAnnotation(annotationForPresent);
+        ConditionContext contextForPresent = new TypeReferenceConditionContext(
+            declarationForPresent,
+            new ClassReference(ConditionTests.class),
+            requiresClass
+        );
         assertThat(condition.matches(contextForPresent).matches()).isTrue();
+    }
 
-        MethodView<ConditionTests, ?> requiresAbsentClass =
-            type.methods().named("requiresAbsentClass").get();
-        RequiresCondition annotationForAbsent =
-            requiresAbsentClass.annotations().get(RequiresCondition.class).get();
-        ConditionContext contextForAbsent = new IntrospectedConditionContext(this.applicationContext,
+    @Test
+    void classConditionOnAbsentClass() {
+        ClassModel model = ClassFileUtilities.getClassModel(ConditionTests.class).get();
+        Condition condition = new ClassCondition();
+
+        MethodModel requiresAbsentClass = ClassFileUtilities.getMethod(
+            model,
+            "requiresAbsentClass"
+        ).get();
+        Annotation annotationForAbsent = ClassFileUtilities.getAnnotation(
             requiresAbsentClass,
-            new AnnotationConditionDeclaration(annotationForAbsent));
+            RequiresClass.class
+        ).get();
+        ReferenceConditionDeclaration declarationForAbsent =
+            ReferenceConditionDeclaration.createFromMetaAnnotation(annotationForAbsent);
+        ConditionContext contextForAbsent = new TypeReferenceConditionContext(
+            declarationForAbsent,
+            new ClassReference(ConditionTests.class),
+            requiresAbsentClass
+        );
         assertThat(condition.matches(contextForAbsent).matches()).isFalse();
     }
 

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/conditions/ConditionTests.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/conditions/ConditionTests.java
@@ -16,10 +16,6 @@
 
 package test.org.dockbox.hartshorn.inject.conditions;
 
-import java.lang.classfile.Annotation;
-import java.lang.classfile.ClassModel;
-import java.lang.classfile.MethodModel;
-import java.util.stream.Stream;
 import org.dockbox.hartshorn.inject.ComponentKey;
 import org.dockbox.hartshorn.inject.annotations.Inject;
 import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
@@ -31,7 +27,7 @@ import org.dockbox.hartshorn.inject.condition.ConditionResult;
 import org.dockbox.hartshorn.inject.condition.IntrospectedConditionContext;
 import org.dockbox.hartshorn.inject.condition.ReferenceConditionDeclaration;
 import org.dockbox.hartshorn.inject.condition.RequiresCondition;
-import org.dockbox.hartshorn.inject.condition.TypeReferenceConditionContext;
+import org.dockbox.hartshorn.inject.condition.ReferenceConditionContext;
 import org.dockbox.hartshorn.inject.condition.support.ClassCondition;
 import org.dockbox.hartshorn.inject.condition.support.RequiresClass;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
@@ -40,7 +36,6 @@ import org.dockbox.hartshorn.launchpad.condition.RequiresActivator;
 import org.dockbox.hartshorn.test.annotations.TestComponents;
 import org.dockbox.hartshorn.test.annotations.TestProperties;
 import org.dockbox.hartshorn.test.junit.HartshornIntegrationTest;
-import org.dockbox.hartshorn.util.introspect.scan.ClassReference;
 import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.types.ClassFileUtilities;
@@ -48,6 +43,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.lang.classfile.Annotation;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -130,10 +130,9 @@ public class ConditionTests {
         ).get();
         ReferenceConditionDeclaration declarationForPresent =
             ReferenceConditionDeclaration.createFromMetaAnnotation(annotationForPresent);
-        ConditionContext contextForPresent = new TypeReferenceConditionContext(
+        ConditionContext contextForPresent = new ReferenceConditionContext(
             declarationForPresent,
-            new ClassReference(ConditionTests.class),
-            requiresClass
+                requiresClass
         );
         assertThat(condition.matches(contextForPresent).matches()).isTrue();
     }
@@ -153,10 +152,9 @@ public class ConditionTests {
         ).get();
         ReferenceConditionDeclaration declarationForAbsent =
             ReferenceConditionDeclaration.createFromMetaAnnotation(annotationForAbsent);
-        ConditionContext contextForAbsent = new TypeReferenceConditionContext(
+        ConditionContext contextForAbsent = new ReferenceConditionContext(
             declarationForAbsent,
-            new ClassReference(ConditionTests.class),
-            requiresAbsentClass
+                requiresAbsentClass
         );
         assertThat(condition.matches(contextForAbsent).matches()).isFalse();
     }

--- a/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/conditions/ConditionalConfiguration.java
+++ b/hartshorn-integration-tests/src/integration-test/java/test/org/dockbox/hartshorn/inject/conditions/ConditionalConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class ConditionalConfiguration {
      */
     @Singleton
     @Named("a")
-    @RequiresClass("java.lang.String")
+    @RequiresClass(classes = String.class)
     public String a() {
         return "a";
     }
@@ -42,7 +42,7 @@ public class ConditionalConfiguration {
      */
     @Singleton
     @Named("b")
-    @RequiresClass("java.gnal.String")
+    @RequiresClass(classNames = "java.gnal.String")
     public String b() {
         return "b";
     }

--- a/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionExecutableParametersIntrospector.java
+++ b/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/ReflectionExecutableParametersIntrospector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,5 +146,10 @@ public class ReflectionExecutableParametersIntrospector
             }
         }
         return true;
+    }
+
+    @Override
+    public int indexOf(ParameterView<?> parameter) {
+        return this.all().indexOf(parameter);
     }
 }

--- a/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionConstructorView.java
+++ b/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionConstructorView.java
@@ -27,7 +27,9 @@ import org.dockbox.hartshorn.util.introspect.view.ConstructorView;
 import org.dockbox.hartshorn.util.introspect.view.ParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
+import org.dockbox.hartshorn.util.types.ClassFileUtilities;
 
+import java.lang.classfile.MethodModel;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
@@ -143,5 +145,15 @@ public class ReflectionConstructorView<T> extends ReflectionExecutableElementVie
         collector.property("type").writeDelegate(this.type());
         collector.property("parameters")
             .writeDelegates(this.parameters().all().toArray(Reportable[]::new));
+    }
+
+    @Override
+    public Option<MethodModel> classFileElement() {
+        return this.declaredBy()
+                .classFileElement()
+                .flatMap(type -> ClassFileUtilities.getConstructor(
+                        type,
+                        this.constructor.getParameterTypes()
+                ));
     }
 }

--- a/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionFieldView.java
+++ b/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionFieldView.java
@@ -31,6 +31,7 @@ import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 
+import java.lang.classfile.FieldModel;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.util.List;
@@ -185,6 +186,16 @@ public class ReflectionFieldView<Parent, FieldType> extends ReflectionAnnotatedE
                 (TypeView<Parent>) this.introspector.introspect(this.field.getDeclaringClass());
         }
         return this.declaredBy;
+    }
+
+    @Override
+    public Option<FieldModel> classFileElement() {
+        return this.declaredBy()
+                .classFileElement()
+                .flatMap(type -> Option.of(type.fields().stream()
+                        .filter(fieldModel -> fieldModel.fieldName().equalsString(this.name()))
+                        .findFirst()
+                ));
     }
 
     @Override

--- a/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionMethodView.java
+++ b/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionMethodView.java
@@ -27,7 +27,9 @@ import org.dockbox.hartshorn.util.introspect.view.MethodView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 import org.dockbox.hartshorn.util.stream.CollectorUtilities;
+import org.dockbox.hartshorn.util.types.ClassFileUtilities;
 
+import java.lang.classfile.MethodModel;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -159,5 +161,16 @@ public class ReflectionMethodView<Parent, ReturnType>
         collector.property("parameters")
             .writeDelegates(this.parameters().all().toArray(Reportable[]::new));
         collector.property("declaredBy").writeDelegate(this.declaredBy());
+    }
+
+    @Override
+    public Option<MethodModel> classFileElement() {
+        return this.declaredBy()
+                .classFileElement()
+                .flatMap(type -> ClassFileUtilities.getMethod(
+                        type,
+                        this.name(),
+                        this.method.getParameterTypes()
+                ));
     }
 }

--- a/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionPackageView.java
+++ b/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionPackageView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.dockbox.hartshorn.util.introspect.view.EnclosableView;
 import org.dockbox.hartshorn.util.introspect.view.PackageView;
 import org.dockbox.hartshorn.util.option.Option;
 
+import java.lang.classfile.ClassFileElement;
 import java.lang.reflect.AnnotatedElement;
 
 /**
@@ -116,6 +117,11 @@ public class ReflectionPackageView extends ReflectionAnnotatedElementView implem
 
     @Override
     public Option<EnclosableView> enclosingView() {
+        return Option.empty();
+    }
+
+    @Override
+    public Option<ClassFileElement> classFileElement() {
         return Option.empty();
     }
 }

--- a/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionParameterView.java
+++ b/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionParameterView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.dockbox.hartshorn.util.introspect.view.ParameterView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 
+import java.lang.classfile.ClassFileElement;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
@@ -142,5 +143,10 @@ public class ReflectionParameterView<T> extends ReflectionAnnotatedElementView
     @Override
     public Option<EnclosableView> enclosingView() {
         return Option.of(this.declaredBy());
+    }
+
+    @Override
+    public Option<ClassFileElement> classFileElement() {
+        return Option.empty();
     }
 }

--- a/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionTypeParameterView.java
+++ b/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionTypeParameterView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.introspect.view.wildcard.WildcardTypeView;
 import org.dockbox.hartshorn.util.option.Option;
 
+import java.lang.classfile.ClassModel;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.ParameterizedType;
@@ -316,5 +317,10 @@ public class ReflectionTypeParameterView extends ReflectionAnnotatedElementView
     @Override
     public Option<EnclosableView> enclosingView() {
         return Option.empty();
+    }
+
+    @Override
+    public Option<ClassModel> classFileElement() {
+        return this.resolvedType().flatMap(TypeView::classFileElement);
     }
 }

--- a/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionTypeView.java
+++ b/hartshorn-introspect-reflection/src/main/java/org/dockbox/hartshorn/util/introspect/reflect/view/ReflectionTypeView.java
@@ -38,8 +38,10 @@ import org.dockbox.hartshorn.util.introspect.view.PackageView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.introspect.view.wildcard.WildcardPackageView;
 import org.dockbox.hartshorn.util.option.Option;
+import org.dockbox.hartshorn.util.types.ClassFileUtilities;
 import org.dockbox.hartshorn.util.types.TypeUtils;
 
+import java.lang.classfile.ClassModel;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -499,6 +501,11 @@ public class ReflectionTypeView<T> extends ReflectionAnnotatedElementView implem
     @Override
     public boolean isParameterized() {
         return this.parameterizedType != null;
+    }
+
+    @Override
+    public Option<ClassModel> classFileElement() {
+        return ClassFileUtilities.getClassModel(this.type());
     }
 
     @Override

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ExecutableParametersIntrospector.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/ExecutableParametersIntrospector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,4 +135,13 @@ public interface ExecutableParametersIntrospector {
      * exactly, else {@code false}
      */
     boolean matchesExact(List<Class<?>> parameterTypes);
+
+    /**
+     * Returns the index of the provided parameter in the executable element. If the parameter is
+     * not declared by the executable element, {@code -1} is returned.
+     *
+     * @param parameter the parameter to find the index of
+     * @return the index of the provided parameter, or {@code -1} if not found
+     */
+    int indexOf(ParameterView<?> parameter);
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/ClassReference.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/scan/ClassReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public class ClassReference implements TypeReference {
 
     @Override
     public String qualifiedName() {
-        return this.type.getCanonicalName();
+        return this.type.getName();
     }
 
     @Override

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/AnnotatedElementView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/AnnotatedElementView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,9 @@
 package org.dockbox.hartshorn.util.introspect.view;
 
 import org.dockbox.hartshorn.util.introspect.ElementAnnotationsIntrospector;
+import org.dockbox.hartshorn.util.option.Option;
+
+import java.lang.classfile.ClassFileElement;
 
 /**
  * Represents a view of an annotated element, such as a field or method. This view can be used to
@@ -35,4 +38,11 @@ public interface AnnotatedElementView extends EnclosableView {
      * @return an introspector for the element's annotations
      */
     ElementAnnotationsIntrospector annotations();
+
+    /**
+     * Returns the underlying class file element represented by this view, if available.
+     *
+     * @return the underlying class file element
+     */
+    Option<? extends ClassFileElement> classFileElement();
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/FieldView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/FieldView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.dockbox.hartshorn.util.introspect.IllegalIntrospectionException;
 import org.dockbox.hartshorn.util.introspect.annotations.Property;
 import org.dockbox.hartshorn.util.option.Option;
 
+import java.lang.classfile.FieldModel;
 import java.lang.reflect.Field;
 
 /**
@@ -91,4 +92,7 @@ public interface FieldView<Parent, FieldType>
      * @return the element's declaring type
      */
     TypeView<Parent> declaredBy();
+
+    @Override
+    Option<FieldModel> classFileElement();
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/MethodView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/MethodView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.util.introspect.view;
 import org.dockbox.hartshorn.util.introspect.IllegalIntrospectionException;
 import org.dockbox.hartshorn.util.option.Option;
 
+import java.lang.classfile.MethodModel;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
@@ -138,4 +139,7 @@ public interface MethodView<Parent, ReturnType>
     default TypeView<?> resultType() {
         return this.returnType();
     }
+
+    @Override
+    Option<MethodModel> classFileElement();
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/TypeView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/TypeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.util.introspect.TypeMethodsIntrospector;
 import org.dockbox.hartshorn.util.introspect.TypeParametersIntrospector;
 import org.dockbox.hartshorn.util.option.Option;
 
+import java.lang.classfile.ClassModel;
 import java.util.List;
 
 /**
@@ -342,4 +343,7 @@ public interface TypeView<T> extends AnnotatedElementView, ModifierCarrierView {
      * @return {@code true} if this type is parameterized, {@code false} otherwise
      */
     boolean isParameterized();
+
+    @Override
+    Option<ClassModel> classFileElement();
 }

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardPackageView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardPackageView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import org.dockbox.hartshorn.util.introspect.ElementAnnotationsIntrospector;
 import org.dockbox.hartshorn.util.introspect.view.EnclosableView;
 import org.dockbox.hartshorn.util.introspect.view.PackageView;
 import org.dockbox.hartshorn.util.option.Option;
+
+import java.lang.classfile.ClassFileElement;
 
 /**
  * A {@link PackageView} implementation for wildcard types.
@@ -50,6 +52,11 @@ public class WildcardPackageView extends DefaultContext implements PackageView {
     @Override
     public ElementAnnotationsIntrospector annotations() {
         return new WildcardElementAnnotationsIntrospector();
+    }
+
+    @Override
+    public Option<ClassFileElement> classFileElement() {
+        return Option.empty();
     }
 
     @Override

--- a/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardTypeView.java
+++ b/hartshorn-introspect/src/main/java/org/dockbox/hartshorn/util/introspect/view/wildcard/WildcardTypeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.dockbox.hartshorn.util.introspect.view.PackageView;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
 import org.dockbox.hartshorn.util.option.Option;
 
+import java.lang.classfile.ClassModel;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,6 +50,11 @@ public class WildcardTypeView extends DefaultContext implements TypeView<Object>
     @Override
     public ElementAnnotationsIntrospector annotations() {
         return new WildcardElementAnnotationsIntrospector();
+    }
+
+    @Override
+    public Option<ClassModel> classFileElement() {
+        return Option.empty();
     }
 
     @Override

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/condition/ActivatorCondition.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/condition/ActivatorCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/condition/ActivatorCondition.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/condition/ActivatorCondition.java
@@ -16,13 +16,13 @@
 
 package org.dockbox.hartshorn.launchpad.condition;
 
-import java.lang.annotation.Annotation;
-
-import org.dockbox.hartshorn.inject.condition.Condition;
-import org.dockbox.hartshorn.inject.condition.ConditionContext;
 import org.dockbox.hartshorn.inject.condition.ConditionResult;
+import org.dockbox.hartshorn.inject.condition.IntrospectedConditionContext;
+import org.dockbox.hartshorn.inject.condition.IntrospectionCondition;
 import org.dockbox.hartshorn.launchpad.ConfigurableActivationInjectionCapableApplication;
 import org.dockbox.hartshorn.launchpad.activation.ModuleActivatorHolder;
+
+import java.lang.annotation.Annotation;
 
 /**
  * A condition that matches when an activator is present.
@@ -34,10 +34,10 @@ import org.dockbox.hartshorn.launchpad.activation.ModuleActivatorHolder;
  * 
  * @author Guus Lieben
  */
-public class ActivatorCondition implements Condition {
+public class ActivatorCondition implements IntrospectionCondition {
 
     @Override
-    public ConditionResult matches(ConditionContext context) {
+    public ConditionResult matches(IntrospectedConditionContext context) {
         if (!(context.application() instanceof ConfigurableActivationInjectionCapableApplication
             configurableInjectionCapableApplication)) {
             return ConditionResult.notMatched("Application is not compatible with activators");

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/environment/EnvironmentTypeCollector.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/environment/EnvironmentTypeCollector.java
@@ -16,12 +16,6 @@
 
 package org.dockbox.hartshorn.launchpad.environment;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import org.dockbox.hartshorn.inject.condition.ConditionMatcher;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.util.introspect.scan.ClassReferenceLoadException;
@@ -30,6 +24,15 @@ import org.dockbox.hartshorn.util.introspect.scan.TypeReference;
 import org.dockbox.hartshorn.util.introspect.scan.TypeReferenceCollector;
 import org.dockbox.hartshorn.util.introspect.scan.TypeReferenceCollectorContext;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
+import org.dockbox.hartshorn.util.types.ClassFileUtilities;
+
+import java.lang.classfile.ClassModel;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * A collector for types in the environment. This delegates to the
@@ -93,7 +96,7 @@ public class EnvironmentTypeCollector {
         ConditionMatcher conditionMatcher = this.environment.conditionMatcher();
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         return references.stream()
-            .filter(conditionMatcher::match)
+            .filter(reference -> conditionMatcher.match(resolveClassModel(reference)))
             .map(reference -> {
                 try {
                     return reference.getOrLoad(classLoader);
@@ -105,5 +108,13 @@ public class EnvironmentTypeCollector {
             })
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
+    }
+
+    private ClassModel resolveClassModel(TypeReference reference) {
+        return ClassFileUtilities.getClassModel(
+                reference.qualifiedName()
+        ).orElseThrow(() -> new IllegalStateException(
+                "Could not load class model for type reference: " + reference
+        ));
     }
 }

--- a/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/environment/EnvironmentTypeCollector.java
+++ b/hartshorn-launchpad/src/main/java/org/dockbox/hartshorn/launchpad/environment/EnvironmentTypeCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,13 @@
 
 package org.dockbox.hartshorn.launchpad.environment;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.dockbox.hartshorn.inject.condition.ConditionMatcher;
 import org.dockbox.hartshorn.launchpad.ApplicationContext;
 import org.dockbox.hartshorn.util.introspect.scan.ClassReferenceLoadException;
 import org.dockbox.hartshorn.util.introspect.scan.TypeCollectionException;
@@ -23,13 +30,6 @@ import org.dockbox.hartshorn.util.introspect.scan.TypeReference;
 import org.dockbox.hartshorn.util.introspect.scan.TypeReferenceCollector;
 import org.dockbox.hartshorn.util.introspect.scan.TypeReferenceCollectorContext;
 import org.dockbox.hartshorn.util.introspect.view.TypeView;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * A collector for types in the environment. This delegates to the
@@ -90,8 +90,10 @@ public class EnvironmentTypeCollector {
     }
 
     private Collection<Class<?>> loadClasses(Collection<TypeReference> references) {
+        ConditionMatcher conditionMatcher = this.environment.conditionMatcher();
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         return references.stream()
+            .filter(conditionMatcher::match)
             .map(reference -> {
                 try {
                     return reference.getOrLoad(classLoader);

--- a/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/collections/GathererUtilities.java
+++ b/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/collections/GathererUtilities.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.util.collections;
+
+import org.dockbox.hartshorn.util.option.Option;
+
+import java.util.stream.Gatherer;
+
+/**
+ * Utility methods for working with {@link Gatherer}s.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
+public class GathererUtilities {
+
+    private GathererUtilities() {}
+
+    /**
+     * Filters elements by their type, only allowing elements of the specified type to pass through.
+     * Resulting values are cast to the specified type.
+     *
+     * @param type the type to filter by
+     * @param <T> the input type
+     * @param <R> the output type
+     *
+     * @return a gatherer that filters elements by their type
+     */
+    public static <T, R> Gatherer<T, ?, R> filterByType(Class<R> type) {
+        return Gatherer.of(
+                (_, element, downstream) -> {
+                    if (type.isInstance(element)) {
+                        return downstream.push(type.cast(element));
+                    }
+                    return true;
+                }
+        );
+    }
+
+    /**
+     * Unwraps {@link Option} elements, only allowing present values to pass through.
+     *
+     * @param <T> the type of the value inside the option
+     *
+     * @return a gatherer that unwraps options
+     */
+    public static <T> Gatherer<Option<T>, ?, T> unwrapOptions() {
+        return Gatherer.of(
+                (_, element, downstream) -> {
+                    if (element.present()) {
+                        return downstream.push(element.get());
+                    }
+                    return true;
+                }
+        );
+    }
+}

--- a/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/ClassFileUtilities.java
+++ b/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/ClassFileUtilities.java
@@ -131,6 +131,28 @@ public final class ClassFileUtilities {
     }
 
     /**
+     * Get the constructor from a {@link ClassModel} by its parameter types. The constructor must
+     * have exactly the same parameter types as specified, otherwise an empty {@link Option} is
+     * returned.
+     *
+     * <p>Constructors are represented as methods with the name {@code <init>}, as defined in the
+     * JVM specification.
+     *
+     * @param model the {@link ClassModel} to search for the constructor
+     * @param parameterTypes the parameter types of the constructor to look for
+     *
+     * @return an {@link Option} containing the {@link MethodModel} if found, otherwise an empty
+     * {@link Option}
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.9">
+     * JVM Specification 2.9 - Special Methods
+     * </a>
+     */
+    public static Option<MethodModel> getConstructor(ClassModel model, Class<?>... parameterTypes) {
+        return getMethod(model, "<init>", parameterTypes);
+    }
+
+    /**
      * Get all annotations present on the given {@link AttributedElement}.
      *
      * @param element the {@link AttributedElement} to extract annotations from

--- a/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/ClassFileUtilities.java
+++ b/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/ClassFileUtilities.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2019-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.util.types;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.classfile.Annotation;
+import java.lang.classfile.AnnotationElement;
+import java.lang.classfile.AnnotationValue;
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
+import java.lang.classfile.constantpool.Utf8Entry;
+import java.lang.constant.ClassDesc;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.dockbox.hartshorn.util.collections.GathererUtilities;
+import org.dockbox.hartshorn.util.option.Option;
+
+/**
+ * Utility class for working with Java's {@link ClassFile} API, primarily focused on extracting
+ * annotation information from class files.
+ *
+ * @since 0.7.0
+ *
+ * @author Guus Lieben
+ */
+public final class ClassFileUtilities {
+
+    private ClassFileUtilities() {
+    }
+
+    /**
+     * Get the {@link ClassModel} for the given class type.
+     *
+     * @param type the class type
+     * @return an {@link Option} containing the {@link ClassModel} if found, otherwise an empty
+     * {@link Option}
+     */
+    public static Option<ClassModel> getClassModel(Class<?> type) {
+        return getClassModel(type.getName());
+    }
+
+    /**
+     * Get the {@link ClassModel} for the given resource name or class name.
+     *
+     * @param resourceOrClassName the resource name (e.g. "org/example/MyClass.class") or class name
+     * (e.g. "org.example.MyClass")
+     *
+     * @return an {@link Option} containing the {@link ClassModel} if found, otherwise an empty
+     * {@link Option}
+     */
+    public static Option<ClassModel> getClassModel(String resourceOrClassName) {
+        if (TypeUtils.isClassName(resourceOrClassName)) {
+            resourceOrClassName = TypeUtils.classNameToResourceName(resourceOrClassName);
+        }
+        InputStream in = Thread.currentThread()
+                .getContextClassLoader()
+                .getResourceAsStream(resourceOrClassName);
+        if (in == null) {
+            return Option.empty();
+        }
+        try {
+            byte[] bytes = in.readAllBytes();
+            ClassFile classFile = ClassFile.of();
+            ClassModel classModel = classFile.parse(bytes);
+            return Option.of(classModel);
+        } catch (IOException e) {
+            return Option.empty();
+        }
+    }
+
+    /**
+     * Get all annotations present on the given {@link ClassModel}.
+     *
+     * @param classModel the {@link ClassModel} to extract annotations from
+     * @return a list of {@link Annotation}s present on the class model
+     */
+    public static List<Annotation> getAnnotations(ClassModel classModel) {
+        List<RuntimeVisibleAnnotationsAttribute> attributes = classModel.findAttributes(
+                Attributes.runtimeVisibleAnnotations()
+        );
+        return attributes.stream()
+                .flatMap(attr -> attr.annotations().stream())
+                .toList();
+    }
+
+    /**
+     * Get all meta-annotations of a specific type present on the given {@link ClassModel}.
+     *
+     * @param classModel the {@link ClassModel} to extract meta-annotations from
+     * @param annotationType the type of meta-annotation to look for
+     *
+     * @return a list of {@link Annotation}s that are meta-annotated with the specified type
+     */
+    public static List<Annotation> getMetaAnnotations(
+        ClassModel classModel,
+        Class<? extends java.lang.annotation.Annotation> annotationType
+    ) {
+        List<Annotation> annotations = getAnnotations(classModel);
+        return annotations.stream()
+                .filter(annotation -> {
+                    ClassModel annotationModel = getClassModel(annotation.classSymbol());
+                    return getAnnotation(annotationModel, annotationType).present();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Get a specific annotation present on the given {@link ClassModel}.
+     *
+     * @param classModel the {@link ClassModel} to extract the annotation from
+     * @param annotationType the type of annotation to look for
+     *
+     * @return an {@link Option} containing the {@link Annotation} if found, otherwise an empty
+     * {@link Option}
+     */
+    public static Option<Annotation> getAnnotation(
+            ClassModel classModel,
+            Class<? extends java.lang.annotation.Annotation> annotationType
+    ) {
+        return getAnnotation(classModel, annotationType.getName());
+    }
+
+    /**
+     * Get a specific annotation present on the given {@link ClassModel}.
+     *
+     * @param classModel the {@link ClassModel} to extract the annotation from
+     * @param annotationQualifiedName the fully qualified name of the annotation to look for
+     *
+     * @return an {@link Option} containing the {@link Annotation} if found, otherwise an empty
+     * {@link Option}
+     */
+    public static Option<Annotation> getAnnotation(
+            ClassModel classModel,
+            String annotationQualifiedName
+    ) {
+        return Option.of(getAnnotations(classModel).stream()
+                .filter(annotation -> matchesConstantPoolName(
+                        annotation.className(),
+                        annotationQualifiedName
+                ))
+                .findFirst());
+    }
+
+    /**
+     * Check if a {@link Utf8Entry} from the constant pool matches the expected fully qualified
+     * class name. Constant pool entries for class names are in the format "Lorg/example/MyClass;",
+     * while the expected value is in the format "org.example.MyClass".
+     *
+     * @param entry the {@link Utf8Entry} from the constant pool
+     * @param expectedValue the expected fully qualified class name
+     * @return true if the entry matches the expected value, false otherwise
+     */
+    public static boolean matchesConstantPoolName(
+            Utf8Entry entry,
+            String expectedValue
+    ) {
+        String entryValue = entry.stringValue();
+        if (entryValue.startsWith("L") && entryValue.endsWith(";")) {
+            entryValue = entryValue.substring(1, entryValue.length() - 1);
+        }
+        entryValue = entryValue.replace('/', '.');
+        return entryValue.equals(expectedValue);
+    }
+
+    /**
+     * Convert a constant pool class name to a fully qualified class name.
+     *
+     * @param entry the {@link Utf8Entry} from the constant pool
+     * @return the fully qualified class name
+     */
+    public static String constantPoolNameToQualifiedName(Utf8Entry entry) {
+        return constantPoolNameToQualifiedName(entry.stringValue());
+    }
+
+    /**
+     * Convert a constant pool class name to a fully qualified class name.
+     *
+     * @param constant the constant pool class name
+     * @return the fully qualified class name
+     */
+    public static String constantPoolNameToQualifiedName(String constant) {
+        if (constant.startsWith("L") && constant.endsWith(";")) {
+            constant = constant.substring(1, constant.length() - 1);
+        }
+        return constant.replace('/', '.');
+    }
+
+    /**
+     * Convert the elements of an {@link Annotation} to a map of element names to their values.
+     *
+     * @param annotation the {@link Annotation} to convert
+     * @return a map of element names to their corresponding {@link AnnotationValue}s
+     */
+    public static Map<String, AnnotationValue> annotationValuesAsMap(Annotation annotation) {
+        return annotation.elements()
+                .stream()
+                .collect(Collectors.toMap(
+                        element -> element.name().stringValue(),
+                        AnnotationElement::value
+                ));
+    }
+
+    /**
+     * Get the value of a specific element from an {@link Annotation}.
+     *
+     * @param annotation the {@link Annotation} to extract the value from
+     * @param name the name of the element to look for
+     * @return an {@link Option} containing the {@link AnnotationValue} if found, otherwise an empty
+     * {@link Option}
+     */
+    public static Option<AnnotationValue> getAnnotationValue(Annotation annotation, String name) {
+        for (AnnotationElement element : annotation.elements()) {
+            if (element.name().equalsString(name)) {
+                return Option.of(element.value());
+            }
+        }
+        return Option.empty();
+    }
+
+    /**
+     * Get the value of a specific element from an {@link Annotation}, cast to a specific type.
+     *
+     * @param annotation the {@link Annotation} to extract the value from
+     * @param name the name of the element to look for
+     * @param type the expected type of the {@link AnnotationValue}
+     * @param <T> the type of the {@link AnnotationValue}
+     *
+     * @return an {@link Option} containing the {@link AnnotationValue} of the specified type if
+     * found, otherwise an empty {@link Option}
+     */
+    public static <T extends AnnotationValue> Option<T> getAnnotationValue(
+        Annotation annotation,
+        String name,
+        Class<T> type
+    ) {
+        return getAnnotationValue(annotation, name).ofType(type);
+    }
+
+    /**
+     * Get the array of values of a specific element from an {@link Annotation}. If the element is
+     * not found or is not an array, an empty list is returned.
+     *
+     * @param annotation the {@link Annotation} to extract the values from
+     * @param name the name of the element to look for
+     * @return a list of {@link AnnotationValue}s contained in the array element, or an empty list
+     * if the element is not found or is not an array
+     */
+    public static List<AnnotationValue> getAnnotationValues(Annotation annotation, String name) {
+        return getAnnotationValue(annotation, name)
+                .ofType(AnnotationValue.OfArray.class)
+                .map(AnnotationValue.OfArray::values)
+                .orElseGet(List::of);
+    }
+
+    /**
+     * Get the array of values of a specific element from an {@link Annotation}, cast to a specific
+     * type. If the element is not found or is not an array, an empty list is returned.
+     *
+     * @param annotation the {@link Annotation} to extract the values from
+     * @param name the name of the element to look for
+     * @param type the expected type of the {@link AnnotationValue}s
+     * @param <T> the type of the {@link AnnotationValue}s
+     *
+     * @return a list of {@link AnnotationValue}s of the specified type contained in the array
+     * element, or an empty list if the element is not found or is not an array
+     */
+    public static <T extends AnnotationValue> List<T> getAnnotationValues(
+        Annotation annotation,
+        String name,
+        Class<T> type
+    ) {
+        return getAnnotationValues(annotation, name).stream()
+                .gather(GathererUtilities.filterByType(type))
+                .toList();
+    }
+
+    /**
+     * Get the {@link ClassModel} for the given {@link ClassDesc} descriptor.
+     *
+     * @param descriptor the {@link ClassDesc} descriptor
+     * @return the corresponding {@link ClassModel}
+     *
+     * @throws IllegalStateException if the {@link ClassModel} could not be loaded
+     */
+    public static ClassModel getClassModel(ClassDesc descriptor) {
+        Option<ClassModel> classModelOption = ClassFileUtilities.getClassModel(
+            constantPoolNameToQualifiedName(descriptor.descriptorString())
+        );
+        return classModelOption.orElseThrow(() -> new IllegalStateException(
+            "Could not load class model for descriptor: " + descriptor
+        ));
+    }
+}

--- a/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/ClassFileUtilities.java
+++ b/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/ClassFileUtilities.java
@@ -16,23 +16,25 @@
 
 package org.dockbox.hartshorn.util.types;
 
-import org.dockbox.hartshorn.util.collections.GathererUtilities;
-import org.dockbox.hartshorn.util.option.Option;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.classfile.Annotation;
 import java.lang.classfile.AnnotationElement;
 import java.lang.classfile.AnnotationValue;
+import java.lang.classfile.AttributedElement;
 import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
 import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
 import java.lang.classfile.constantpool.Utf8Entry;
 import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.dockbox.hartshorn.util.collections.GathererUtilities;
+import org.dockbox.hartshorn.util.option.Option;
 
 /**
  * Utility class for working with Java's {@link ClassFile} API, primarily focused on extracting
@@ -87,14 +89,36 @@ public final class ClassFileUtilities {
         }
     }
 
+    public static Option<MethodModel> getMethod(ClassModel model, String name, Class<?>... parameterTypes) {
+        methods:
+        for (MethodModel method : model.methods()) {
+            if (!method.methodName().equalsString(name)) {
+                continue;
+            }
+            MethodTypeDesc descriptor = method.methodTypeSymbol();
+            if (descriptor.parameterCount() != parameterTypes.length) {
+                continue;
+            }
+            ClassDesc[] parameters = descriptor.parameterArray();
+            for (int i = 0; i < parameters.length; i++) {
+                ClassDesc parameter = parameters[i];
+                if (!matchesConstantPoolName(parameter.descriptorString(), parameterTypes[i].getName())) {
+                    continue methods;
+                }
+            }
+            return Option.of(method);
+        }
+        return Option.empty();
+    }
+
     /**
-     * Get all annotations present on the given {@link ClassModel}.
+     * Get all annotations present on the given {@link AttributedElement}.
      *
-     * @param classModel the {@link ClassModel} to extract annotations from
+     * @param element the {@link AttributedElement} to extract annotations from
      * @return a list of {@link Annotation}s present on the class model
      */
-    public static List<Annotation> getAnnotations(ClassModel classModel) {
-        List<RuntimeVisibleAnnotationsAttribute> attributes = classModel.findAttributes(
+    public static List<Annotation> getAnnotations(AttributedElement element) {
+        List<RuntimeVisibleAnnotationsAttribute> attributes = element.findAttributes(
                 Attributes.runtimeVisibleAnnotations()
         );
         return attributes.stream()
@@ -103,18 +127,18 @@ public final class ClassFileUtilities {
     }
 
     /**
-     * Get all meta-annotations of a specific type present on the given {@link ClassModel}.
+     * Get all meta-annotations of a specific type present on the given {@link AttributedElement}.
      *
-     * @param classModel the {@link ClassModel} to extract meta-annotations from
+     * @param element the {@link AttributedElement} to extract meta-annotations from
      * @param annotationType the type of meta-annotation to look for
      *
      * @return a list of {@link Annotation}s that are meta-annotated with the specified type
      */
     public static List<Annotation> getMetaAnnotations(
-        ClassModel classModel,
+        AttributedElement element,
         Class<? extends java.lang.annotation.Annotation> annotationType
     ) {
-        List<Annotation> annotations = getAnnotations(classModel);
+        List<Annotation> annotations = getAnnotations(element);
         return annotations.stream()
                 .filter(annotation -> {
                     ClassModel annotationModel = getClassModel(annotation.classSymbol());
@@ -124,35 +148,35 @@ public final class ClassFileUtilities {
     }
 
     /**
-     * Get a specific annotation present on the given {@link ClassModel}.
+     * Get a specific annotation present on the given {@link AttributedElement}.
      *
-     * @param classModel the {@link ClassModel} to extract the annotation from
+     * @param element the {@link AttributedElement} to extract the annotation from
      * @param annotationType the type of annotation to look for
      *
      * @return an {@link Option} containing the {@link Annotation} if found, otherwise an empty
      * {@link Option}
      */
     public static Option<Annotation> getAnnotation(
-            ClassModel classModel,
+            AttributedElement element,
             Class<? extends java.lang.annotation.Annotation> annotationType
     ) {
-        return getAnnotation(classModel, annotationType.getName());
+        return getAnnotation(element, annotationType.getName());
     }
 
     /**
-     * Get a specific annotation present on the given {@link ClassModel}.
+     * Get a specific annotation present on the given {@link AttributedElement}.
      *
-     * @param classModel the {@link ClassModel} to extract the annotation from
+     * @param element the {@link AttributedElement} to extract the annotation from
      * @param annotationQualifiedName the fully qualified name of the annotation to look for
      *
      * @return an {@link Option} containing the {@link Annotation} if found, otherwise an empty
      * {@link Option}
      */
     public static Option<Annotation> getAnnotation(
-            ClassModel classModel,
+            AttributedElement element,
             String annotationQualifiedName
     ) {
-        return Option.of(getAnnotations(classModel).stream()
+        return Option.of(getAnnotations(element).stream()
                 .filter(annotation -> matchesConstantPoolName(
                         annotation.className(),
                         annotationQualifiedName
@@ -184,11 +208,37 @@ public final class ClassFileUtilities {
             String expectedValue
     ) {
         String entryValue = entry.stringValue();
-        if (entryValue.startsWith("L") && entryValue.endsWith(";")) {
-            entryValue = entryValue.substring(1, entryValue.length() - 1);
+        return matchesConstantPoolName(entryValue, expectedValue);
+    }
+
+    /**
+     * Check if a descriptor from the constant pool matches the expected fully qualified
+     * class name. Constant pool entries for class names are expected to be equal to field
+     * descriptors as defined in JVM Specification 4.3.2, thus being in the format {@code
+     * Lorg/example/MyClass;}, while the expected value is in the format {@code
+     * org.example.MyClass}.
+     *
+     * <p>Only reference type field descriptors are supported (i.e., those with term {@code L}).
+     * primitive field descriptors (including array dimensions) are not supported.
+     *
+     * @param resourceName the descriptor from the constant pool
+     * @param expectedValue the expected fully qualified class name
+     *
+     * @return true if the entry matches the expected value, false otherwise
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.2">
+     * JVM Specification 4.3.2 - Field Descriptors. Table 4.3-A Interpretation of field descriptors
+     * </a>
+     */
+    public static boolean matchesConstantPoolName(
+        String resourceName,
+        String expectedValue
+    ) {
+        if (resourceName.startsWith("L") && resourceName.endsWith(";")) {
+            resourceName = resourceName.substring(1, resourceName.length() - 1);
         }
-        entryValue = entryValue.replace('/', '.');
-        return entryValue.equals(expectedValue);
+        resourceName = resourceName.replace('/', '.');
+        return resourceName.equals(expectedValue);
     }
 
     /**

--- a/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/ClassFileUtilities.java
+++ b/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/ClassFileUtilities.java
@@ -16,6 +16,9 @@
 
 package org.dockbox.hartshorn.util.types;
 
+import org.dockbox.hartshorn.util.collections.GathererUtilities;
+import org.dockbox.hartshorn.util.option.Option;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.classfile.Annotation;
@@ -33,8 +36,6 @@ import java.lang.constant.MethodTypeDesc;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.dockbox.hartshorn.util.collections.GathererUtilities;
-import org.dockbox.hartshorn.util.option.Option;
 
 /**
  * Utility class for working with Java's {@link ClassFile} API, primarily focused on extracting
@@ -89,7 +90,22 @@ public final class ClassFileUtilities {
         }
     }
 
-    public static Option<MethodModel> getMethod(ClassModel model, String name, Class<?>... parameterTypes) {
+    /**
+     * Get a specific method from a {@link ClassModel} by its name and parameter types. The method
+     * must have exactly the same name and parameter types as specified, otherwise an empty
+     * {@link Option} is returned.
+     *
+     * @param model the {@link ClassModel} to search for the method
+     * @param name the name of the method to look for
+     * @param parameterTypes the parameter types of the method to look for
+     * @return an {@link Option} containing the {@link MethodModel} if found, otherwise an empty
+     * {@link Option}
+     */
+    public static Option<MethodModel> getMethod(
+            ClassModel model,
+            String name,
+            Class<?>... parameterTypes
+    ) {
         methods:
         for (MethodModel method : model.methods()) {
             if (!method.methodName().equalsString(name)) {
@@ -102,7 +118,10 @@ public final class ClassFileUtilities {
             ClassDesc[] parameters = descriptor.parameterArray();
             for (int i = 0; i < parameters.length; i++) {
                 ClassDesc parameter = parameters[i];
-                if (!matchesConstantPoolName(parameter.descriptorString(), parameterTypes[i].getName())) {
+                if (!matchesConstantPoolName(
+                        parameter.descriptorString(),
+                        parameterTypes[i].getName()
+                )) {
                     continue methods;
                 }
             }

--- a/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/ClassFileUtilities.java
+++ b/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/ClassFileUtilities.java
@@ -16,6 +16,9 @@
 
 package org.dockbox.hartshorn.util.types;
 
+import org.dockbox.hartshorn.util.collections.GathererUtilities;
+import org.dockbox.hartshorn.util.option.Option;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.classfile.Annotation;
@@ -30,8 +33,6 @@ import java.lang.constant.ClassDesc;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.dockbox.hartshorn.util.collections.GathererUtilities;
-import org.dockbox.hartshorn.util.option.Option;
 
 /**
  * Utility class for working with Java's {@link ClassFile} API, primarily focused on extracting
@@ -161,12 +162,22 @@ public final class ClassFileUtilities {
 
     /**
      * Check if a {@link Utf8Entry} from the constant pool matches the expected fully qualified
-     * class name. Constant pool entries for class names are in the format "Lorg/example/MyClass;",
-     * while the expected value is in the format "org.example.MyClass".
+     * class name. Constant pool entries for class names are expected to be equal to field
+     * descriptors as defined in JVM Specification 4.3.2, thus being in the format {@code
+     * Lorg/example/MyClass;}, while the expected value is in the format {@code
+     * org.example.MyClass}.
+     *
+     * <p>Only reference type field descriptors are supported (i.e., those with term {@code L}).
+     * primitive field descriptors (including array dimensions) are not supported.
      *
      * @param entry the {@link Utf8Entry} from the constant pool
      * @param expectedValue the expected fully qualified class name
+     *
      * @return true if the entry matches the expected value, false otherwise
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.2">
+     * JVM Specification 4.3.2 - Field Descriptors. Table 4.3-A Interpretation of field descriptors
+     * </a>
      */
     public static boolean matchesConstantPoolName(
             Utf8Entry entry,

--- a/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/TypeUtils.java
+++ b/hartshorn-shared/src/main/java/org/dockbox/hartshorn/util/types/TypeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -564,6 +564,56 @@ public class TypeUtils {
             return throwable;
         }
         return getRootCause(cause);
+    }
+
+    /**
+     * Returns whether the given name is a resource name.
+     *
+     * @param name the name to check
+     * @return {@code true} if the name is a resource name, {@code false} otherwise
+     */
+    public static boolean isResourceName(String name) {
+        return name != null && !name.isEmpty() && name.contains("/") && name.endsWith(".class");
+    }
+
+    /**
+     * Converts a fully qualified class name to a resource name.
+     *
+     * @param className the fully qualified class name, e.g. {@code java.lang.String}
+     * @return the corresponding resource name, e.g. {@code java/lang/String.class}
+     * @throws IllegalArgumentException if the given class name is not valid
+     */
+    public static String classNameToResourceName(String className) {
+        if (!isClassName(className)) {
+            throw new IllegalArgumentException("Not a valid class name: " + className);
+        }
+        return className.replace('.', '/') + ".class";
+    }
+
+    /**
+     * Returns whether the given name is a fully qualified class name.
+     *
+     * @param name the name to check
+     * @return {@code true} if the name is a fully qualified class name, {@code false} otherwise
+     */
+    public static boolean isClassName(String name) {
+        return name != null && name.contains(".") && !name.endsWith(".class");
+    }
+
+    /**
+     * Converts a resource name to a fully qualified class name.
+     *
+     * @param resourceName the resource name, e.g. {@code java/lang/String.class}
+     * @return the corresponding fully qualified class name, e.g. {@code java.lang.String}
+     * @throws IllegalArgumentException if the given resource name is not valid
+     */
+    public static String resourceNameToClassName(String resourceName) {
+        if (!isResourceName(resourceName)) {
+            throw new IllegalArgumentException("Not a valid resource name: " + resourceName);
+        }
+        return resourceName
+                .substring(0, resourceName.length() - ".class".length())
+                .replace('/', '.');
     }
 
     /**


### PR DESCRIPTION
### Type of Change
- [x] Feature (non-breaking change that adds functionality)

### Description
Expands conditions to also support type reference metadata, which is specifically useful during early application construction (i.e. during classpath scanning, so conditionals can be filtered before class loading takes place).

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
- [x] I have added documentation that describes my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch

### Related Issue

Closes #932
