### PR TITLE
Directly use NPX for Antora build

### DIFF
--- a/.github/workflows/postbuild.docs.yml
+++ b/.github/workflows/postbuild.docs.yml
@@ -8,20 +8,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up NPM
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Build developer documentation
+        run: "npm --prefix hartshorn-assembly/antora run antora -- playbook-local.yml"
+        shell: bash
+      - name: Archive Antora artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Antora documentation archive
+          path: hartshorn-assembly/antora/target/site
+          if-no-files-found: error
+          retention-days: 7
       - name: Set up source JDK
         uses: actions/setup-java@v3
         with:
           java-version: 25
           distribution: temurin
-      - name: Build developer documentation
-        run: mvn clean install -DskipTests -P ci -DincludeModules=false -Dantora.skip=false -Dantora.playbook=playbook-local.yml
-      - name: Archive Antora artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: Antora documentation archive
-          path: target/site
-          if-no-files-found: error
-          retention-days: 7
       - name: Build Javadocs
         run: mvn clean install site -DskipTests -P ci -Djavadoc.skip=false
       - name: Archive Javadoc artifacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,15 +113,14 @@ other documentation files as necessary.
 
 ### Previewing documentation
 
-When working with the Asciidoc documentation, you can build the documentation locally using the
-Asciidoctor Maven Plugin.
+When working with the Asciidoc documentation, you can build the documentation locally using Antora.
 
 ```shell
-mvn clean antora:antora -Dantora.playbook=playbook-local.yml
+npm --prefix hartshorn-assembly/antora run antora -- playbook-local.yml
 ```
 
 After building the documentation, you can view it in your browser by opening the [
-`target/site/index.html`](target/site/index.html) file.
+`hartshorn-assembly/antora/target/site/index.html`](hartshorn-assembly/antora/target/site/index.html) file.
 
 ### Working with attachments
 

--- a/hartshorn-assembly/antora/package.json
+++ b/hartshorn-assembly/antora/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "antora": "npx --yes --package antora --package @antora/lunr-extension --package @asciidoctor/tabs --package asciidoctor-interdoc-reftext antora --to-dir target/site"
+  }
+}

--- a/hartshorn-assembly/pom.platform.support.xml
+++ b/hartshorn-assembly/pom.platform.support.xml
@@ -31,7 +31,6 @@
     <javadoc.skip>false</javadoc.skip>
 
     <!-- Maven plugin versions, in alphabetical order -->
-    <plugin.antora.version>1.0.0-alpha.4</plugin.antora.version>
     <plugin.checkstyle.version>3.6.0</plugin.checkstyle.version>
     <plugin.versions.version>2.18.0</plugin.versions.version>
     <plugin.jacoco.version>0.8.13</plugin.jacoco.version>
@@ -316,11 +315,6 @@
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
           <version>${plugin.owasp.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.antora</groupId>
-          <artifactId>antora-maven-plugin</artifactId>
-          <version>${plugin.antora.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,7 @@
 
     <!-- Assembly properties -->
     <jacoco.skip>false</jacoco.skip>
-    <antora.skip>false</antora.skip>
     <javadoc.skip>false</javadoc.skip>
-
-    <!-- Antora playbook for documentation build. Set to playbook-local.yml for local builds -->
-    <antora.playbook>playbook-release.yml</antora.playbook>
 
     <!-- Maven plugin versions, in alphabetical order -->
     <plugin.jacoco.version>0.8.14</plugin.jacoco.version>
@@ -77,7 +73,6 @@
       <id>ci</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
-        <antora.skip>true</antora.skip>
         <javadoc.skip>true</javadoc.skip>
       </properties>
     </profile>
@@ -96,32 +91,6 @@
               <goal>aggregate</goal>
             </goals>
             <phase>site</phase>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- Antora documentation -->
-      <plugin>
-        <groupId>org.antora</groupId>
-        <artifactId>antora-maven-plugin</artifactId>
-        <configuration>
-          <skip>${antora.skip}</skip>
-          <playbookFile>
-            ${maven.multiModuleProjectDirectory}/hartshorn-assembly/antora/${antora.playbook}
-          </playbookFile>
-          <packages>
-            <package>@antora/lunr-extension</package>
-            <package>@asciidoctor/tabs</package>
-            <package>asciidoctor-interdoc-reftext</package>
-          </packages>
-        </configuration>
-        <executions>
-          <execution>
-            <id>generate</id>
-            <phase>install</phase>
-            <goals>
-              <goal>antora</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
### Type of Change
- [x] Chore (changes to the build process or auxiliary tools)

### Description
Moves the Antora documentation build from Maven to NPX

### Checklist
- [x] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have rebased my branch on top of the latest `develop` branch
