### PR TITLE
Do not block PRs if dependency check fails

### DIFF
--- a/.github/workflows/prebuild.dependency.yml
+++ b/.github/workflows/prebuild.dependency.yml
@@ -6,6 +6,7 @@ jobs:
   depCheck:
     name: OWASP Dependency Check
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 25


### PR DESCRIPTION
### Type of Change
- [x] Chore (changes to the build process or auxiliary tools)

### Description
We want to be notified about risks with our dependencies, but this shouldn't block PRs if it isn't related to the PR itself. In such cases the PR should still be marked with the `Security: risk accepted` label.

### Checklist
- [x] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch